### PR TITLE
Fix: Bug missing roots display

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -452,23 +452,21 @@ class ApplicationController < ActionController::Base
       if ignore_concept_param
         # get the top level nodes for the root
         # TODO_REV: Support views? Replace old view call: @ontology.top_level_classes(view)
-        roots = @ontology.explore.roots(concept_schemes: params[:concept_schemes])
-        if roots.nil? || roots.empty?
-          LOG.add :debug, "Missing roots for #{@ontology.acronym}"
-          not_found("Missing roots for #{@ontology.acronym}")
+        @roots = @ontology.explore.roots(concept_schemes: params[:concept_schemes])        
+        if @roots.nil? || @roots.empty?
+          LOG.add :debug, "Missing @roots for #{@ontology.acronym}"
+          @concept = @ontology.explore.classes.collection.first.explore.self(full: true)
+          return
         end
+        
         @root = LinkedData::Client::Models::Class.new(read_only: true)
-        @root.children = roots.sort{|x,y| (x.prefLabel || "").downcase <=> (y.prefLabel || "").downcase}
+        @root.children = @roots.sort{|x,y| (x.prefLabel || "").downcase <=> (y.prefLabel || "").downcase}
 
         # get the initial concept to display
         root_child = @root.children.first
 
         @concept = root_child.explore.self(full: true)
-        # Some ontologies have "too many children" at their root. These will not process and are handled here.
-        if @concept.nil?
-          LOG.add :debug, "Missing class #{root_child.links.self}"
-          not_found("Missing class #{root_child.links.self}")
-        end
+
       else
         # if the id is coming from a param, use that to get concept
         @concept = @ontology.explore.single_class({full: true}, params[:conceptid])
@@ -480,13 +478,14 @@ class ApplicationController < ActionController::Base
         # Create the tree
         rootNode = @concept.explore.tree(include: "prefLabel,hasChildren,obsolete", concept_schemes: params[:concept_schemes])
         if rootNode.nil? || rootNode.empty?
-          roots = @ontology.explore.roots(concept_schemes: params[:concept_schemes])
-          if roots.nil? || roots.empty?
-            LOG.add :debug, "Missing roots for #{@ontology.acronym}"
-            not_found("Missing roots for #{@ontology.acronym}")
+          @roots = @ontology.explore.roots(concept_schemes: params[:concept_schemes])
+          if @roots.nil? || @roots.empty?
+            LOG.add :debug, "Missing @roots for #{@ontology.acronym}"
+            @concept = @ontology.explore.classes.collection.first.explore.self(full: true)
+            return
           end
-          if roots.any? {|c| c.id == @concept.id}
-            rootNode = roots
+          if @roots.any? {|c| c.id == @concept.id}
+            rootNode = @roots
           else
             rootNode = [@concept]
           end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -466,7 +466,11 @@ class ApplicationController < ActionController::Base
         root_child = @root.children.first
 
         @concept = root_child.explore.self(full: true)
-
+        # Some ontologies have "too many children" at their root. These will not process and are handled here.
+        if @concept.nil?
+          LOG.add :debug, "Missing class #{root_child.links.self}"
+          not_found("Missing class #{root_child.links.self}")
+        end
       else
         # if the id is coming from a param, use that to get concept
         @concept = @ontology.explore.single_class({full: true}, params[:conceptid])

--- a/app/controllers/ontologies_controller.rb
+++ b/app/controllers/ontologies_controller.rb
@@ -174,8 +174,6 @@ display_context: false, include: browse_attributes)
       @notes = @concept.explore.notes
     end
 
-    update_tab(@ontology, @concept.id)
-
     if request.xhr?
       render 'ontologies/sections/visualize', layout: false
     else

--- a/app/views/ontologies/concepts_browsers/_concepts_tree.html.haml
+++ b/app/views/ontologies/concepts_browsers/_concepts_tree.html.haml
@@ -16,6 +16,11 @@
                         'chosen-enable-colors-value': 'true'}}
   -# Class tree
   %div#sd_content.card.p-1.py-3{style: 'overflow-y: scroll; height: 60vh;'}
-    = render TurboFrameComponent.new(id: 'concepts_tree_view',
+    - if skos? && @roots.empty?
+      %div.text-wrap
+        = render AlertMessageComponent.new do
+          Missing roots for #{@ontology.acronym}
+    - else
+      = render TurboFrameComponent.new(id: 'concepts_tree_view',
                                      src: "/ajax/classes/treeview?ontology=#{@ontology.acronym}&conceptid=#{escape(@concept.id)}&concept_schemes=#{params[:concept_schemes]}&auto_click=false",
-                                     data: {'turbo-frame-target': 'frame'})
+                                     data: {'turbo-frame-target': 'frame'})                          


### PR DESCRIPTION
### Context
Resolve https://github.com/ontoportal-lirmm/bioportal_web_ui/issues/298

### Changes
- show error message if alert component if there is no roots 
- the list tab selected if there are collections
- the dates tabs selected if there are no empty

![image](https://github.com/ontoportal-lirmm/bioportal_web_ui/assets/31127782/4e735922-4ded-40e9-aa46-17c6ca2adbfb)
