### PR TITLE
Fix: feedback action when ontology_submissions_request is checked

### DIFF
--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -103,7 +103,7 @@ class HomeController < ApplicationController
     unless params[:question].nil? || params[:question].empty?
       @tags << "Question"
     end
-    unless params[:ontology_submissions_request].nil? || params[:bug].empty?
+    unless params[:ontology_submissions_request].nil? || params[:ontology_submissions_request].empty?
       @tags << "Ontology submissions request"
     end
 


### PR DESCRIPTION
In Agroportal it seems when sending feedback and we the user checked the `Ontology submissions request` tags 
<img width="745" alt="image" src="https://github.com/ontoportal-lirmm/bioportal_web_ui/assets/29259906/3707ee47-b359-4c19-84b7-582cc6b3093a">

This PR fix that 