### PR TITLE
Fix:  AGROVOC concept seed not displaying and a better handling of concept not in a scheme information

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/ontoportal-lirmm/ontologies_api_ruby_client.git
-  revision: f49cd49aee437c98221521f7763ecb8386855e17
+  revision: 775c59477cfc99d8cbf02ce199089f984476fca1
   branch: development
   specs:
     ontologies_api_client (2.2.0)
@@ -182,7 +182,7 @@ GEM
       actionpack (>= 6.0.0)
       railties (>= 6.0.0)
     io-console (0.6.0)
-    irb (1.8.1)
+    irb (1.8.3)
       rdoc
       reline (>= 0.3.8)
     jquery-rails (4.6.0)
@@ -239,6 +239,8 @@ GEM
     netrc (0.11.0)
     newrelic_rpm (9.5.0)
     nio4r (2.5.9)
+    nokogiri (1.15.4-x86_64-darwin)
+      racc (~> 1.4)
     nokogiri (1.15.4-x86_64-linux)
       racc (~> 1.4)
     oj (3.16.1)
@@ -329,7 +331,7 @@ GEM
       rspec-mocks (~> 3.12)
       rspec-support (~> 3.12)
     rspec-support (3.12.1)
-    rubocop (1.57.0)
+    rubocop (1.57.1)
       base64 (~> 0.1.1)
       json (~> 2.3)
       language_server-protocol (>= 3.17.0)
@@ -427,6 +429,7 @@ GEM
     zeitwerk (2.6.12)
 
 PLATFORMS
+  x86_64-darwin-21
   x86_64-linux
 
 DEPENDENCIES
@@ -493,4 +496,4 @@ DEPENDENCIES
   will_paginate (~> 3.0)
 
 BUNDLED WITH
-   2.3.23
+   2.4.12

--- a/app/controllers/concepts_controller.rb
+++ b/app/controllers/concepts_controller.rb
@@ -44,7 +44,7 @@ class ConceptsController < ApplicationController
       display = params[:callback].eql?('load') ? {full: true} : {display: "prefLabel"}
       @concept = @ontology.explore.single_class(display, params[:id])
       concept_not_found(params[:id]) if @concept.nil?
-      @schemes = params[:concept_schemes].split(',')
+      @schemes = params[:concept_schemes]&.split(',')
       show_ajax_request # process an ajax call
     else
       # Get the latest 'ready' submission, or fallback to any latest submission
@@ -189,7 +189,7 @@ private
       gather_details
       render :partial => 'load'
     when 'children' # Children is called only for drawing the tree
-      @children = @concept.explore.children(pagesize: 750, concept_schemes: @schemes.join(',')).collection || []
+      @children = @concept.explore.children(pagesize: 750, concept_schemes: params[:concept_schemes]).collection || []
       @children.sort! { |x, y| (x.prefLabel || "").downcase <=> (y.prefLabel || "").downcase } unless @children.empty?
       render :partial => 'child_nodes'
     end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -179,11 +179,12 @@ module ApplicationHelper
     string
   end
 
-  def tree_link_to_concept(child:, ontology_acronym:, active_style:, node: nil)
+  def tree_link_to_concept(child:, ontology_acronym:, active_style:, node: nil, skos: false)
     li_id = child.id.eql?('bp_fake_root') ? 'bp_fake_root' : short_uuid
     open = child.expanded? ? "class='open'" : ''
     icons = child.relation_icon(node)
-    muted_style = child.isInActiveScheme&.empty? ? 'text-muted' : ''
+    muted_style = skos && Array(child.isInActiveScheme).empty? ? 'text-muted' : nil
+    muted_title = muted_style  && !child.obsolete? ? "title='is not in a scheme'" : nil
     href = ontology_acronym.blank? ? '#' : "/ontologies/#{child.explore.ontology.acronym}/concepts/?id=#{CGI.escape(child.id)}"
     link = <<-EOS
         <a id='#{child.id}' data-conceptid='#{child.id}'
@@ -191,7 +192,7 @@ module ApplicationHelper
            data-collections-value='#{child.memberOf || []}'
            data-active-collections-value='#{child.isInActiveCollection || []}'
            data-skos-collection-colors-target='collection'
-            class='#{muted_style} #{active_style}'>
+            class='#{muted_style} #{active_style}' #{muted_title}>
             #{child.prefLabel ? child.prefLabel({ use_html: true }) : child.id}
         </a>
     EOS

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -143,14 +143,14 @@ module ApplicationHelper
     end
   end
 
