### PR TITLE
Feature: Implement CI deployment  for development servers 

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -17,7 +17,7 @@ name: Capistrano Deployment
 # Controls when the action will run.
 on:
   push:
-    branches: [ development staging ]
+    branches: [ development stage test]
   # Allows running this workflow manually from the Actions tab
   workflow_dispatch:
     inputs:
@@ -25,9 +25,10 @@ on:
         description: 'Branch/tag to deploy'
         options:
           - development
-          - staging
+          - stage
+          - test
           - master
-        default: staging
+        default: test
         required: true
       environment:
         description: 'target environment to deploy to'
@@ -36,7 +37,9 @@ on:
           - development
           - staging
           - production
-        default: staging
+          - appliance
+          - test
+        default: test
 jobs:
   deploy:
     runs-on: ubuntu-latest

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -58,6 +58,10 @@ jobs:
 
         USER_INPUT_ENVIRONMENT=${{ inputs.environment }}
         echo "TARGET=${USER_INPUT_ENVIRONMENT:-staging}" >> $GITHUB_ENV
+        
+        CONFIG_REPO=${{ secrets.CONFIG_REPO }}
+        GH_PAT=${{ secrets.GH_PAT }}
+        echo "PRIVATE_CONFIG_REPO=https://${GH_PAT}@github.com/${CONFIG_REPO}" >> $GITHUB_ENV
     # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
     - uses: actions/checkout@v3
     - uses: ruby/setup-ruby@v1

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -9,6 +9,7 @@
 # GH_PAT - github Personal Access Token for accessing private config repo
 #
 # SSH_JUMPHOST - ssh jump/proxy host though which deployments have to though if UI nodes live on private network.
+# SSH_JUMPHOST_USER - username  to use to connect to the ssh jump/proxy.
 #
 # DEPLOY_ENC_KEY - key for decrypting deploymnet ssh key residing in config/
 # this SSH key is used for accessing jump host, UI nodes, and private github repo.
@@ -62,6 +63,9 @@ jobs:
         CONFIG_REPO=${{ secrets.CONFIG_REPO }}
         GH_PAT=${{ secrets.GH_PAT }}
         echo "PRIVATE_CONFIG_REPO=https://${GH_PAT}@github.com/${CONFIG_REPO}" >> $GITHUB_ENV
