### PR TITLE
Feature: Update account page submitted ontologies

### DIFF
--- a/app/views/users/show.html.haml
+++ b/app/views/users/show.html.haml
@@ -111,7 +111,7 @@
             %h4.account-page-card-title Submitted ontologies
             .account-page-small-cards-container
               - @admin_ontologies.each do |ont|
-                .account-page-submitted-ontology
+                .account-page-submitted-ontology{data: {controller: 'tooltip'}, title: ont.name}
                   %a{href: "/ontologies/#{ont.acronym}"}= ont.acronym
         - unless @user_projects.nil? || @user_projects.empty?
           - no_ontologies = false

--- a/app/views/users/show.html.haml
+++ b/app/views/users/show.html.haml
@@ -112,7 +112,7 @@
             .account-page-small-cards-container
               - @admin_ontologies.each do |ont|
                 .account-page-submitted-ontology
-                  %a{href: "/ontologies/#{ont.acronym}"}= ont.name
+                  %a{href: "/ontologies/#{ont.acronym}"}= ont.acronym
         - unless @user_projects.nil? || @user_projects.empty?
           - no_ontologies = false
           .account-page-card


### PR DESCRIPTION
### Context
This pull request addresses an issue on the account page where the names of submitted ontologies are too long and negatively impacting the design of the page. 
To improve the user experience, this pull request proposes using acronyms for the ontology names instead. The acronyms are shorter and easier to read, while still allowing users to easily recognize their ontologies.

### Changes Made
- Updated the account page to use ontology acronyms instead of full names in the section displaying submitted ontologies.
- Tested the changes to ensure they do not negatively impact the functionality of the account page or other related features.