### PR TITLE
Fix: Force cast to string submission version of type number

### DIFF
--- a/app/helpers/ontologies_helper.rb
+++ b/app/helpers/ontologies_helper.rb
@@ -297,7 +297,7 @@ module OntologiesHelper
 
   # Creates a link based on the status of an ontology submission
   def status_link(submission, latest = false, target = '')
-    version_text = submission.version.nil? || submission.version.length == 0 ? 'unknown' : submission.version
+    version_text = submission.version.nil? || submission.version.to_s.length == 0 ? 'unknown' : submission.version.to_s
     status_text = " <span class='ontology_submission_status'>" + submission_status2string(submission) + '</span>'
     if submission.ontology.summaryOnly || latest == false
       version_link = version_text


### PR DESCRIPTION
### Issue
Fix https://github.com/agroportal/project-management/issues/350

### Change
Force the cast of the submission version to string

<img width="1757" alt="image" src="https://user-images.githubusercontent.com/29259906/213211852-34999608-55d6-4727-b11a-58135c216ced.png">
