### PR TITLE
Fix: class jump to

### DIFF
--- a/app/views/ontologies/concepts_browsers/_jump_to.html.haml
+++ b/app/views/ontologies/concepts_browsers/_jump_to.html.haml
@@ -4,8 +4,8 @@
       %i.fas.fa-search
   = text_field_tag("search_box", nil, class: "form-control rounded-right", placeholder: "Jump to", aria: {label: "Jump to:"},
                 data: {controller: 'class-search-auto-complete',
-                       'class-search-auto-complete': { 'ontology-acronym-value': @ontology.acronym,
-                          'spinner-src-value': asset_path("jquery.simple.tree/spinner.gif")}})
+                       'class-search-auto-complete-ontology-acronym-value': @ontology.acronym,
+                          'class-search-auto-complete-spinner-src-value': asset_path("jquery.simple.tree/spinner.gif")})
   = hidden_field_tag("jump_to_concept_id")
   - if skos?
     %div.input-group-append


### PR DESCRIPTION
### issue
Jump to did the search in all the ontologies of the portal and not only in the current showed ontology
### Before

![image](https://user-images.githubusercontent.com/29259906/212818113-5322a1e0-9f2a-4483-93dc-312d15a30bde.png)


### After
![image](https://user-images.githubusercontent.com/29259906/212818023-39530e82-41d8-4818-bd76-7297f9ae3950.png)
