### PR TITLE
Feature: Create subscribe to ontology button component 

### DIFF
--- a/app/assets/javascripts/bp_notes.js
+++ b/app/assets/javascripts/bp_notes.js
@@ -311,38 +311,6 @@ function getNoteType(note) {
     return "Comment";
   }
 }
-
-function subscribeToNotes(button) {
-  var ontologyId = jQuery(button).attr("data-bp_ontology_id");
-  var isSubbed = jQuery(button).attr("data-bp_is_subbed");
-  var userId = jQuery(button).attr("data-bp_user_id");
-
-  jQuery(".notes_sub_error").html("");
-  jQuery(".notes_subscribe_spinner").show();
-
-  jQuery.ajax({
-    type: "POST",
-    url: "/subscriptions?user_id="+userId+"&ontology_id="+ontologyId+"&subbed="+isSubbed,
-    dataType: "json",
-    success: function(data) {
-      jQuery(".notes_subscribe_spinner").hide();
-
-      // Change subbed value on a element
-      var subbedVal = (isSubbed == "true") ? "false" : "true";
-      jQuery("a.subscribe_to_notes").attr("data-bp_is_subbed", subbedVal);
-
-      // Change button text
-      var txt = jQuery("a.subscribe_to_notes").html();
-      var newButtonText = txt.match("Unsubscribe") ? txt.replace("Unsubscribe", "Subscribe") : txt.replace("Subscribe", "Unsubscribe");
-      jQuery("a.subscribe_to_notes").html(newButtonText);
-    },
-    error: function(data) {
-      jQuery(".notes_subscribe_spinner").hide();
-      jQuery(".notes_sub_error").html("Problem subscribing to emails, please try again");
-    }
-  });
-}
-
 function hideOrUnhideArchivedOntNotes() {
   if (jQuery("#hide_archived_ont:checked").val() !== undefined) {
     // Checked

--- a/app/components/ontology_subscribe_button_component.rb
+++ b/app/components/ontology_subscribe_button_component.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+class OntologySubscribeButtonComponent < ViewComponent::Base
+  def initialize(ontology_id: , subscribed: , user_id:)
+    super
+    @sub_text = subscribed ? "Unsubscribe" : "Subscribe"
+    @controller_params =  {
+      data: {
+        controller: 'subscribe-notes',
+        'subscribe-notes-ontology-id-value':  ontology_id,
+        'subscribe-notes-is-subbed-value': subscribed.to_s,
+        'subscribe-notes-user-id-value':  user_id,
+        action: 'click->subscribe-notes#subscribeToNotes'
+      }
+    }
+  end
+end

--- a/app/components/ontology_subscribe_button_component/ontology_subscribe_button_component.html.haml
+++ b/app/components/ontology_subscribe_button_component/ontology_subscribe_button_component.html.haml
@@ -1,0 +1,6 @@
+%span{@controller_params}
+  %a.subscribe_to_notes.btn.btn-primary{href:'javascript:void(0);'}
+    #{@sub_text} to notes emails
+  %span{style:"display: none;", 'data-subscribe-notes-target': 'loader'}
+    = image_tag("spinners/spinner_000000_16px.gif", style: "vertical-align: text-bottom; background: transparent")
+  %span.notes_sub_error{style:'color: red; display: none', 'data-subscribe-notes-target': 'error'}

--- a/app/components/ontology_subscribe_button_component/ontology_subscribe_button_component_controller.js
+++ b/app/components/ontology_subscribe_button_component/ontology_subscribe_button_component_controller.js
@@ -1,0 +1,64 @@
+import {Controller} from "@hotwired/stimulus";
+import useAjax from "../../javascript/mixins/useAjax";
+
+// Connects to data-controller="subscribe-notes"
+export default class extends Controller {
+    static values = {
+        ontologyId: String,
+        isSubbed: Boolean,
+        userId: String
+    }
+    static targets = ["error", "loader"]
+
+    subscribeToNotes() {
+        let ontologyId = this.ontologyIdValue
+        let isSubbed = this.isSubbedValue
+        let userId = this.userIdValue
+
+        this.#hideError()
+        this.#showSpinner()
+
+        let url = "/subscriptions?user_id=" + userId + "&ontology_id=" + ontologyId + "&subbed=" + isSubbed;
+        useAjax({
+            type: "POST",
+            url: url,
+            dataType: "json",
+            success: () => {
+                // Change subbed value on a element
+                this.#hideSpinner()
+                let linkElement = $(this.element);
+                this.isSubbedValue = !isSubbed
+
+                // Change button text
+                let txt = linkElement.html();
+                let newButtonText = txt.match("Unsubscribe") ? txt.replace("Unsubscribe", "Subscribe") : txt.replace("Subscribe", "Unsubscribe");
+                linkElement.html(newButtonText);
+            },
+            error: () => {
+                this.#hideSpinner()
+                this.#showError()
+            }
+        })
+    }
+
+    #showSpinner() {
+        $(this.loaderTarget).show()
+    }
+
+    #hideSpinner() {
+        $(this.loaderTarget).hide()
+    }
+
+
+    #showError() {
+        const errorElem = $(this.errorTarget)
+        errorElem.html("Problem subscribing to emails, please try again")
+        errorElem.show()
+    }
+
+    #hideError() {
+        $(this.errorTarget).hide()
+    }
+
+
+}

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -391,6 +391,17 @@ module ApplicationHelper
     error = "<span style='color: red;' class='subscribe_error'></span>"
     return "<a href='javascript:void(0);' class='subscribe_to_ontology btn btn-primary' #{params}>#{sub_text}</a> #{spinner} #{error}"
   end
