### PR TITLE
Fix/add db volume to dockerfile

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -47,5 +47,6 @@ services:
     profiles: ["web"]
     command: "yarn build --watch"
 volumes:
+  db-v:
   bundle:
   node:


### PR DESCRIPTION
## Problem

A volume with the name 'db-v' does not appear in the list of volumes that are specified in the Dockerfile.

## Solution

To fix this issue, I added 'db-v' to the volumes section in the Dockerfile.

## Changes Made

- Include 'db-v' in the list of volumes.

## Testing

No tests are necessary or required.

## Types of changes

- [x] Bug fix
