### PR TITLE
Feature: Show ontology data by one language - part 3

### DIFF
--- a/app/components/edit_submission_attribute_button_component.rb
+++ b/app/components/edit_submission_attribute_button_component.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+class EditSubmissionAttributeButtonComponent < ViewComponent::Base
+  include ActionView::Helpers::TagHelper
+
+  def initialize(acronym: , submission_id:, attribute:, inline: false)
+    @acronym = acronym
+    @submission_id  = submission_id
+    @attribute = attribute
+
+    if inline
+      @link = "ontologies_metadata_curator/#{@acronym}/submissions/#{@submission_id}?properties=#{@attribute}&inline_save=true"
+    else
+      @link = "/ontologies/#{@acronym}/submissions/#{@submission_id}/edit?properties=#{@attribute}"
+    end
+  end
+
+  def call
+    link_to @link, data: {turbo: true},  class: "btn btn-sm btn-light" do
+      content
+    end
+  end
+
+end

--- a/app/helpers/ontologies_helper.rb
+++ b/app/helpers/ontologies_helper.rb
@@ -447,7 +447,18 @@ module OntologiesHelper
 
 
   def language_selector_tag(name)
-    select_tag name, languages_options, class: 'custom-select', disabled: !ontology_data_section?, data: {'ontology-viewer-tabs-target': 'languageSelector'}
+    languages = languages_options
+
+    if languages.empty?
+      content_tag(:div ,data: {'ontology-viewer-tabs-target': 'languageSelector'}, style: "visibility: #{ontology_data_section? ? 'visible' : 'hidden'} ; margin-bottom: -1px;") do
+        render EditSubmissionAttributeButtonComponent.new(acronym: @ontology.acronym, submission_id: @submission_latest.submissionId, attribute: :naturalLanguage) do
+          concat "Enable multilingual display "
+          concat content_tag(:i , "", class: "fas fa-lg fa-question-circle")
+        end
+      end
+    else
+      select_tag name, languages_options, class: 'custom-select', disabled: !ontology_data_section?, style: "visibility: #{ontology_data_section? ? 'visible' : 'hidden'}; margin-bottom: -10px;", data: {'ontology-viewer-tabs-target': 'languageSelector'}
+    end
   end
 
   def language_selector_hidden_tag(section)

--- a/app/javascript/controllers/ontology_viewer_tabs_controller.js
+++ b/app/javascript/controllers/ontology_viewer_tabs_controller.js
@@ -31,8 +31,8 @@ export default class extends Controller {
   }
 
   #updateURL(event){
-    const page = jQuery(event.target).attr("data-bp-ont-page");
-    const page_name = jQuery(event.target).attr("data-bp-ont-page-name");
+    const page = event.target.getAttribute("data-bp-ont-page");
+    const page_name = event.target.getAttribute("data-bp-ont-page-name");
 
     (new HistoryService()).pushState({p: page}, page_name + " | " + jQuery(document).data().bp.ont_viewer.org_site, "?p=" + page);
 
@@ -42,8 +42,10 @@ export default class extends Controller {
   #disableLanguageSelector(selectedSection){
     if (this.languageSectionsValue.includes(selectedSection)){
       this.languageSelectorTarget.removeAttribute("disabled")
+      this.languageSelectorTarget.style.visibility = 'visible'
     } else{
       this.languageSelectorTarget.setAttribute("disabled", true)
+      this.languageSelectorTarget.style.visibility = 'hidden'
     }
   }
 

--- a/app/views/layouts/_ontology_viewer.html.haml
+++ b/app/views/layouts/_ontology_viewer.html.haml
@@ -49,7 +49,7 @@
     %div.col
       - sections = sections_to_show
       %div.card
-        %div.card-header{style: 'padding-bottom: 3px'}
+        %div.card-header
           %div{style: "display: flex; justify-content: space-between;"}
             %ul.nav.nav-tabs.card-header-tabs{id: "navbar-ontology", role: "tablist"}
               - sections.each do |section|

--- a/app/views/ontologies/sections/_metadata.html.haml
+++ b/app/views/ontologies/sections/_metadata.html.haml
@@ -68,7 +68,7 @@
           - unless (@submission_latest.nil? || (@submission_latest.respond_to?(:status) && @submission_latest.status == 404))
             = link_to(edit_ontology_submission_path(@ontology.acronym, @submission_latest.submissionId), "aria-label": "Edit latest submission", title: "Edit latest submission") do
               %i.fas.fa-user-edit{"aria-hidden": "true", style: "margin-left: 0.5rem;"}
-      = render TurboFrameComponent.new(id: 'ontology_submissions', src: ontology_submissions_path(@ontology.acronym))
+      = render TurboFrameComponent.new(id: 'ontology_submissions', src: ontology_submissions_path(@ontology.acronym), target: '_top')
 
 
     -# Views pane (don't show if the ontology is a view - we don't allow views of views).

--- a/app/views/ontologies_metadata_curator/_attribute_inline_editable.html.haml
+++ b/app/views/ontologies_metadata_curator/_attribute_inline_editable.html.haml
@@ -20,5 +20,5 @@
 
 
           %div
-            %a.btn.btn-sm.btn-light{href: "ontologies_metadata_curator/#{ontology.acronym}/submissions/#{submission_id}?properties=#{attribute}&inline_save=true", data: {turbo: true}}
+            = render EditSubmissionAttributeButtonComponent.new(acronym: ontology.acronym, submission_id: submission_id, attribute: attribute, inline: true) do
               %i.far.fa-edit

--- a/app/views/submissions/_form.html.haml
+++ b/app/views/submissions/_form.html.haml
@@ -44,7 +44,7 @@
     - unless @filters_disabled
       %div.w-75.mt-3
         - if @submission.id
-          = render MetadataSelectorComponent.new(label: 'Filter properties to show', values: submission_editable_properties , selected:  nil, inline: true)
+          = render MetadataSelectorComponent.new(label: 'Filter properties to show', values: submission_editable_properties , selected:  @selected_attributes, inline: true)
       %div
         = render SwitchInputComponent.new(id:"filter-required-only", name: "required-only", label: "Required only", checked: @required_only)
 


### PR DESCRIPTION
Follow up of https://github.com/ontoportal-lirmm/bioportal_web_ui/pull/225

### Changes

- Display an information text if no language is configured, and when clicked open the submission edit page with only the naturalLanguage attribute. 
![image](https://user-images.githubusercontent.com/29259906/236706452-59702307-2a43-4c27-930d-22a80175934c.png)
- Fix the submission edit page to show the selected attributes in the URL(https://github.com/ontoportal-lirmm/bioportal_web_ui/commit/f809e1bedcf98f04233d1966fc826f5f90788f5f)
- Fix the submission edit page to show the selected attributes in the URL (https://github.com/ontoportal-lirmm/bioportal_web_ui/commit/f809e1bedcf98f04233d1966fc826f5f90788f5f)
- Some code refactoring  (https://github.com/ontoportal-lirmm/bioportal_web_ui/commit/7463fe87c3655e240ff6e822b6808afe61fdc9ba)