+  def subscribe_button(ontology_id)
+    if session[:user].nil?
+      return link_to 'Subscribe to notes emails', "/login?redirect=#{request.url}", {style:'font-size: .9em;', class:'link_button'}
+    end
+
+    user = LinkedData::Client::Models::User.find(session[:user].id)
+    ontology_acronym = ontology_id.split('/').last
+    subscribed = subscribed_to_ontology?(ontology_acronym, user)
+
+    render OntologySubscribeButtonComponent.new(ontology_id: ontology_id, subscribed: subscribed, user_id: user.id)
+  end
 
   def subscribed_to_ontology?(ontology_acronym, user)
     user.bring(:subscription) if user.subscription.nil?

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -363,34 +363,7 @@ module ApplicationHelper
     output = "<span class='more_less_container'><span class='truncated_more'>#{truncate(text, :length => length, :omission => trailing_text)}" + more + "</span>"
   end
 
-  def subscribe_ontology_button(ontology_id, user = nil)
-    user = session[:user] if user.nil?
-    if user.nil?
-      # subscribe button must redirect to login
-      return sanitize("<a href='/login?redirect=#{request.url}' style='font-size: .9em;' class='subscribe_to_ontology'>Subscribe</a>")
-    end
-    # Init subscribe button parameters.
-    sub_text = "Subscribe"
-    params = "data-bp_ontology_id='#{ontology_id}' data-bp_is_subbed='false' data-bp_user_id='#{user.id}'"
-    begin
-      # Try to create an intelligent subscribe button.
-      if ontology_id.start_with? 'http'
-        ont = LinkedData::Client::Models::Ontology.find(ontology_id)
-      else
-        ont = LinkedData::Client::Models::Ontology.find_by_acronym(ontology_id).first
-      end
-      subscribed = subscribed_to_ontology?(ont.acronym, user)  # application_helper
-      sub_text = subscribed ? "Unsubscribe" : "Subscribe"
-      params = "data-bp_ontology_id='#{ont.acronym}' data-bp_is_subbed='#{subscribed}' data-bp_user_id='#{user.id}'"
-    rescue
-      # pass, fallback init done above begin block to scope parameters beyond the begin/rescue block
-    end
-    # TODO: modify/copy CSS for notes_sub_error => subscribe_error
-    # TODO: modify/copy CSS for subscribe_to_notes => subscribe_to_ontology
-    spinner = '<span class="subscribe_spinner" style="display: none;">' + image_tag("spinners/spinner_000000_16px.gif", style: "vertical-align: text-bottom;") + '</span>'
-    error = "<span style='color: red;' class='subscribe_error'></span>"
-    return "<a href='javascript:void(0);' class='subscribe_to_ontology btn btn-primary' #{params}>#{sub_text}</a> #{spinner} #{error}"
-  end
+ 
   def subscribe_button(ontology_id)
     if session[:user].nil?
       return link_to 'Subscribe to notes emails', "/login?redirect=#{request.url}", {style:'font-size: .9em;', class:'link_button'}