-  def draw_tree(root, id = nil, concept_schemes = [])
+  def draw_tree(root, acronym, id = nil, concept_schemes = nil)
     id = root.children.first.id if id.nil?
 
     # TODO: handle tree view for obsolete classes, e.g. 'http://purl.obolibrary.org/obo/GO_0030400'
-    raw build_tree(root, '', id, concept_schemes: concept_schemes)
+    raw build_tree(root, '', id, acronym, concept_schemes: concept_schemes)
   end
 
-  def build_tree(node, string, id, concept_schemes: [])
+  def build_tree(node, string, id, acronym, concept_schemes: nil)
 
     return string if node.children.nil? || node.children.empty?
 
@@ -161,16 +161,16 @@ module ApplicationHelper
       # This fake root will be present at the root of "flat" ontologies, we need to keep the id intact
 
       if child.id.eql?('bp_fake_root')
-        string << tree_link_to_concept(child: child, ontology_acronym: '',
-                                       active_style: active_style, node: node)
+        string << tree_link_to_concept(child: child, ontology_acronym: acronym,
+                                       active_style: active_style, node: node, skos: !concept_schemes.nil?)
       else
-        string << tree_link_to_concept(child: child, ontology_acronym: child.explore.ontology.acronym,
-                                       active_style: active_style, node: node)
+        string << tree_link_to_concept(child: child, ontology_acronym: acronym,
+                                       active_style: active_style, node: node, skos: !concept_schemes.nil?)
         if child.hasChildren && !child.expanded?
-          string << tree_link_to_children(child: child, concept_schemes: concept_schemes)
+          string << tree_link_to_children(child: child, acronym: acronym, concept_schemes: concept_schemes)
         elsif child.expanded?
           string << '<ul>'
-          build_tree(child, string, id, concept_schemes: concept_schemes)
+          build_tree(child, string, id, acronym, concept_schemes: concept_schemes)
           string << '</ul>'
         end
         string << '</li>'
@@ -200,10 +200,11 @@ module ApplicationHelper
     "<li #{open} id='#{li_id}'>#{link} #{icons}"
   end
 
-  def tree_link_to_children(child:, concept_schemes: [])
+  def tree_link_to_children(child:, acronym: ,concept_schemes: nil)
     li_id = child.id.eql?('bp_fake_root') ? 'bp_fake_root' : short_uuid
-    concept_schemes = concept_schemes.map{|x| CGI.escape(x)}.join(',')
-    link = "<a id='#{child.id}' href='/ajax_concepts/#{child.explore.ontology.acronym}/?conceptid=#{CGI.escape(child.id)}&concept_schemes=#{concept_schemes}&callback=children'>ajax_class</a>"
+    concept_schemes = "&concept_schemes=#{concept_schemes.map{|x| CGI.escape(x)}.join(',')}" if concept_schemes
+
+    link = "<a id='#{child.id}' href='/ajax_concepts/#{acronym}/?conceptid=#{CGI.escape(child.id)}#{concept_schemes}&callback=children'>ajax_class</a>"
     "<ul class='ajax'><li id='#{li_id}'>#{link}</li></ul>"
   end
 
@@ -398,7 +399,7 @@ module ApplicationHelper
  
   def subscribe_button(ontology_id)
     if session[:user].nil?
-      return link_to 'Subscribe to notes emails', "/login?redirect=#{request.url}", {style:'font-size: .9em;', class:'link_button'}
+      return link_to 'Subscribe to notes emails', "/login?redirect=#{request.url}", {style:'font-size: .9em;', class: 'link_button'}
     end
 
     user = LinkedData::Client::Models::User.find(session[:user].id)

--- a/app/views/concepts/_child_nodes.html.haml
+++ b/app/views/concepts/_child_nodes.html.haml
@@ -1,7 +1,7 @@
 - output =""
 - for child in @children
-  - output << tree_link_to_concept(child: child, ontology_acronym: child.explore.ontology.acronym, active_style: '', node: @concept)
+  - output << tree_link_to_concept(child: child, ontology_acronym: @ontology.acronym, active_style: '', node: @concept, skos: !@schemes.nil?)
   - if child.hasChildren
-    - output << tree_link_to_children(child: child, concept_schemes: @schemes)
+    - output << tree_link_to_children(child: child, acronym: @ontology.acronym, concept_schemes: @schemes)
   - output << "</li>"
 = raw output

--- a/app/views/ontologies/_treeview.html.haml
+++ b/app/views/ontologies/_treeview.html.haml
@@ -5,6 +5,6 @@
                         action: 'clicked->history#updateURL'}}
       %li.root
         %ul
-          = draw_tree(@root, @concept.id, (params[:concept_schemes] || '').split(','))
+          = draw_tree(@root, params[:ontology], @concept.id, params[:concept_schemes]&.split(','))
 
 

