### PR TITLE
Fix: Nested form component empty state

### DIFF
--- a/app/components/nested_form_inputs_component.rb
+++ b/app/components/nested_form_inputs_component.rb
@@ -5,6 +5,7 @@ class NestedFormInputsComponent < ViewComponent::Base
   renders_one :template
   renders_one :header
   renders_many :rows
+  renders_one :empty_state
 
   def initialize(object_name: '')
     super

--- a/app/components/nested_form_inputs_component/nested_form_inputs_component.html.haml
+++ b/app/components/nested_form_inputs_component/nested_form_inputs_component.html.haml
@@ -8,6 +8,8 @@
           = inline_svg 'icons/delete.svg'
   %div.titles
     = header
+  %div.d-none
+    = empty_state
   - rows.each_with_index  do |row , index|
     %div.d-flex.align-items-center.nested-form-wrapper.my-1{'data-new-record': 'true'}
       %div{style: 'width: 90%'}

--- a/app/helpers/submissions_helper.rb
+++ b/app/helpers/submissions_helper.rb
@@ -49,10 +49,10 @@ module SubmissionsHelper
 
   def attribute_container(attr, required: false, &block)
     if show_attribute?(attr, required)
-      content_tag(:div) do
-        capture(&block)
-      end
+    content_tag(:div) do
+      capture(&block)
     end
+  end
   end
 
   def inline_save?
@@ -355,6 +355,11 @@ module SubmissionsHelper
       c.template do
         method(field_func).call("#{name}[NEW_RECORD]", '', :id => attr["attribute"].to_s + "_" + @ontology.acronym, class: "metadataInput form-control my-1")
       end
+
+      c.empty_state do
+        hidden_field_tag "#{name}[#{values.size}]"
+      end
+
       values.each_with_index do |metadata_val, i|
         c.row do
           method(field_func).call("#{name}[#{i}]", metadata_val, :id => "submission_#{attr["attribute"].to_s}" + "_" + @ontology.acronym, class: "metadataInput my-1 form-control")

--- a/app/views/submissions/_form_content.html.haml
+++ b/app/views/submissions/_form_content.html.haml
@@ -46,19 +46,16 @@
           = text_area c.name, c.method_name, rows: 5, value: @submission.description, required: true, class: "form-control"
 
         -# Home page
-        = attribute_text_field_container('homepage') do |c|
-          - c.help do
-            Enter a URL for the main page of your ontology.
+        = form_group_attribute('homepage') do
+          Enter a URL for the main page of your ontology.
 
         -# Documentation page
-        = attribute_text_field_container('documentation') do |c|
-          - c.help do
-            Enter a URL for a page that provides ontology documentation.
+        = form_group_attribute('documentation') do
+          Enter a URL for a page that provides ontology documentation.
 
         -# Publications page
-        = attribute_text_field_container('publication') do |c|
-          - c.help do
-            Enter a URL for a page that lists publications about your ontology.
+        = form_group_attribute('publication') do
+          Enter a URL for a page that lists publications about your ontology.
 
         -# Used ontology engineering tool
         = form_group_attribute("usedOntologyEngineeringTool")
@@ -106,7 +103,8 @@
             - c.template do
               = render partial: "submissions/submission_contact_form", locals: {contact: nil, index: 'NEW_RECORD'}
             - c.empty_state do
-              = hidden_field_tag object_name+"[contact][#{index.to_s.upcase}][email]"
+              = hidden_field_tag object_name+"[contact][#{@submission.contact.size}][email]"
+              = hidden_field_tag object_name+"[contact][#{@submission.contact.size}][name]"
             - @submission.contact.each_with_index do |contact, i|
               - c.row do
                 = render partial: "submissions/submission_contact_form", locals: {contact: contact, index: i}

--- a/app/views/submissions/_form_content.html.haml
+++ b/app/views/submissions/_form_content.html.haml
@@ -105,6 +105,8 @@
           = render NestedFormInputsComponent.new do |c|
             - c.template do
               = render partial: "submissions/submission_contact_form", locals: {contact: nil, index: 'NEW_RECORD'}
+            - c.empty_state do
+              = hidden_field_tag object_name+"[contact][#{index.to_s.upcase}][email]"
             - @submission.contact.each_with_index do |contact, i|
               - c.row do
                 = render partial: "submissions/submission_contact_form", locals: {contact: contact, index: i}


### PR DESCRIPTION
### Context
Before this PR, nested forms as the contacts or input lists couldn't be saved as empty in the curator.  Even if we remove all the rows.

It is solved by adding a hiding input as an empty array 

### Changes

- Add margin top and bottom for the nested form component (https://github.com/ontoportal-lirmm/bioportal_web_ui/commit/7f0702fde1b386cb4b9e84ccb81be73663e522d9)
- Update nested form component to have an empty state to send to the back (https://github.com/ontoportal-lirmm/bioportal_web_ui/commit/9ce277c6b54d15f56a5def035b46f4dab64fbc80)
- Handle contact nested form empty state (https://github.com/ontoportal-lirmm/bioportal_web_ui/commit/e41cdca13e5c388f3cbac8b5c05d475031657519)