### PR TITLE
Fix: bug alert text when there is no collection view of ontology

### DIFF
--- a/app/components/alert_message_component.rb
+++ b/app/components/alert_message_component.rb
@@ -2,7 +2,7 @@
 
 class AlertMessageComponent < ViewComponent::Base
   include Turbo::FramesHelper
-  def initialize(id: '', message: '', type: 'info', closeable: true)
+  def initialize(id: '', message: nil, type: 'info', closeable: true)
     @id = id
     @message = message
     @type = "alert-#{type}"

--- a/app/components/alert_message_component/alert_message_component.html.haml
+++ b/app/components/alert_message_component/alert_message_component.html.haml
@@ -1,5 +1,5 @@
-.alert.alert-dismissible.fade.show{:role => "alert", class: "#{@type}", style: "text-align: left"}
-  = @message
+.alert.alert-dismissible.fade.show{:role => "alert", class: "#{@type}", style: "text-align: left;white-space: normal;"}
+  = @message || content
   
   - if @closeable 
     %button.close{"aria-label": "Close", "data-dismiss": "alert", type: "button", style: "background: transparent"}


### PR DESCRIPTION
## Context
see : https://github.com/ontoportal-lirmm/bioportal_web_ui/issues/266

![image](https://github.com/ontoportal-lirmm/bioportal_web_ui/assets/31127782/983c4085-96eb-431e-9011-8be524106364)

## Changes : 
- fix bug of display text in alert 

![image](https://github.com/ontoportal-lirmm/bioportal_web_ui/assets/31127782/7e04addb-caa6-4548-93d7-0fafd811051b)