+        
+        echo "SSH_JUMPHOST=${{ secrets.SSH_JUMPHOST }}" >> $GITHUB_ENV
+        echo "SSH_JUMPHOST_USER=${{ secrets.SSH_JUMPHOST_USER }}" >> $GITHUB_ENV
     # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
     - uses: actions/checkout@v3
     - uses: ruby/setup-ruby@v1

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -76,6 +76,13 @@ jobs:
         path:  deploy_config
     - name: copy-deployment-config
       run:  cp -r deploy_config/ontoportal_web_ui/${{ inputs.environment }}/* .
+      # add ssh hostkey so that capistrano doesn't complain
+    - name: Add jumphost's hostkey to Known Hosts
+      run: |
+        mkdir -p ~/.ssh
+        echo "${{ secrets.SSH_JUMPHOST }}"
+        ssh-keyscan -H ${{ secrets.SSH_JUMPHOST }} > ~/.ssh/known_hosts
+      shell: bash
     - uses: miloserdow/capistrano-deploy@master
       with:
         target: ${{ env.TARGET }} # which environment to deploy

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,14 +18,13 @@ name: Capistrano Deployment
 # Controls when the action will run.
 on:
   push:
-    branches: [ development stage test]
+    branches: [ stage test]
   # Allows running this workflow manually from the Actions tab
   workflow_dispatch:
     inputs:
       BRANCH:
         description: 'Branch/tag to deploy'
         options:
-          - development
           - stage
           - test
           - master
@@ -35,7 +34,6 @@ on:
         description: 'target environment to deploy to'
         type: choice
         options:
-          - development
           - staging
           - production
           - appliance

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -76,13 +76,18 @@ set :passenger_restart_with_touch, true
 #     # password: 'please use keys'
 #   }
 # setting per server overrides global ssh_options
+
+SSH_JUMPHOST = ENV.include?('SSH_JUMPHOST') ? ENV['SSH_JUMPHOST'] : 'jumpbox.hostname.com'
+SSH_JUMPHOST_USER = ENV.include?('SSH_JUMPHOST_USER') ? ENV['SSH_JUMPHOST_USER'] : 'username'
+
+JUMPBOX_PROXY = "#{SSH_JUMPHOST_USER}@#{SSH_JUMPHOST}"
 set :ssh_options, {
   user: 'ontoportal',
   forward_agent: 'true',
   keys: %w(config/deploy_id_rsa),
   auth_methods: %w(publickey),
   # use ssh proxy if UI servers are on a private network
-  proxy: Net::SSH::Proxy::Command.new('ssh sbouazzouni@jumpbox.lirmm.fr -W %h:%p')
+  proxy: Net::SSH::Proxy::Command.new("ssh #{JUMPBOX_PROXY} -W %h:%p")
 }
 
 desc "Check if agent forwarding is working"

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -11,7 +11,6 @@ set :deploy_via, :remote_cache
 # default deployment branch is master which can be overwritten with BRANCH env var
 # BRANCH env var can be set to specific branch of tag, i.e 'v6.8.1'
 
-set :branch, ENV.include?('BRANCH') ? ENV['BRANCH'] : 'master'
 
 # Default deploy_to directory is /var/www/my_app
 set :deploy_to, "/srv/ontoportal/#{fetch(:application)}"

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -90,6 +90,8 @@ set :ssh_options, {
   proxy: Net::SSH::Proxy::Command.new("ssh #{JUMPBOX_PROXY} -W %h:%p")
 }
 
+#private git repo for configuraiton
+PRIVATE_CONFIG_REPO = ENV.include?('PRIVATE_CONFIG_REPO') ? ENV['PRIVATE_CONFIG_REPO'] : 'https://your_github_pat_token@github.com/your_organization/ontoportal-configs.git'
 desc "Check if agent forwarding is working"
 task :forwarding do
   on roles(:all) do |h|

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -55,6 +55,36 @@ set :passenger_restart_with_touch, true
 # If you don't set `:passenger_restart_with_touch`, capistrano-passenger will check what version of passenger you are running
 # and use `passenger-config restart-app` if it is available in that version.
 
+# you can set custom ssh options
+# it's possible to pass any option but you need to keep in mind that net/ssh understand limited list of options
+# you can see them in [net/ssh documentation](http://net-ssh.github.io/net-ssh/classes/Net/SSH.html#method-c-start)
+# set it globally
+#  set :ssh_options, {
+#    keys: %w(/home/rlisowski/.ssh/id_rsa),
+#    forward_agent: false,
+#    auth_methods: %w(password)
+#  }
+# and/or per server
+# server 'example.com',
+#   user: 'user_name',
+#   roles: %w{web app},
+#   ssh_options: {
+#     user: 'user_name', # overrides user setting above
+#     keys: %w(/home/user_name/.ssh/id_rsa),
+#     forward_agent: false,
+#     auth_methods: %w(publickey password)
+#     # password: 'please use keys'
+#   }
+# setting per server overrides global ssh_options
+set :ssh_options, {
+  user: 'ontoportal',
+  forward_agent: 'true',
+  keys: %w(config/deploy_id_rsa),
+  auth_methods: %w(publickey),
+  # use ssh proxy if UI servers are on a private network
+  proxy: Net::SSH::Proxy::Command.new('ssh sbouazzouni@jumpbox.lirmm.fr -W %h:%p')
+}
+
 desc "Check if agent forwarding is working"
 task :forwarding do
   on roles(:all) do |h|

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -41,7 +41,7 @@ set :linked_dirs, %w{log tmp/pids tmp/cache public/system public/assets}
 set :keep_releases, 5
 set :bundle_without, 'development:test'
 set :bundle_config, { deployment: true }
-
+set :rails_env, "appliance"
 # Defaults to [:web]
 set :assets_roles, [:web, :app]
 set :keep_assets, 3
@@ -101,6 +101,7 @@ namespace :deploy do
   end
 
 
+  after :updating, :get_config
   after :publishing, :restart
 
   after :restart, :clear_cache do

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -42,6 +42,7 @@ set :keep_releases, 5
 set :bundle_without, 'development:test'
 set :bundle_config, { deployment: true }
 set :rails_env, "appliance"
+set :config_folder_path, "#{fetch(:application)}/#{fetch(:stage)}"
 # Defaults to [:web]
 set :assets_roles, [:web, :app]
 set :keep_assets, 3
@@ -82,7 +83,7 @@ namespace :deploy do
       TMP_CONFIG_PATH = "/tmp/#{SecureRandom.hex(15)}".freeze
       on roles(:app) do
         execute "git clone -q #{PRIVATE_CONFIG_REPO} #{TMP_CONFIG_PATH}"
-        execute "rsync -a #{TMP_CONFIG_PATH}/#{fetch(:application)}/ #{release_path}/"
+        execute "rsync -a #{TMP_CONFIG_PATH}/#{fetch(:config_folder_path)}/ #{release_path}/"
         execute "rm -rf #{TMP_CONFIG_PATH}"
       end
     elsif defined?(LOCAL_CONFIG_PATH)

--- a/config/deploy/production.rb
+++ b/config/deploy/production.rb
@@ -6,7 +6,7 @@
 # Don't declare `role :all`, it's a meta role
 role :app, %w{ui1.prd.ontoportal.org ui2.prd.ontoportal.org}
 role :db, %w{ui1.prd.ontoportal.org} # sufficient to run db:migrate only on one system
-
+set :branch, ENV.include?('BRANCH') ? ENV['BRANCH'] : 'master'
 # Extended Server Syntax
 # ======================
 # This can be used to drop a more detailed server

--- a/config/deploy/production.rb
+++ b/config/deploy/production.rb
@@ -15,35 +15,3 @@ set :branch, ENV.include?('BRANCH') ? ENV['BRANCH'] : 'master'
 # extended properties on the server.
 #server 'example.com', user: 'deploy', roles: %w{web app}, my_property: :my_value
 set :log_level, :error
-# you can set custom ssh options
-# it's possible to pass any option but you need to keep in mind that net/ssh understand limited list of options
-# you can see them in [net/ssh documentation](http://net-ssh.github.io/net-ssh/classes/Net/SSH.html#method-c-start)
-# set it globally
-#  set :ssh_options, {
-#    keys: %w(/home/rlisowski/.ssh/id_rsa),
-#    forward_agent: false,
-#    auth_methods: %w(password)
-#  }
-# and/or per server
-# server 'example.com',
-#   user: 'user_name',
-#   roles: %w{web app},
-#   ssh_options: {
-#     user: 'user_name', # overrides user setting above
-#     keys: %w(/home/user_name/.ssh/id_rsa),
-#     forward_agent: false,
-#     auth_methods: %w(publickey password)
-#     # password: 'please use keys'
-#   }
-# setting per server overrides global ssh_options
-set :ssh_options, {
-  user: 'deployer',
-  forward_agent: 'true',
-  keys: %w(config/deploy_id_rsa),
-  auth_methods: %w(publickey),
-  # use ssh proxy if UI servers are on a private network
-  proxy: Net::SSH::Proxy::Command.new('ssh deployer@sshproxy.ontoportal.org -W %h:%p')
-}
-
-#private git repo for configuraiton
-PRIVATE_CONFIG_REPO = ENV.include?('PRIVATE_CONFIG_REPO') ? ENV['PRIVATE_CONFIG_REPO'] : 'git@github.com:author/private_config_repo.git'

--- a/config/deploy/staging.rb
+++ b/config/deploy/staging.rb
@@ -6,7 +6,7 @@
 # Don't declare `role :all`, it's a meta role
 role :app, %w{stageportal.lirmm.fr}
 role :db, %w{stageportal.lirmm.fr} # sufficient to run db:migrate only on one system
-
+set :branch, ENV.include?('BRANCH') ? ENV['BRANCH'] : 'stage'
 # Extended Server Syntax
 # ======================
 # This can be used to drop a more detailed server

--- a/config/deploy/staging.rb
+++ b/config/deploy/staging.rb
@@ -15,35 +15,3 @@ set :branch, ENV.include?('BRANCH') ? ENV['BRANCH'] : 'stage'
 # extended properties on the server.
 #server 'example.com', user: 'deploy', roles: %w{web app}, my_property: :my_value
 set :log_level, :error
-# you can set custom ssh options
-# it's possible to pass any option but you need to keep in mind that net/ssh understand limited list of options
-# you can see them in [net/ssh documentation](http://net-ssh.github.io/net-ssh/classes/Net/SSH.html#method-c-start)
-# set it globally
-#  set :ssh_options, {
-#    keys: %w(/home/rlisowski/.ssh/id_rsa),
-#    forward_agent: false,
-#    auth_methods: %w(password)
-#  }
-# and/or per server
-# server 'example.com',
-#   user: 'user_name',
-#   roles: %w{web app},
-#   ssh_options: {
-#     user: 'user_name', # overrides user setting above
-#     keys: %w(/home/user_name/.ssh/id_rsa),
-#     forward_agent: false,
-#     auth_methods: %w(publickey password)
-#     # password: 'please use keys'
-#   }
-# setting per server overrides global ssh_options
-set :ssh_options, {
-  user: 'deploy',
-  forward_agent: 'true',
-  keys: %w(config/deploy_id_rsa),
-  auth_methods: %w(publickey),
-  # use ssh proxy if UI servers are on a private network
-  # proxy: Net::SSH::Proxy::Command.new('ssh deployer@sshproxy.ontoportal.org -W %h:%p')
-}
-
-#private git repo for configuraiton
-PRIVATE_CONFIG_REPO = ENV.include?('PRIVATE_CONFIG_REPO') ? ENV['PRIVATE_CONFIG_REPO'] : 'git@github.com:author/private_config_repo.git'

--- a/config/deploy/test.rb
+++ b/config/deploy/test.rb
@@ -1,0 +1,17 @@
+# Simple Role Syntax
+# ==================
+# Supports bulk-adding hosts to roles, the primary
+# server in each group is considered to be the first
+# unless any hosts have the primary property set.
+# Don't declare `role :all`, it's a meta role
+role :app, %w{testportal.lirmm.fr}
+role :db, %w{testportal.lirmm.fr} # sufficient to run db:migrate only on one system
+# Extended Server Syntax
+# ======================
+# This can be used to drop a more detailed server
+# definition into the server list. The second argument
+# something that quacks like a hash can be used to set
+# extended properties on the server.
+#server 'example.com', user: 'deploy', roles: %w{web app}, my_property: :my_value
+set :log_level, :error
+set :branch, ENV.include?('BRANCH') ? ENV['BRANCH'] : 'test'


### PR DESCRIPTION
### Context

This update the deploy action https://github.com/ncbo/bioportal_web_ui/pull/222), to work in our context. By making more configurable 

### Changes 

- Add test environment option (https://github.com/ontoportal-lirmm/bioportal_web_ui/commit/0ca14b77ed331dc77f3b394b9e31effe6f4bbcf0 and https://github.com/ontoportal-lirmm/bioportal_web_ui/commit/60b0a6873a64b59894da23094aa2934674eb4078)
- Use a variable for the `config folder path` to use in the `get_config` task (https://github.com/ontoportal-lirmm/bioportal_web_ui/commit/fdd665eab63201a13378fef9035751149e09618a)
- Set the deployment rails_env to "appliance" for all the environments (https://github.com/ontoportal-lirmm/bioportal_web_ui/commit/05f4b121e9ad611036fb53c7d05bf20e12bb5d9d)
- Make the jump box `host` and `username` configurable for the deployment](https://github.com/ontoportal-lirmm/bioportal_web_ui/commit/413ff18b8ffe3163e28632f7df0f28f8247aa975)
- Make `PRIVATE_CONFIG_REPO` default example use HTTPS with GitHub PAT token (https://github.com/ontoportal-lirmm/bioportal_web_ui/commit/8f906203a4ae7fee2ec5d437bd3ee385b25b8c15)