### PR TITLE
fix: bug after search : the redirect for an empty search page and hidden popup

### DIFF
--- a/app/assets/javascripts/bp_search.js.erb
+++ b/app/assets/javascripts/bp_search.js.erb
@@ -985,7 +985,7 @@ function resultLinksSpan(res) {
     clsCode = encodeURIComponent(clsID);
     // construct link for class 'details' in facebox
     detailsAttr = {
-        "href": "/ajax/class_details?ontology=" + ontAcronym + "&conceptid=" + clsCode + "&styled=false",
+        "href": "/ajax/class_details?modal=false&ontology=" + ontAcronym + "&conceptid=" + clsCode + "&styled=false",
         "rel": "facebox[.class_details_pop]"
     };
     detailsAnchor = jQuery("<a>");

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -507,7 +507,7 @@ module ApplicationHelper
     if cls_id.start_with?('http://') || cls_id.start_with?('https://')
       link = bp_class_link(cls_id, ont_acronym)
       ajax_url = '/ajax/classes/label'
-      cls_url = "?p=classes&conceptid=#{CGI.escape(cls_id)}"
+      cls_url = "/ontologies/#{ont_acronym}?p=classes&conceptid=#{CGI.escape(cls_id)}"
       label_ajax_link(link, cls_id, ont_acronym, ajax_url , cls_url ,target)
     else
       auto_link(cls_id, :all, target: '_blank')
@@ -536,14 +536,19 @@ module ApplicationHelper
   end
 
 
-  def get_link_for_label_xl_ajax(label_xl, ont_acronym, cls_id)
+  def get_link_for_label_xl_ajax(label_xl, ont_acronym, cls_id, modal: true)
     link = label_xl
     ajax_uri = "/ajax/label_xl/label?cls_id=#{CGI.escape(cls_id)}"
     label_xl_url = "/ajax/label_xl/?id=#{CGI.escape(label_xl)}&ontology=#{ont_acronym}&cls_id=#{CGI.escape(cls_id)}"
     data = label_ajax_data_h(label_xl, ont_acronym, ajax_uri, label_xl_url)
     data[:data][:controller] = 'label-ajax'
+    if modal
+      link_to_modal(cls_id, link, {data: data[:data] , class: 'btn btn-sm btn-light'})
+    else
+      link_to(link,'', {data: data[:data], class: 'btn btn-sm btn-light', target: '_blank'})
+    end
+     
 
-    link_to_modal(cls_id, link, {data: data[:data] , class: 'btn btn-sm btn-light'})
   end
 
   ###END ruby equivalent of JS code in bp_ajax_controller.

--- a/app/views/concepts/_details.html.haml
+++ b/app/views/concepts/_details.html.haml
@@ -62,4 +62,4 @@
         - get_link_for_scheme_ajax(v, @ontology.acronym, '_blank')
     - c.section do
       = c.render_properties(label_xl_set, c.concept_properties) do |v|
-        - get_link_for_label_xl_ajax(v, @ontology.acronym, @concept.id)
+        - get_link_for_label_xl_ajax(v, @ontology.acronym, @concept.id, modal: params[:modal].nil? || params[:modal]&.eql?('true'))


### PR DESCRIPTION
### Context
See https://github.com/ontoportal-lirmm/bioportal_web_ui/issues/308

### Changes

-  Redirect to the right page after search .
 - Fix the problem of hidden popup.

![image](https://github.com/ontoportal-lirmm/bioportal_web_ui/assets/31127782/e63498e0-9959-4d78-8964-69eaedf97931)


![image](https://github.com/ontoportal-lirmm/bioportal_web_ui/assets/31127782/77d918fa-814a-46d1-879f-260d17b80568)