--- a/app/views/ontologies/concepts_browsers/_concepts_tree.html.haml
+++ b/app/views/ontologies/concepts_browsers/_concepts_tree.html.haml
@@ -21,6 +21,7 @@
         = render AlertMessageComponent.new do
           Missing roots for #{@ontology.acronym} (skos:topConceptOf)
     - else
+      - concept_schemes = skos? ? "&concept_schemes=#{params[:concept_schemes]}" : ''
       = render TurboFrameComponent.new(id: 'concepts_tree_view',
-                                     src: "/ajax/classes/treeview?ontology=#{@ontology.acronym}&conceptid=#{escape(@concept.id)}&concept_schemes=#{params[:concept_schemes]}&auto_click=false",
+                                     src: "/ajax/classes/treeview?ontology=#{@ontology.acronym}&conceptid=#{escape(@concept.id)}#{concept_schemes}&auto_click=false",
                                      data: {'turbo-frame-target': 'frame'})                          

--- a/app/views/ontologies/concepts_browsers/_concepts_tree.html.haml
+++ b/app/views/ontologies/concepts_browsers/_concepts_tree.html.haml
@@ -16,7 +16,7 @@
                         'chosen-enable-colors-value': 'true'}}
   -# Class tree
   %div#sd_content.card.p-1.py-3{style: 'overflow-y: scroll; height: 60vh;'}
-    - if skos? && @roots.empty?
+    - if skos? && @roots&.empty?
       %div.text-wrap
         = render AlertMessageComponent.new do
           Missing roots for #{@ontology.acronym} (skos:topConceptOf)

--- a/vendor/assets/javascripts/jquery.simple.tree.js.erb
+++ b/vendor/assets/javascripts/jquery.simple.tree.js.erb
@@ -156,11 +156,8 @@ $.fn.simpleTree = function(opt){
 			.bind('selectstart', function() {
 				return false;
 			}).click(function(){
-				$('.active',TREE).attr('class','text');
-				if(this.className=='text')
-				{
-					this.className='active';
-				}
+				$('.active',TREE).removeClass('active');
+				this.classList.add('active');
 				if(typeof TREE.option.afterClick == 'function')
 				{
 					TREE.option.afterClick($(this).parent());
@@ -177,11 +174,8 @@ $.fn.simpleTree = function(opt){
 				// added by Erik Dohmen (2BinBusiness.nl) to make context menu actions
 				// available
 			}).bind("contextmenu",function(){
-				$('.active',TREE).attr('class','text');
-				if(this.className=='text')
-				{
-					this.className='active';
-				}
+				$('.active',TREE).removeClass('active');
+				this.classList.add('active');
 				if(typeof TREE.option.afterContextMenu == 'function')
 				{
 					TREE.option.afterContextMenu($(this).parent());


### PR DESCRIPTION
## Context

Resolve  https://github.com/agroportal/project-management/issues/440 and a follow-up of https://github.com/ontoportal-lirmm/bioportal_web_ui/issues/352

In brief,  this PR fixes a small bug in displaying the AGROVOC concept "seed" due to an unchecking variable (that normally should never be null), the concept tree view now shows a message if a concept is not in the scheme. Finally, the tree view should be a little bit faster, removing a useless API call occurring on each displayed child to fetch its ontology information.

## Changes

-  Fix the bug of concept "seed" in AGROVOC, by safe checking the the `@roots` variable 
![image](https://github.com/ontoportal-lirmm/bioportal_web_ui/assets/31127782/3d32bf1b-66d4-400a-978a-0f35ab651802)
- fix JQuery simple tree script removing css class of elements on click (https://github.com/ontoportal-lirmm/bioportal_web_ui/pull/355/commits/68ea68165c6e7134f840ec725aa42a0da4e5cd51)
- add concept tree links muted title text if skos and not in a scheme (https://github.com/ontoportal-lirmm/bioportal_web_ui/pull/355/commits/fe72f9840d8a20f9bb83d5a3bf4f54147197091b)
<img width="554" alt="image" src="https://github.com/ontoportal-lirmm/bioportal_web_ui/assets/29259906/2a0f1ac4-c0a2-4cac-88ca-5df8402b4c23">

- make the concept_scheme request parameter nil if the resource is not SKOS (https://github.com/ontoportal-lirmm/bioportal_web_ui/pull/355/commits/b2339d2b1fd735ae661bcce3fc04fa6ba77faad9)

- Optimize the build tree function by passing to its childs the acronym instead of requesting ontology.aconym for each child (https://github.com/ontoportal-lirmm/bioportal_web_ui/pull/355/commits/6e86129a93c61ee89b3099be3680845b837fcb11)
