### PR TITLE
Feature: Add monitoring links to admin page 

### DIFF
--- a/app/views/admin/index.html.haml
+++ b/app/views/admin/index.html.haml
@@ -59,8 +59,8 @@
           %div.site-admin-page-header
             MONITORING LINKS
           %dive.site-admin-page-section
-            = link_to("Newrelic", "https://login.newrelic.com/login", id: "newrelic_link", class: "btn btn-outline-secondary btn-sm admin-action-item",  role: "button")
-            = link_to("StatusCake", "https://app.statuscake.com/Login", id: "statuscake_link", class: "btn btn-outline-secondary btn-sm admin-action-item",  role: "button")
+            = link_to("Newrelic", "https://login.newrelic.com/login", target: '_blank', id: "newrelic_link", class: "btn btn-outline-secondary btn-sm admin-action-item",  role: "button")
+            = link_to("StatusCake", "https://app.statuscake.com/Login", target: '_blank', id: "statuscake_link", class: "btn btn-outline-secondary btn-sm admin-action-item",  role: "button")
           
 
       -# Ontology Administration tab

--- a/app/views/admin/index.html.haml
+++ b/app/views/admin/index.html.haml
@@ -13,7 +13,6 @@
 
 %div.row
   %div.col
-
     %ul.nav.nav-tabs{id: "admin-tabs", role: "tablist"}
       %li.nav-item
         =link_to("Site Administration", "#site-admin", id: "site-admin-tab", class: "nav-link active", role: "tab", data: { toggle: "tab" }, aria: { controls: "site-admin", selected: "true" })
@@ -54,6 +53,15 @@
           %dive.site-admin-page-section
             %div#appliance-id
               %span
+        
+        -# Clear caches
+        %div#site-admin-clear-caches.my-5
+          %div.site-admin-page-header
+            MONITORING LINKS
+          %dive.site-admin-page-section
+            = link_to("Newrelic", "https://login.newrelic.com/login", id: "newrelic_link", class: "btn btn-outline-secondary btn-sm admin-action-item",  role: "button")
+            = link_to("StatusCake", "https://app.statuscake.com/Login", id: "statuscake_link", class: "btn btn-outline-secondary btn-sm admin-action-item",  role: "button")
+          
 
       -# Ontology Administration tab
       %div.tab-pane.fade{id: "ontology-admin", role: "tabpanel", aria: { labelledby: "ontology-admin-tab" }}


### PR DESCRIPTION
### Changes

- add monitoring links `NewRelic` and `StatusCake` to admin panel
<img width="457" alt="image" src="https://user-images.githubusercontent.com/29259906/225517314-425da17d-1d03-406e-af3d-2148b5476eea.png">
