### PR TITLE
Fix: disable cache_refresh_all for submission save

### DIFF
--- a/app/controllers/concerns/submission_updater.rb
+++ b/app/controllers/concerns/submission_updater.rb
@@ -8,7 +8,7 @@ module SubmissionUpdater
     @submission = LinkedData::Client::Models::OntologySubmission.new(values: submission_params(new_submission_hash))
 
     update_ontology_summary_only
-    @submission.save
+    @submission.save(cache_refresh_all: false)
   end
 
   def update_submission(new_submission_hash)


### PR DESCRIPTION
### Issue
 Saving/ Creating a submission raises a Time out error. Because refresh the cache of all submission 

<img width="771" alt="image" src="https://user-images.githubusercontent.com/29259906/227238358-46812f0b-1352-47c7-a30f-89038d50be91.png">


### Solution 

https://github.com/ncbo/ontologies_api_ruby_client/pull/9