### PR TITLE
Feature: Add Lookbook to preview view components - fix the new version release 

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -69,7 +69,6 @@ gem 'rest-client'
 gem 'stackprof', require: false
 gem 'thin'
 gem 'view_component', '~> 2.72'
-gem "lookbook"
 gem 'turnout'
 gem 'will_paginate', '~> 3.0'
 
@@ -85,7 +84,7 @@ group :staging, :production, :appliance do
 end
 
 group :development do
-   # Capistrano Deployment
+  # Capistrano Deployment
   gem 'bcrypt_pbkdf', '>= 1.0', '< 2.0', require: false # https://github.com/miloserdow/capistrano-deploy/issues/42
   gem 'capistrano', '~> 3.11', require: false
   gem 'capistrano-bundler', require: false
@@ -105,6 +104,7 @@ group :development do
 
   # Use console on exceptions pages [https://github.com/rails/web-console]
   gem 'web-console'
+  gem "lookbook", '~> 1.5.5'
 end
 
 group :test, :development do

--- a/app/views/layouts/component_preview.html.erb
+++ b/app/views/layouts/component_preview.html.erb
@@ -4,7 +4,7 @@
   <meta name="viewport" content="width=device-width,initial-scale=1">
   <%= stylesheet_link_tag "application" %>
 </head>
-<body style="margin: 20px">
+<body class="d-flex align-items-center justify-content-center w-100 h-100">
 
     <%= yield %> <!-- rendered preview will be injected here -->
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -207,6 +207,9 @@ Rails.application.routes.draw do
   get '/visualize' => 'ontologies#visualize', :as => :visualize_concept, :constraints => { ontology: /[^\/?]+/, id: /[^\/?]+/, ontologyid: /[^\/?]+/, conceptid: /[^\/?]+/ }
 
   get '/exhibit/:ontology/:id' => 'concepts#exhibit'
-  
-  mount Lookbook::Engine, at: "/lookbook"
+
+  if Rails.env.development?
+    mount Lookbook::Engine, at: "/lookbook"
+  end
+
 end

--- a/test/components/previews/alert_component_preview.rb
+++ b/test/components/previews/alert_component_preview.rb
@@ -1,0 +1,12 @@
+class AlertComponentPreview < ViewComponent::Preview
+
+  # @param message text
+  # @param type select [primary, danger, success, info, light]
+
+  def default(type: "success", message: "Here we can type a success or failure message to the user")
+    render AlertMessageComponent.new(id: '', type: type) do
+      message
+    end
+  end
+
+end


### PR DESCRIPTION
Follow up of https://github.com/ontoportal-lirmm/bioportal_web_ui/pull/236

### Context

Last week, Lookbook released the V2, which seems to not work with our current version of the code.  
So I pinned (blocked) the version to the latest version of V1 (v1.5.5)

### Changes

- Mount lookbook only in the development environment (https://github.com/ontoportal-lirmm/bioportal_web_ui/commit/276760c4225d41072457db4de4b22b9ed32f9ad4)
- Put the "lookbook" gem in the development group and pin it to the latest path of v1 (https://github.com/ontoportal-lirmm/bioportal_web_ui/commit/7c75a1cdbc44ba5e18336bfee67c5613a71b831a)
- Align and center previewed components (https://github.com/ontoportal-lirmm/bioportal_web_ui/commit/67a74d6d7cb66ef88b59e3b79552f673bbb81e5d)