--- a/app/helpers/notes_helper.rb
+++ b/app/helpers/notes_helper.rb
@@ -129,34 +129,7 @@ module NotesHelper
       return "Change Property Value Proposal"
     end
   end
-
-  def subscribe_button(ontology_id)
-    user = session[:user]
-    if user.nil?
-      # subscribe button must redirect to login
-      return link_to 'Subscribe to notes emails', "/login?redirect=#{request.url}", {style:'font-size: .9em;', class:'link_button'}
-    end
-    # Init subscribe button parameters.
-    user = LinkedData::Client::Models::User.find(session[:user].id)
-    sub_text = "Subscribe"
-    params = "data-bp_ontology_id='#{ontology_id}' data-bp_is_subbed='false' data-bp_user_id='#{user.id}'"
-    begin
-      # Try to create an intelligent subscribe button.
-      if ontology_id.start_with? 'http'
-        ont = LinkedData::Client::Models::Ontology.find(ontology_id)
-      else
-        ont = LinkedData::Client::Models::Ontology.find_by_acronym(ontology_id).first
-      end
-      subscribed = subscribed_to_ontology?(ont.acronym, user)  # application_helper
-      sub_text = subscribed ? "Unsubscribe" : "Subscribe"
-      params = "data-bp_ontology_id='#{ont.acronym}' data-bp_is_subbed='#{subscribed}' data-bp_user_id='#{user.id}'"
-    rescue
-      # pass, fallback init done above begin block to scope parameters beyond the begin/rescue block
-    end
-    spinner = '<span class="notes_subscribe_spinner" style="display: none;">' + image_tag("spinners/spinner_000000_16px.gif", style: "vertical-align: text-bottom;") + '</span>'
-    error = "<span style='color: red;' class='notes_sub_error'></span>"
-    return "<a href='javascript:void(0);' class='subscribe_to_notes btn btn-primary' #{params}>#{sub_text} to notes emails</a> #{spinner} #{error}".html_safe
-  end
+  
 
   def delete_button
     user = session[:user]

--- a/app/javascript/component_controllers/index.js
+++ b/app/javascript/component_controllers/index.js
@@ -8,8 +8,11 @@ import Select_input_component_controller
     from "../../components/select_input_component/select_input_component_controller";
 import Metadata_selector_component_controller
     from "../../components/metadata_selector_component/metadata_selector_component_controller";
+import Ontology_subscribe_button_component_controller
+    from "../../components/ontology_subscribe_button_component/ontology_subscribe_button_component_controller";
 
 application.register("turbo-modal", TurboModalController)
 application.register("file-input", FileInputLoaderController)
 application.register("select-input", Select_input_component_controller)
 application.register("metadata-select", Metadata_selector_component_controller)
+application.register("subscribe-notes", Ontology_subscribe_button_component_controller)

--- a/app/javascript/controllers/application.js
+++ b/app/javascript/controllers/application.js
@@ -6,4 +6,13 @@ const application = Application.start()
 application.debug = false
 window.Stimulus   = application
 
+
+import Flatpickr from "stimulus-flatpickr"
+
+application.register("flatpickr", Flatpickr);
+import NestedForm from 'stimulus-rails-nested-form'
+application.register('nested-form', NestedForm)
+
 export { application }
+
+

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -7,12 +7,6 @@ import { application } from "./application"
 import ChosenController from "./chosen_controller"
 application.register("chosen", ChosenController)
 
-
-import Flatpickr from "stimulus-flatpickr"
-
-application.register("flatpickr", Flatpickr);
-import NestedForm from 'stimulus-rails-nested-form'
-application.register('nested-form', NestedForm)
 import ClassSearchAutoCompleteController from "./class_search_auto_complete_controller"
 application.register("class-search-auto-complete", ClassSearchAutoCompleteController)
 

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -49,6 +49,9 @@ application.register("simple-tree", SimpleTreeController)
 import SkosCollectionColorsController from "./skos_collection_colors_controller"
 application.register("skos-collection-colors", SkosCollectionColorsController)
 
+import SubscribeNotesController from "./subscribe_notes_controller"
+application.register("subscribe-notes", SubscribeNotesController)
+
 import TooltipController from "./tooltip_controller"
 application.register("tooltip", TooltipController)
 

