### PR TITLE
Feature: Add edit and  delete submissions for users

### DIFF
--- a/app/components/concept_details_component.rb
+++ b/app/components/concept_details_component.rb
@@ -16,12 +16,12 @@ class ConceptDetailsComponent < ViewComponent::Base
     @exclude_keys = exclude_keys
     @id = id
 
-    @concept_properties = concept_properties2hash(@properties)
+    @concept_properties = concept_properties2hash(@properties) if @properties
   end
 
   def render_properties(properties_set, ontology_acronym, &block)
     out = ''
-    properties_set.each do |key, data|
+    properties_set&.each do |key, data|
       next if exclude_relation?(key) || !data[:values]
 
       values = data[:values]
@@ -49,14 +49,14 @@ class ConceptDetailsComponent < ViewComponent::Base
   end
 
   def properties_set_by_keys(keys, concept_properties, exclude_keys = [])
-    concept_properties.select do |k, v|
+    concept_properties&.select do |k, v|
       (keys.include?(k) || !keys.select { |key| v[:key].to_s.include?(key) }.empty?) && !exclude_keys.include?(k) &&
         exclude_keys.select { |key| v[:key].to_s.include?(key) }.empty?
     end
   end
 
   def filter_properties(top_keys, bottom_keys, exclude_keys, concept_properties)
-    all_keys = concept_properties.keys
+    all_keys = concept_properties&.keys || []
     top_set = properties_set_by_keys(top_keys, concept_properties, exclude_keys)
     bottom_set = properties_set_by_keys(bottom_keys, concept_properties, exclude_keys)
     leftover = properties_set_by_keys(all_keys - top_keys - bottom_keys, concept_properties, exclude_keys)

--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -1,4 +1,5 @@
 class AdminController < ApplicationController
+  include TurboHelper
   layout :determine_layout
   before_action :cache_setup
 
@@ -180,21 +181,19 @@ class AdminController < ApplicationController
   end
 
   def delete_submission
-    response = {errors: '', success: ''}
-
+    response = { errors: '', success: '' }
+    submission_id = params["id"]
     begin
       ont = params["acronym"]
       ontology = LinkedData::Client::Models::Ontology.find_by_acronym(ont).first
 
       if ontology
-        submissions = ontology.explore.submissions
-        submission = submissions.select {|o| o.submissionId == params["id"].to_i}.first
+        submission = ontology.explore.submissions({ display: 'submissionId' }, submission_id)
 
         if submission
           error_response = submission.delete
-
           if response_error?(error_response)
-            errors = response_errors(error_response) # see application_controller::response_errors
+            errors = response_errors(error_response)
             _process_errors(errors, response, true)
           else
             response[:success] << "Submission #{params["id"]} for ontology #{ont} was deleted successfully"
@@ -208,7 +207,18 @@ class AdminController < ApplicationController
     rescue Exception => e
       response[:errors] << "Problem deleting submission #{params["id"]} for ontology #{ont} - #{e.class}: #{e.message}"
     end
-    render :json => response
+
+    if params[:turbo_stream]
+      if response[:errors].empty?
+        render_turbo_stream( alert_success { response[:success] }, remove('submission_' + submission_id.to_s))
+
+      else
+        render_turbo_stream alert_error { response[:errors] }
+      end
+    else
+      render :json => response
+    end
+
   end
 
   def users

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -206,7 +206,14 @@ class ApplicationController < ActionController::Base
     file_exists
   end
 
+  def parse_response_body(response)
+    return nil if response.nil?
+    
+    OpenStruct.new(JSON.parse(response.body, symbolize_names: true))
+  end
+
   def response_errors(error_struct)
+    error_struct = parse_response_body(error_struct)
     errors = {error: "There was an error, please try again"}
     return errors unless error_struct
     return errors unless error_struct.respond_to?(:errors)

--- a/app/controllers/ontologies_metadata_curator_controller.rb
+++ b/app/controllers/ontologies_metadata_curator_controller.rb
@@ -88,7 +88,7 @@ class OntologiesMetadataCuratorController < ApplicationController
 
     errors = nil
     if error_responses.compact.any? { |x| x.status != 204 }
-      errors = error_responses.map { |error_response| response_errors(OpenStruct.new(JSON.parse(error_response.body, symbolize_names: true))) }
+      errors = error_responses.map { |error_response| response_errors(error_response)) }
     end
 
     respond_to do |format|

--- a/app/controllers/submissions_controller.rb
+++ b/app/controllers/submissions_controller.rb
@@ -35,7 +35,8 @@ class SubmissionsController < ApplicationController
 
   # Called when form to "Edit submission" is submitted
   def edit
-    display_submission_attributes params[:ontology_id], params[:properties]&.split(','), required: params[:required]&.eql?('true'),
+    display_submission_attributes params[:ontology_id], params[:properties]&.split(','), submissionId: params[:id],
+                                  required: params[:required]&.eql?('true'),
                                   show_sections: params[:show_sections].nil? || params[:show_sections].eql?('true'),
                                   inline_save: params[:inline_save]&.eql?('true')
   end

--- a/app/controllers/submissions_controller.rb
+++ b/app/controllers/submissions_controller.rb
@@ -44,12 +44,12 @@ class SubmissionsController < ApplicationController
   # When editing a submission (called when submit "Edit submission information" form)
   def update
     error_responses = []
-    _, submission_params =  params[:submission].each.first
+    _, submission_params = params[:submission].each.first
 
     error_responses << update_submission(submission_params)
 
     if error_responses.compact.any? { |x| x.status != 204 }
