### PR TITLE
Fix: error messages on ontology creation 

### DIFF
--- a/app/controllers/ontologies_controller.rb
+++ b/app/controllers/ontologies_controller.rb
@@ -200,6 +200,7 @@ display_context: false, include: browse_attributes)
     @ontology_saved = @ontology.save
     if response_error?(@ontology_saved)
       @categories = LinkedData::Client::Models::Category.all
+      @groups = LinkedData::Client::Models::Group.all(display_links: false, display_context: false)
       @user_select_list = LinkedData::Client::Models::User.all.map { |u| [u.username, u.id] }
       @user_select_list.sort! { |a, b| a[1].downcase <=> b[1].downcase }
       @errors = response_errors(@ontology_saved)


### PR DESCRIPTION
### Issue
When we have an error on the ontology creation, the page that shows those errors does not fetch groups so can't display it again
![image](https://user-images.githubusercontent.com/29259906/212411808-63138a4c-3931-450f-91e9-59dab016592e.png)
