### PR TITLE
Fix: bug of display list submitted ontologies of account setting

### DIFF
--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -135,7 +135,7 @@ class HomeController < ApplicationController
     @user_ontologies = @user.customOntology
     @user_ontologies ||= []
 
-    onts = LinkedData::Client::Models::Ontology.all
+    onts = LinkedData::Client::Models::Ontology.all(include_views: true);
     @admin_ontologies = onts.select { |o| o.administeredBy.include? @user.id }
 
     projects = LinkedData::Client::Models::Project.all

--- a/app/views/users/show.html.haml
+++ b/app/views/users/show.html.haml
@@ -113,6 +113,10 @@
               - @admin_ontologies.each do |ont|
                 .account-page-submitted-ontology{data: {controller: 'tooltip'}, title: ont.name}
                   %a{href: "/ontologies/#{ont.acronym}"}= ont.acronym
+                - unless ont.views.nil? || ont.views.empty?
+                  - ont.views.each do |view|
+                    .account-page-submitted-ontology{data: {controller: 'tooltip'}, title: ont.name}
+                      %a{href: "/ontologies/#{view.match(/\/([^\/]+)$/)[1]}"}= view.match(/\/([^\/]+)$/)[1]
         - unless @user_projects.nil? || @user_projects.empty?
           - no_ontologies = false
           .account-page-card


### PR DESCRIPTION
## Context :
see : https://github.com/ontoportal-lirmm/bioportal_web_ui/issues/270

## Changes : 
- Display list of ontologies by acronym ( Ontologies + views of ontologies) in the liste of Submitted ontologies

![image](https://github.com/ontoportal-lirmm/bioportal_web_ui/assets/31127782/b6393fa0-261c-4a33-9372-f7a6c008b273)