-      @errors = error_responses.map { |error_response| response_errors(OpenStruct.new(JSON.parse(error_response.body, symbolize_names: true))) }
+      @errors = error_responses.map { |error_response| response_errors(error_response) }
     end
 
     if params[:attribute]

--- a/app/helpers/schemes_helper.rb
+++ b/app/helpers/schemes_helper.rb
@@ -9,8 +9,10 @@ module SchemesHelper
   end
 
   def get_scheme_label(scheme)
+    return '' if scheme.nil?
+
     if scheme['prefLabel'].nil? || scheme['prefLabel'].empty?
-      extract_label_from(scheme['@id']).html_safe
+      extract_label_from(scheme['@id']).html_safe if scheme['@id']
     else
       scheme['prefLabel']
     end

--- a/app/helpers/turbo_helper.rb
+++ b/app/helpers/turbo_helper.rb
@@ -25,6 +25,10 @@ module TurboHelper
   def replace(id, options = {}, &block)
     turbo_stream.replace(id, options, &block)
   end
+
+  def remove(id)
+    turbo_stream.remove(id)
+  end
   def render_turbo_stream(*streams)
     render turbo_stream: streams
   end

--- a/app/javascript/application_esbuild.js
+++ b/app/javascript/application_esbuild.js
@@ -7,3 +7,12 @@ import "./controllers"
 import "./component_controllers"
 
 
+Turbo.setConfirmMethod((message) => {
+    return new Promise((resolve, reject) => {
+        alertify.confirm(message, (e) => {
+            resolve(e)
+        })
+    })
+})
+
+

--- a/app/javascript/controllers/turbo_frame_error_controller.js
+++ b/app/javascript/controllers/turbo_frame_error_controller.js
@@ -12,6 +12,7 @@ export default class extends Turbo_frame_controller {
   showError(event) {
     let response = event.detail.fetchResponse
     if (!response.succeeded) {
+      event.preventDefault()
       response = response.response.clone()
       response.text().then(text => {
           this.#hideContent()

--- a/app/views/ontologies/_submissions.html.haml
+++ b/app/views/ontologies/_submissions.html.haml
@@ -17,10 +17,11 @@
 
 
 
-- more_colspan = 4
-- more_colspan = 3 if @ont_restricted
+- more_colspan = 6
+- more_colspan = 5 if @ont_restricted
 
 %div.click_versions_collapse
+  = render_alerts_container(AdminController)
   %table#ontology_versions.table.table-sm.table-striped
     %thead
       %tr
@@ -33,14 +34,17 @@
           = generate_attribute_text("creationDate", "Uploaded")
         - unless @ont_restricted
           %th.align-middle Downloads
+        - if @ontology.admin?(session[:user])
+          %th.align-middle Actions
+
     - begin
-      - submission_ready = @ontology.explore.latest_submission({:include_status => 'ready'})
+      - submission_ready = @ontology.explore.latest_submission({:include_status => 'ready', display: 'submissionId'})
       - submission_readyId = submission_ready.submissionId unless submission_ready.nil?
-      - rescue
+    - rescue
       - submission_readyId = -1
     - @submissions.each_with_index do |sub, index|
       - hidden_row_class = index >= 5 ? "hidden_ont hidden_select" : ""
-      %tr{class: "#{hidden_row_class}"}
+      %tr{class: "#{hidden_row_class}", id: "submission_#{sub.submissionId}"}
         %td
           = raw status_link(sub, sub.submissionId==submission_readyId)
         %td
@@ -52,6 +56,15 @@
         - unless @ont_restricted
           %td
             = raw download_link(sub, @ontology)
+        - if @ontology.admin?(session[:user])
+          %td
+            %div.d-flex
+              %a.btn.btn-sm.btn-link{:href => "#{@ontology.acronym}/submissions/#{sub.submissionId}/edit"}
+                %span Edit
+              - unless index.zero?
+                - alert_text = "Are you sure you want to delete submission <span style='color:red;font-weight:bold;'>" + sub.submissionId.to_s + "</span> for ontology <span style='color:red;font-weight:bold;'>" + @ontology.acronym + "</span>?<br/><b>This action CAN NOT be undone!!!</b>"
+                = button_to "Delete", "/admin/ontologies/#{@ontology.acronym}/submissions/#{sub.submissionId}?turbo_stream=true", method: :delete, class:'btn btn-sm btn-link',  form: {data: { turbo: true, turbo_confirm: alert_text, turbo_frame: '_top'}}
+
     - if @submissions.length >= 5
       %tr
         %td{colspan: more_colspan, class: "show_more_subs"}


### PR DESCRIPTION
## Prerequisites 

- https://github.com/ontoportal-lirmm/bioportal_web_ui/pull/87
- https://github.com/ontoportal-lirmm/bioportal_web_ui/pull/136
- https://github.com/ontoportal-lirmm/bioportal_web_ui/pull/138

## Changes

### Features
- Add edit and delete buttons to the ontology submission table 
![image](https://user-images.githubusercontent.com/29259906/210177383-c2cd1f30-3b41-4d73-b97c-e85a32aa68e9.png)

- Show success/error alerts after delete and remove the line in the table
![image](https://user-images.githubusercontent.com/29259906/210177434-d0bc631c-bf03-43e7-b995-4280f4574b93.png)



### Technical 

- Fix  some bugs of showing schemes with no ids 
- Fix error response handling 
- Add and remove turbo stream helper 
- Use as a default Turbo confirm method Alertify
- Fix turbo frame error handling 