--- a/app/views/notes/_list.html.haml
+++ b/app/views/notes/_list.html.haml
@@ -70,10 +70,6 @@
     bindReplyCancelClick();
     bindReplySaveClick();
 
-    jQuery("a.subscribe_to_notes").live("click", function(){
-      subscribeToNotes(this);
-    });
-
     jQuery("#hide_archived_ont").click(function(){
       hideOrUnhideArchivedOntNotes();
     });

--- a/app/views/notes/_ontology_list.html.haml
+++ b/app/views/notes/_ontology_list.html.haml
@@ -93,9 +93,7 @@
     bindReplyCancelClick();
     bindReplySaveClick();
 
-    jQuery("a.subscribe_to_notes").live("click", function(){
-      subscribeToNotes(this);
-    });
+
 
     jQuery("#hide_archived_ont").click(function(){
       hideOrUnhideArchivedOntNotes();

--- a/app/views/users/show.html.haml
+++ b/app/views/users/show.html.haml
@@ -30,8 +30,9 @@
     %h2 Subscriptions
     %table
       - @user.subscription.each do |subscription|
-        - ont = (!subscription[:ontology].nil? ? subscription[:ontology].split('/').last: nil) # ensure we get the acronym
-        - type = (!subscription[:notification_type].nil? ? subscription[:notification_type].downcase : nil)
+        - ont_id = subscription[:ontology]
+        - ont = ont_id.nil? ? nil: subscription[:ontology].split('/').last
+        - type = subscription[:notification_type].nil? ? nil : subscription[:notification_type].downcase
         %tr{style: "padding: 5px;"}
           %td{style: "padding: 5px;"}
             %a{href: "/ontologies/#{ont}"}= ont
@@ -42,7 +43,7 @@
               = type
           %td{style: "padding: 5px;"}
             .subscribe_to_ontology{style: "float: left;"}
-              = raw subscribe_ontology_button(ont, @user)
+              = subscribe_button(ont_id)
     %br/
 
   - unless @user_projects.nil? || @user_projects.empty?
@@ -66,38 +67,8 @@
   :javascript
     jQuery(document).ready(function(){
       jQuery("#edit_custom_ontologies").click(editCustomOntologies);
-      // Wire up subscriptions button activity
-      jQuery("a.subscribe_to_ontology").live("click", function(){
-        subscribeToOntology(this);
-      });
     });
 
-    function subscribeToOntology(button) {
-      var ontologyId = jQuery(button).attr("data-bp_ontology_id");
-      var isSubbed = jQuery(button).attr("data-bp_is_subbed");
-      var userId = jQuery(button).attr("data-bp_user_id");
-      jQuery(".subscribe_error").html("");
-      jQuery(".subscribe_spinner").show();
-      jQuery.ajax({
-        type: "POST",
-        url: "/subscriptions?user_id="+userId+"&ontology_id="+ontologyId+"&subbed="+isSubbed,
-        dataType: "json",
-        success: function(data) {
-          jQuery(".subscribe_spinner").hide();
-          // Toggle subbed value on a element
-          var subbedVal = (isSubbed === "true") ? "false" : "true";
-          jQuery("a.subscribe_to_ontology").attr("data-bp_is_subbed", subbedVal);
-          // Change button text
-          var txt = jQuery("a.subscribe_to_ontology").html();
-          var newButtonText = txt.match("Unsubscribe") ? txt.replace("Unsubscribe", "Subscribe") : txt.replace("Subscribe", "Unsubscribe");
-          jQuery("a.subscribe_to_ontology").html(newButtonText);
-        },
-        error: function(data) {
-          jQuery(".subscribe_spinner").hide();
-          jQuery(".subscribe_error").html("Problem subscribing to emails, please try again");
-        }
-      });
-    }
 
     function editCustomOntologies() {
       jQuery("#custom_ontologies_picker").css("left", "").css("position", "");


### PR DESCRIPTION
### Changes

- Migrate the old js code to the Stimulus controller
- Create a reusable component to subscribe a user to an ontology  
- Remove duplicate code
- Fix a bug that subscribes the user to the same ontology multiple times 
- Fix a bug that makes the user that wanted to unsubscribe to an Ontology instead unsubscribe him to all his subscriptions 