### PR TITLE
Fix: replace nav_bar  css nav-link to top-nav-nav-link to prevent conflicts

### DIFF
--- a/app/assets/stylesheets/nav_bar.scss
+++ b/app/assets/stylesheets/nav_bar.scss
@@ -118,7 +118,7 @@
     display: none;
 }
 
-.nav-link{
+.top-nav-nav-link{
     color: white !important;
     padding: 0 !important;
 }


### PR DESCRIPTION
Follow up of https://github.com/ontoportal-lirmm/bioportal_web_ui/pull/238, to fix a conflict with a global bootstrap class (`nav-link`)