### PR TITLE
Fix: Password recovery success message

### DIFF
--- a/app/views/login/lost_password_success.html.haml
+++ b/app/views/login/lost_password_success.html.haml
@@ -1,1 +1,1 @@
-= render(CardMessageComponent.new(title:"no-title" ,message: "A password reset email has been sent to your email, please follow the instructions in the email to reset your password.", button_text: "Back home", type:"success"))
+= render(CardMessageComponent.new(message: "A password reset email has been sent to your email, please follow the instructions in the email to reset your password.", button_text: "Back home", type:"success"))


### PR DESCRIPTION
### Context
Before, to make a message card component without a title, you need to fill the parameter title with "no-title"
Now, to do the same thing, you just need to keep the parameter title empty (by default it's nil).

### Problem
In the lost password success we used the old message card component.

### Solution
I removed the parameter title.