### PR TITLE
Feature: add IT and DE  internationalization for the homepage

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -115,7 +115,8 @@ group :development do
 
   # Use console on exceptions pages [https://github.com/rails/web-console]
   gem 'web-console'
-
+  gem 'i18n-tasks'
+  gem 'deepl-rb'
 end
 
 group :test, :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -85,13 +85,20 @@ GEM
     addressable (2.8.5)
       public_suffix (>= 2.0.2, < 6.0)
     aes_key_wrap (1.1.0)
-    airbrussh (1.4.2)
+    airbrussh (1.5.0)
       sshkit (>= 1.6.1, != 1.7.0)
     ast (2.4.2)
     autoprefixer-rails (10.4.15.0)
       execjs (~> 2)
     base64 (0.1.1)
     bcrypt_pbkdf (1.1.0)
+    better_html (2.0.2)
+      actionview (>= 6.0)
+      activesupport (>= 6.0)
+      ast (~> 2.0)
+      erubi (~> 1.4)
+      parser (>= 2.4)
+      smart_properties
     bindata (2.4.15)
     bindex (0.8.1)
     bootsnap (1.16.0)
@@ -141,6 +148,7 @@ GEM
     debug (1.8.0)
       irb (>= 1.5.0)
       reline (>= 0.3.1)
+    deepl-rb (2.5.3)
     diff-lcs (1.5.0)
     domain_name (0.5.20190701)
       unf (>= 0.0.5, < 1.0.0)
@@ -148,8 +156,8 @@ GEM
     erubi (1.12.0)
     erubis (2.7.0)
     eventmachine (1.2.7)
-    excon (0.102.0)
-    execjs (2.8.1)
+    excon (0.103.0)
+    execjs (2.9.1)
     faraday (2.0.1)
       faraday-net_http (~> 2.0)
       ruby2_keywords (>= 0.0.4)
@@ -161,7 +169,7 @@ GEM
     faraday-multipart (1.0.4)
       multipart-post (~> 2)
     faraday-net_http (2.1.0)
-    ffi (1.15.5)
+    ffi (1.16.1)
     flag-icons-rails (3.4.6.1)
       sass-rails
     flamegraph (0.9.5)
@@ -175,6 +183,7 @@ GEM
       temple (>= 0.8.0)
       tilt
     hashie (5.0.0)
+    highline (2.1.0)
     html2haml (2.3.0)
       erubis (~> 2.7.0)
       haml (>= 4.0)
@@ -187,6 +196,17 @@ GEM
       domain_name (~> 0.5)
     i18n (1.14.1)
       concurrent-ruby (~> 1.0)
+    i18n-tasks (1.0.12)
+      activesupport (>= 4.0.2)
+      ast (>= 2.1.0)
+      better_html (>= 1.0, < 3.0)
+      erubi
+      highline (>= 2.0.0)
+      i18n
+      parser (>= 2.2.3.0)
+      rails-i18n
+      rainbow (>= 2.2.2, < 4.0)
+      terminal-table (>= 1.5.1)
     iconv (1.0.8)
     importmap-rails (1.2.1)
       actionpack (>= 6.0.0)
@@ -205,7 +225,7 @@ GEM
       thor (>= 0.14, < 2.0)
     jquery-ui-rails (6.0.1)
       railties (>= 3.2.16)
-    jsbundling-rails (1.1.2)
+    jsbundling-rails (1.2.1)
       railties (>= 6.0.0)
     json (2.6.3)
     json-jwt (1.16.3)
@@ -248,7 +268,7 @@ GEM
       mime-types-data (~> 3.2015)
     mime-types-data (3.2023.0808)
     mini_mime (1.1.5)
-    minitest (5.19.0)
+    minitest (5.20.0)
     msgpack (1.7.2)
     multi_json (1.15.0)
     multi_xml (0.6.0)
@@ -268,11 +288,11 @@ GEM
       timeout
     net-scp (4.0.0)
       net-ssh (>= 2.6.5, < 8.0.0)
-    net-smtp (0.3.3)
+    net-smtp (0.4.0)
       net-protocol
     net-ssh (7.2.0)
     netrc (0.11.0)
-    newrelic_rpm (9.4.2)
+    newrelic_rpm (9.5.0)
     nio4r (2.5.9)
     nokogiri (1.15.4-x86_64-darwin)
       racc (~> 1.4)
@@ -405,7 +425,7 @@ GEM
       rspec-mocks (~> 3.12)
       rspec-support (~> 3.12)
     rspec-support (3.12.1)
-    rubocop (1.56.2)
+    rubocop (1.56.3)
       base64 (~> 0.1.1)
       json (~> 2.3)
       language_server-protocol (>= 3.17.0)
@@ -441,6 +461,7 @@ GEM
       rubyzip (>= 1.2.2, < 3.0)
       websocket (~> 1.0)
     sexp_processor (4.17.0)
+    smart_properties (1.17.0)
     snaky_hash (2.0.1)
       hashie
       version_gem (~> 1.1, >= 1.1.1)
@@ -459,6 +480,8 @@ GEM
     stimulus-rails (1.2.2)
       railties (>= 6.0.0)
     temple (0.10.2)
+    terminal-table (3.0.2)
+      unicode-display_width (>= 1.1.1, < 3)
     terser (1.1.18)
       execjs (>= 0.3.0, < 3)
     thin (1.8.2)
@@ -466,7 +489,7 @@ GEM
       eventmachine (~> 1.0, >= 1.0.4)
       rack (>= 1, < 3)
     thor (1.2.2)
-    tilt (2.2.0)
+    tilt (2.3.0)
     time (0.2.2)
       date
     timeout (0.4.0)
@@ -500,7 +523,7 @@ GEM
       nokogiri (~> 1.6)
       rubyzip (>= 1.3.0)
       selenium-webdriver (~> 4.0, < 4.11)
-    websocket (1.2.9)
+    websocket (1.2.10)
     websocket-driver (0.7.6)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
@@ -513,6 +536,7 @@ GEM
 PLATFORMS
   x86_64-darwin-21
   x86_64-linux
+  x86_64-linux-musl
 
 DEPENDENCIES
   bcrypt_pbkdf (>= 1.0, < 2.0)
@@ -530,6 +554,7 @@ DEPENDENCIES
   cube-ruby
   dalli
   debug
+  deepl-rb
   ed25519 (>= 1.2, < 2.0)
   flag-icons-rails (~> 3.4)
   flamegraph
@@ -537,6 +562,7 @@ DEPENDENCIES
   haml (~> 5.1)
   html2haml
   i18n
+  i18n-tasks
   iconv
   importmap-rails
   inline_svg

--- a/app/components/ontology_search_input_component.rb
+++ b/app/components/ontology_search_input_component.rb
@@ -2,7 +2,7 @@
 
 class OntologySearchInputComponent < ViewComponent::Base
 
-  def initialize(name: 'search', placeholder: 'Search for an ontology or concept (Ex: Agrovoc ...)', scroll_down: true)
+  def initialize(name: 'search', placeholder: t('ontologies.ontology_search_prompt'), scroll_down: true)
     @name = name
     @placeholder = placeholder
     @scroll_down = scroll_down

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -20,6 +20,7 @@ class ApplicationController < ActionController::Base
   def set_locale    
     I18n.locale = cookies[:locale] || detect_locale
     cookies.permanent[:locale] = I18n.locale if cookies[:locale].nil?
+    logger.debug "* Locale set to '#{I18n.locale}'"
   end
 
   # Returns detedted locale based on the Accept-Language header of the request or the default locale if none is found.

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -23,11 +23,11 @@ class HomeController < ApplicationController
     @users_count = LinkedData::Client::Models::User.all.length
 
     @upload_benefits = [
-      'Discover new insights and connections by exploring other ontologies in the repository.',
-      'Contribute to the growth and development of your domain by adding new concepts and categories.',
-      'Use version control to manage the changes to your ontology over time and collaborate with other users.',
-      'Get feedback and suggestions from other users who can review and comment on your ontology.',
-      'Get the FAIR score and metrics for your ontology.'
+      t('home.benefit1'),
+      t('home.benefit2'),
+      t('home.benefit3'), 
+      t('home.benefit4'),
+      t('home.benefit5')
     ]
 
     @anal_ont_names = []

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -688,9 +688,19 @@ module ApplicationHelper
     $SITE
     end
   def navitems
-    items = [["/ontologies", "Browse"],["/mappings", "Mappings"],["/recommender", "Recommender"],["/annotator", "Annotator"], ["/landscape", "Landscape"]]
+    items = [["/ontologies", t('layout.header.browse')],
+             ["/mappings", t('layout.header.mappings')],
+             ["/recommender", t("layout.header.recommender")],
+             ["/annotator", t("layout.header.annotator")],
+             ["/landscape", t("layout.header.landscape")]]
   end
 
+  def portal_language_selector(id: 'language-select')
+    languages = %w[en fr it de].map{|x| [x.upcase, x]}
+    select_tag('language',options_for_select(languages), id: id, class: 'nav-language',
+               data: { controller: "platform-language", action: "change->platform-language#handleLangChanged" })
+
+  end
   def attribute_enforced_values(attr)
     submission_metadata.select {|x| x['@id'][attr]}.first['enforcedValues']
   end

--- a/app/views/annotator/index.html.haml
+++ b/app/views/annotator/index.html.haml
@@ -2,175 +2,175 @@
 
 %head
   = javascript_include_tag "bp_annotator"
+%div.container
+  %div.container-fluid.flex-grow-1
+    %div.row
+      %div.col
+        %h2.mt-3= t('annotator.title')
+        %p
+          = t('annotator.index.intro', site: $SITE).html_safe
+          = link_to(help_path(anchor: "Annotator_Tab"), id: "annotator-help", target: "_blank") do
+            %i.fa.fa-question-circle.fa-lg{"aria-hidden": "true"}
 
-%div.container-fluid.flex-grow-1
-  %div.row
-    %div.col
-      %h2.mt-3= t('annotator.title')
-      %p
-        = t('annotator.index.intro', site: $SITE).html_safe
-        = link_to(help_path(anchor: "Annotator_Tab"), id: "annotator-help", target: "_blank") do
-          %i.fa.fa-question-circle.fa-lg{"aria-hidden": "true"}
-
-  %div.row
-    %div.col
-      %form
-        %div.form-group
-          = hidden_field_tag :annotation_sample_text, t('annotator.index.sample_text')
-          = text_area_tag("annotation_text", @text, rows: 10, class: "form-control", placeholder: "Enter or paste text to be annotated", "aria-describedby": "annotateTextHelpBlock")
-          %small#annotateTextHelpBlock.form-text
-            %a#insert_text_link{href: "javascript:void(0);"}= t('shared.insert_sample_text')
-
-        %a#advancedOptionsLink{:href => "javascript:void(0);"}= t('shared.show_advanced_options') + ">>"
-
-        %div#advanced-options-container.mt-4
+    %div.row
+      %div.col
+        %form
           %div.form-group
-            %div.custom-control.custom-checkbox.custom-control-inline
-              = check_box_tag("longest_only", "all", false, class: "custom-control-input")
-              %label.custom-control-label{for: "longest_only"}= t('annotator.filters.match_longest_only')
+            = hidden_field_tag :annotation_sample_text, t('annotator.index.sample_text')
+            = text_area_tag("annotation_text", @text, rows: 10, class: "form-control", placeholder: t('annotator.annotate_text_prompt'), "aria-describedby": "annotateTextHelpBlock")
+            %small#annotateTextHelpBlock.form-text
+              %a#insert_text_link{href: "javascript:void(0);"}= t('nbco_annotatosplus.insert_sample_text')
 
-            %div.custom-control.custom-checkbox.custom-control-inline
-              = check_box_tag("whole_word_only", "all", false, class: "custom-control-input")
-              %label.custom-control-label{for: "whole_word_only"}= t('annotator.filters.match_partial_words')
+          %a#advancedOptionsLink{:href => "javascript:void(0);"}= t('nbco_annotatosplus.show_advanced_options') + ">>"
 
-            %div.custom-control.custom-checkbox.custom-control-inline
-              = check_box_tag("mappings", "all", false, id: "mappings_all", class: "custom-control-input")
-              %label.custom-control-label{for: "mappings_all"}= t('annotator.filters.include_mappings')
-
-            %div.custom-control.custom-checkbox.custom-control-inline
-              = check_box_tag("exclude_numbers", "all", false, class: "custom-control-input")
-              %label.custom-control-label{for: "exclude_numbers"}= t('annotator.filters.exclude_numbers')
-
-            %div.custom-control.custom-checkbox.custom-control-inline
-              = check_box_tag("exclude_synonyms", "all", false, class: "custom-control-input")
-              %label.custom-control-label{for: "exclude_synonyms"}= t('annotator.filters.exclude_synonyms')
-
-          %div.form-group
-            %label{for: "ontology_ontologyId"}= t('annotator.select', name: t('ontology'))
-            = select_tag("ontology_ontologyId", options_from_collection_for_select(@annotator_ontologies, :acronym, lambda { |ont| "#{ont.name} (#{ont.acronym})" }), |
-                multiple: true, class: "form-control", "aria-describedby": "selectOntologiesHelpBlock") |
-            %small#selectOntologiesHelpBlock.form-text.text-muted= t('annotator.start_typing_to_select', type: t('ontology'))
-
-          - if @sem_type_ont
+          %div#advanced-options-container.mt-4
             %div.form-group
-              %label{for: "semantic_types"}= t('annotator.select', name: t('annotator.umls.semantic_types'))
-              = select_tag("semantic_types", options_for_select(@semantic_types_for_select), multiple: "true", class: "form-control", "aria-describedby": "selectSemanticTypesHelpBlock")
-              %small#selectSemanticTypesHelpBlock.form-text.text-muted= t('annotator.start_typing_to_select', type: t('annotator.umls.semantic_types'))
+              %div.custom-control.custom-checkbox.custom-control-inline
+                = check_box_tag("longest_only", "all", false, class: "custom-control-input")
+                %label.custom-control-label{for: "longest_only"}= t('annotator.filters.match_longest_only')
+
+              %div.custom-control.custom-checkbox.custom-control-inline
+                = check_box_tag("whole_word_only", "all", false, class: "custom-control-input")
+                %label.custom-control-label{for: "whole_word_only"}= t('annotator.filters.match_partial_words')
+
+              %div.custom-control.custom-checkbox.custom-control-inline
+                = check_box_tag("mappings", "all", false, id: "mappings_all", class: "custom-control-input")
+                %label.custom-control-label{for: "mappings_all"}= t('annotator.filters.include_mappings')
+
+              %div.custom-control.custom-checkbox.custom-control-inline
+                = check_box_tag("exclude_numbers", "all", false, class: "custom-control-input")
+                %label.custom-control-label{for: "exclude_numbers"}= t('annotator.filters.exclude_numbers')
+
+              %div.custom-control.custom-checkbox.custom-control-inline
+                = check_box_tag("exclude_synonyms", "all", false, class: "custom-control-input")
+                %label.custom-control-label{for: "exclude_synonyms"}= t('annotator.filters.exclude_synonyms')
 
             %div.form-group
-              %label{for: "semantic_groups"}= t('annotator.select', name: t('annotator.umls.semantic_groups'))
-              = select_tag("semantic_groups", options_for_select(@semantic_groups_for_select), multiple: "true", class: "form-control", "aria-describedby": "selectSemanticGroupsHelpBlock")
-              %small#selectSemanticGroupsHelpBlock.form-text.text-muted= t('annotator.start_typing_to_select', type: t('annotator.umls.semantic_groups'))
+              %label{for: "ontology_ontologyId"}= t('annotator.select', name: t('ontology'))
+              = select_tag("ontology_ontologyId", options_from_collection_for_select(@annotator_ontologies, :acronym, lambda { |ont| "#{ont.name} (#{ont.acronym})" }), |
+                  multiple: true, class: "form-control", "aria-describedby": "selectOntologiesHelpBlock") |
+              %small#selectOntologiesHelpBlock.form-text.text-muted= t('annotator.start_typing_to_select', type: t('ontology'))
 
-          %div.form-group
-            %label{for: "class_hierarchy_max_level"}= t('annotator.filters.max_hierarchy_level')
-            - options = [["none", 0], *(1..10).map {|i| [i, i]}, ["all", 999]]
-            = select_tag("class_hierarchy_max_level", options_for_select(options, 0), class: "form-control")
+            - if @sem_type_ont
+              %div.form-group
+                %label{for: "semantic_types"}= t('annotator.select', name: t('annotator.umls.semantic_types'))
+                = select_tag("semantic_types", options_for_select(@semantic_types_for_select), multiple: "true", class: "form-control", "aria-describedby": "selectSemanticTypesHelpBlock")
+                %small#selectSemanticTypesHelpBlock.form-text.text-muted= t('annotator.start_typing_to_select', type: t('annotator.umls.semantic_types'))
 
-          %div.form-group
-            %label{for: "score"}= t('annotator.filters.score')
-            - options = [["none", ""], ["old", "old"], ["cvalue", "cvalue"], ["cvalueh", "cvalueh"]]
-            = select_tag(:score, options_for_select(options, 0), class: "form-control", "aria-describedby": "includeScoreHelpBlock")
-            %small#includeScoreHelpBlock.form-text.text-muted= t('annotator.filters.score_help')
+              %div.form-group
+                %label{for: "semantic_groups"}= t('annotator.select', name: t('annotator.umls.semantic_groups'))
+                = select_tag("semantic_groups", options_for_select(@semantic_groups_for_select), multiple: "true", class: "form-control", "aria-describedby": "selectSemanticGroupsHelpBlock")
+                %small#selectSemanticGroupsHelpBlock.form-text.text-muted= t('annotator.start_typing_to_select', type: t('annotator.umls.semantic_groups'))
 
-          %div.form-group
-            %label{for: "score_threshold"}= t('annotator.filters.score_threshold')
-            = number_field_tag(:score_threshold, 0, id: "score_threshold", class: "form-control", "aria-describedby": "scoreThresholdHelpBlock")
-            %small#scoreThresholdHelpBlock.form-text.text-muted= t('annotator.filters.score_threshold_help')
-
-          %div.form-group
-            %label{for: "confidence_threshold"}= t('annotator.filters.confidence_threshold')
-            = number_field_tag(:confidence_threshold, 0, min: 0, max: 100, id: "confidence_threshold", class: "form-control", "aria-describedby": "confidenceThresholdHelpBlock")
-            %small#confidenceThresholdHelpBlock.form-text.text-muted= t('annotator.filters.confidence_threshold_help')
-
-          - if @recognizers.length > 1
             %div.form-group
-              %label{for: "recognizer"}= t('annotator.filters.recognizer')
-              - default_recognizer = @recognizers.include?("mgrep") ? "mgrep" : @recognizers.first
-              = select_tag("recognizer", options_for_select(@recognizers.map {|r| [r, r]}, default_recognizer), class: "form-control")
+              %label{for: "class_hierarchy_max_level"}= t('annotator.filters.max_hierarchy_level')
+              - options = [["none", 0], *(1..10).map {|i| [i, i]}, ["all", 999]]
+              = select_tag("class_hierarchy_max_level", options_for_select(options, 0), class: "form-control")
 
-          %div.form-group
-            %div.custom-control.custom-checkbox
-              = check_box_tag("fast_context", :all, false, class: "custom-control-input")
-              %label.custom-control-label{for: "fast_context"}= t('annotator.fast_context')
-              %small#fast_contextnHelp.form-text.text-muted= t('annotator.index.fast_context.tooltip')
-          %div.form-group
-            %div.custom-control.custom-checkbox
-              = check_box_tag("lemmatize", false, false, class: "custom-control-input")
-              %label.custom-control-label{for: "lemmatize"}= t('annotator.lemmatize')
-              %small#lemmatize.form-text.text-muted= t('annotator.index.lemmatize.tooltip')
-        %div.my-4
-          = button_tag(t('annotator.get_annotator'), type: "button", id: "annotator_button", class: "btn btn-primary btn-lg")
-          %span.annotator_spinner
-            %img{src: asset_path('spinners/spinner_000000_16px.gif')}/
-          %span#annotator_error.annotator_error
+            %div.form-group
+              %label{for: "score"}= t('annotator.filters.score')
+              - options = [["none", ""], ["old", "old"], ["cvalue", "cvalue"], ["cvalueh", "cvalueh"]]
+              = select_tag(:score, options_for_select(options, 0), class: "form-control", "aria-describedby": "includeScoreHelpBlock")
+              %small#includeScoreHelpBlock.form-text.text-muted= t('annotator.filters.score_help')
 
-  %div.row
-    %div.col
-      #annotations_container
-        #result_counts
-        %h4= t('annotator.annotations_result')
-        #filter_list{:style => "font-size: 9pt; color: gray; display: none; clear: both; margin: -15px 0 5px"}
-          %span#filter_title>  #{t('annotator.results_filtered_by')}:&nbsp;
-          \&nbsp;
-          %span#filter_names
-        #results_error{:style => "color: red; margin-bottom: 7px;"}
-        %table#annotations.zebra{:style => "min-width: 700px; width: 100%;"}
-          %thead
-            %tr
-              %th
-                = t('class')
-                %span.popup_container
-                  %span.bp_popup_link_container
-                    %a#filter_classes.bp_popup_link{:href => "javascript:void(0);"}= t('filter')
-                  %div#classes_filter_list.bp_popup_list
-              %th
-                = t('ontology')
-                %span.popup_container
-                  %span.bp_popup_link_container
-                    %a#filter_ontologies.bp_popup_link{:href => "javascript:void(0);"}= t('filter')
-                  %div#ontology_filter_list.bp_popup_list
-              %th{class: "match_type"}
-                = t('type')
-                %span.popup_container
-                  %span.bp_popup_link_container
-                    %a#filter_match_type.bp_popup_link{:href => "javascript:void(0);"}= t('filter')
-                  %div#match_type_filter_list.bp_popup_list
-              %th= t('umls_sem_type')
-              %th{class: "match_context"}= t('context')
-              %th
-                = t('matched_class')
-                %span.popup_container
-                  %span.bp_popup_link_container
-                    %a#filter_matched_classes.bp_popup_link{:href => "javascript:void(0);"}= t('filter')
-                  %div#matched_classes_filter_list.bp_popup_list
-              %th
-                = t('matched_ontology')
-                %span.popup_container
-                  %span.bp_popup_link_container
-                    %a#filter_matched_ontologies.bp_popup_link{:href => "javascript:void(0);"}= t('filter')
-                  %div#matched_ontology_filter_list.bp_popup_list
-              %th= t('score')
-              %th= t('negation')
-              %th= t('experiencer')
-              %th= t('temporality')
-              %th= t('certainty')
-          %tbody
-        %div.my-3
-          %b= t('format_results')
-        %div.my-3
-          %span#download_links_tabdelimited.link_button.ui_button
-          %span#download_links_json.link_button.ui_button
-          %span#download_links_rdf.link_button.ui_button
-          %span#download_links_text.link_button.ui_button
-          -# %span#download_links_xml.link_button.ui_button
-        %div.mt-3
-          = link_to(t('reproduce_results'))
-          %span#annotator_parameters
-        %div.mb-4
-          = t('additional_parameters')
-          = link_to('Annotator API documentation', "#{$REST_URL}/documentation#nav_annotator", target: "_blank")
-          
+            %div.form-group
+              %label{for: "score_threshold"}= t('annotator.filters.score_threshold')
+              = number_field_tag(:score_threshold, 0, id: "score_threshold", class: "form-control", "aria-describedby": "scoreThresholdHelpBlock")
+              %small#scoreThresholdHelpBlock.form-text.text-muted= t('annotator.filters.score_threshold_help')
+
+            %div.form-group
+              %label{for: "confidence_threshold"}= t('annotator.filters.confidence_threshold')
+              = number_field_tag(:confidence_threshold, 0, min: 0, max: 100, id: "confidence_threshold", class: "form-control", "aria-describedby": "confidenceThresholdHelpBlock")
+              %small#confidenceThresholdHelpBlock.form-text.text-muted= t('annotator.filters.confidence_threshold_help')
+
+            - if @recognizers.length > 1
+              %div.form-group
+                %label{for: "recognizer"}= t('annotator.filters.recognizer')
+                - default_recognizer = @recognizers.include?("mgrep") ? "mgrep" : @recognizers.first
+                = select_tag("recognizer", options_for_select(@recognizers.map {|r| [r, r]}, default_recognizer), class: "form-control")
+
+            %div.form-group
+              %div.custom-control.custom-checkbox
+                = check_box_tag("fast_context", :all, false, class: "custom-control-input")
+                %label.custom-control-label{for: "fast_context"}= t('annotator.fast_context')
+                %small#fast_contextnHelp.form-text.text-muted= t('annotator.index.fast_context.tooltip')
+            %div.form-group
+              %div.custom-control.custom-checkbox
+                = check_box_tag("lemmatize", false, false, class: "custom-control-input")
+                %label.custom-control-label{for: "lemmatize"}= t('annotator.lemmatize')
+                %small#lemmatize.form-text.text-muted= t('annotator.index.lemmatize.tooltip')
+          %div.my-4
+            = button_tag(t('annotator.get_annotator'), type: "button", id: "annotator_button", class: "btn btn-primary btn-lg")
+            %span.annotator_spinner
+              %img{src: asset_path('spinners/spinner_000000_16px.gif')}/
+            %span#annotator_error.annotator_error
+
+    %div.row
+      %div.col
+        #annotations_container
+          #result_counts
+          %h4= t('annotator.annotations_result')
+          #filter_list{:style => "font-size: 9pt; color: gray; display: none; clear: both; margin: -15px 0 5px"}
+            %span#filter_title>  #{t('annotator.results_filtered_by')}:&nbsp;
+            \&nbsp;
+            %span#filter_names
+          #results_error{:style => "color: red; margin-bottom: 7px;"}
+          %table#annotations.zebra{:style => "min-width: 700px; width: 100%;"}
+            %thead
+              %tr
+                %th
+                  = t('class')
+                  %span.popup_container
+                    %span.bp_popup_link_container
+                      %a#filter_classes.bp_popup_link{:href => "javascript:void(0);"}= t('filter')
+                    %div#classes_filter_list.bp_popup_list
+                %th
+                  = t('ontology')
+                  %span.popup_container
+                    %span.bp_popup_link_container
+                      %a#filter_ontologies.bp_popup_link{:href => "javascript:void(0);"}= t('filter')
+                    %div#ontology_filter_list.bp_popup_list
+                %th{class: "match_type"}
+                  = t('type')
+                  %span.popup_container
+                    %span.bp_popup_link_container
+                      %a#filter_match_type.bp_popup_link{:href => "javascript:void(0);"}= t('filter')
+                    %div#match_type_filter_list.bp_popup_list
+                %th= t('umls_sem_type')
+                %th{class: "match_context"}= t('context')
+                %th
+                  = t('matched_class')
+                  %span.popup_container
+                    %span.bp_popup_link_container
+                      %a#filter_matched_classes.bp_popup_link{:href => "javascript:void(0);"}= t('filter')
+                    %div#matched_classes_filter_list.bp_popup_list
+                %th
+                  = t('matched_ontology')
+                  %span.popup_container
+                    %span.bp_popup_link_container
+                      %a#filter_matched_ontologies.bp_popup_link{:href => "javascript:void(0);"}= t('filter')
+                    %div#matched_ontology_filter_list.bp_popup_list
+                %th= t('score')
+                %th= t('negation')
+                %th= t('experiencer')
+                %th= t('temporality')
+                %th= t('certainty')
+            %tbody
+          %div.my-3
+            %b= t('format_results')
+          %div.my-3
+            %span#download_links_tabdelimited.link_button.ui_button
+            %span#download_links_json.link_button.ui_button
+            %span#download_links_rdf.link_button.ui_button
+            %span#download_links_text.link_button.ui_button
+            -# %span#download_links_xml.link_button.ui_button
+          %div.mt-3
+            = link_to(t('reproduce_results'))
+            %span#annotator_parameters
+          %div.mb-4
+            = t('additional_parameters')
+            = link_to('Annotator API documentation', "#{$REST_URL}/documentation#nav_annotator", target: "_blank")
+            
 :javascript
   window.addEventListener("load", function() {
     if(document.getElementById("annotation_text").value != ''){

--- a/app/views/annotatorplus/index.html.haml
+++ b/app/views/annotatorplus/index.html.haml
@@ -16,39 +16,39 @@
     %div.col
       %form
         %div.form-group
-          = text_area_tag("annotation_text", nil, rows: 10, class: "form-control", placeholder: "Enter or paste text to be annotated", "aria-describedby": "annotateTextHelpBlock")
+          = text_area_tag("annotation_text", nil, rows: 10, class: "form-control", placeholder: t('annotator.annotate_text_prompt'), "aria-describedby": "annotateTextHelpBlock")
           %small#annotateTextHelpBlock.form-text
-            %a#insert_text_link{href: "javascript:void(0);"} insert sample text
+            %a#insert_text_link{href: "javascript:void(0);"}= t('nbco_annotatosplus.insert_sample_text')
 
-        %a#advancedOptionsLink{:href => "javascript:void(0);"} Show advanced options >>
+        %a#advancedOptionsLink{:href => "javascript:void(0);"}= t('nbco_annotatosplus.show_advanced_options') + ">>"
 
         %div#advanced-options-container.mt-4
           %div.form-group
             %div.custom-control.custom-checkbox.custom-control-inline
               = check_box_tag("longest_only", "all", false, class: "custom-control-input")
-              %label.custom-control-label{for: "longest_only"} Match longest only
+              %label.custom-control-label{for: "longest_only"}= t('nbco_annotatosplus.match_longest_only')
 
             %div.custom-control.custom-checkbox.custom-control-inline
               = check_box_tag("whole_word_only", "all", false, class: "custom-control-input")
-              %label.custom-control-label{for: "whole_word_only"} Match partial words
+              %label.custom-control-label{for: "whole_word_only"}= t('nbco_annotatosplus.match_partial_words')
 
             %div.custom-control.custom-checkbox.custom-control-inline
               = check_box_tag("mappings", "all", false, id: "mappings_all", class: "custom-control-input")
-              %label.custom-control-label{for: "mappings_all"} Include mappings
+              %label.custom-control-label{for: "mappings_all"}= t('nbco_annotatosplus.include_mappings')
 
             %div.custom-control.custom-checkbox.custom-control-inline
               = check_box_tag("exclude_numbers", "all", false, class: "custom-control-input")
-              %label.custom-control-label{for: "exclude_numbers"} Exclude numbers
+              %label.custom-control-label{for: "exclude_numbers"}= t('nbco_annotatosplus.exclude_numbers')
 
             %div.custom-control.custom-checkbox.custom-control-inline
               = check_box_tag("exclude_synonyms", "all", false, class: "custom-control-input")
-              %label.custom-control-label{for: "exclude_synonyms"} Exclude synonyms
+              %label.custom-control-label{for: "exclude_synonyms"}= t('nbco_annotatosplus.exclude_synonyms')
 
           %div.form-group
             %label{for: "ontology_ontologyId"} Select ontologies
             = select_tag("ontology_ontologyId", options_from_collection_for_select(@annotator_ontologies, :acronym, lambda { |ont| "#{ont.name} (#{ont.acronym})" }), |
                 multiple: true, class: "form-control", "aria-describedby": "selectOntologiesHelpBlock") |
-            %small#selectOntologiesHelpBlock.form-text.text-muted Start typing to select ontologies or leave blank to use all
+            %small#selectOntologiesHelpBlock.form-text.text-muted= t('nbco_annotatosplus.select_ontologies')
 
           - if @sem_type_ont
             %div.form-group

--- a/app/views/home/index.html.haml
+++ b/app/views/home/index.html.haml
@@ -22,18 +22,18 @@
     .home-bubble.home-bubble-one
       %h5
         = @anal_ont_names[0]
-      %p
-        = @anal_ont_numbers[0].to_s + " visits"
+      %p 
+        = @anal_ont_numbers[0].to_s + " " + t('visits')
     .home-bubble.home-bubble-two
       %h5
         = @anal_ont_names[1]
-      %p
-        = @anal_ont_numbers[1].to_s + " visits"
+      %p 
+        = @anal_ont_numbers[1].to_s + " " + t('visits')
     .home-bubble.home-bubble-three
       %h5
         = @anal_ont_names[2]
-      %p
-        = @anal_ont_numbers[2].to_s + " visits"
+      %p 
+        = @anal_ont_numbers[2].to_s + " " + t('visits')
     %a.home-bubble.home-bubble-four{:href => "/visits"}
       %h5 ...
 
@@ -42,15 +42,15 @@
       %h4
         = t('.welcome', site: $SITE)
       %p
-        = t('.tagline')
+        = t('home.index.tagline')
       = render OntologySearchInputComponent.new
  
 .home-body-container
   .home-section
-    %h4 Wanna upload an ontology?
+    %h4= t('home.ontology_upload')
     %hr.home-section-line/
-    %p Uploading an ontology is a way of sharing your domain knowledge with others.
-    %p By uploading your ontology to #{$SITE}, you can:
+    %p= t('home.ontology_upload_desc')
+    %p= t('home.ontology_upload_benefits', site: $SITE)
     .home-upload-benifits
       - @upload_benefits.each do |benefit|
         %div
@@ -60,43 +60,43 @@
     - if session[:user].nil?
       %a.home-upload-ontology-button{:href => "/login?redirect=/ontologies/new"}
         = inline_svg_tag "upload.svg", class: "home-upload-icon"
-        upload ontology
+        = t('home.ontology_upload_button')
     - else
       %a.home-upload-ontology-button{:href => "/ontologies/new"}
         = inline_svg_tag "upload.svg", class: "home-upload-icon"
-        Upload ontology
+        = t('home.ontology_upload_button')
   .home-section
     %h4
-      Recommender and annotator
+      = t('home.recommender_annotator')
     %hr.home-section-line/
     .home-card
       %form{action: "/annotator_recommender_form", method: "post"}
-        %textarea.home-recommendations-and-annotations{rows: "6" , placeholder: "Paste a paragraph of text or some keywords ...", name: "text"}
+        %textarea.home-recommendations-and-annotations{rows: "6" , placeholder: t('home.paste_text_prompt'), name: "text"}
         %input.d-none{type: "submit", name: "submit_button" ,value: "annotator", id: "annotator_submit"}/
         %input.d-none{type: "submit" , name: "submit_button" ,value: "recommender", id: "recommender_submit"}/
         .home-services-buttons
           .home-get-recommendations{onclick: "submitRecommender()"}
-            %p Get recommendations
+            %p= t('home.get_recommendations')
             = inline_svg_tag "play.svg", class: "home-play-icon"
           .home-services-buttons
             .home-get-annotations{onclick: "submitAnnotator()"}
-              %p Get annotations
+              %p= t('home.get_annotations')
               %img{:src => asset_path("play-white.svg")}/
   .home-section
     .home-section-sub-sections-container
       .home-sub-section-left
-        %h4 FAIR scores
+        %h4= t('home.fairness')
         %hr.home-section-line/
         .home-card.home-fair-scores
           - if fairness_service_enabled?
             %div#fair-home{data:{controller:"fair-score-home"}}
               = render partial: "shared/fair_score_bars", locals: {data: nil}
-            %a{:href => "#fairDetails"}
-              %div.home-fair-details
-                %p See details
-                = inline_svg_tag "arrow-right.svg"
+            %a{:href => "/landscape#fairness_assessment"}
+            %div.home-fair-details
+              %p= t('home.fair_details')
+              = inline_svg_tag "arrow-right.svg"
       .home-sub-section-right
-        %h4 News
+        %h4= t('home.twitter_news')
         %hr.home-section-line
         .home-card.home-twitter-news
           %a.twitter-timeline{"data-height" => "349", :href => "https://twitter.com/lagroportal?ref_src=twsrc%5Etfw"} Tweets by lagroportal
@@ -106,8 +106,8 @@
     .home-statistics-container
       .home-agroportal-figures
         = inline_svg_tag "ontoportal-icon.svg"
-        %p
-          = portal_name+" in figures:"
+        %p 
+          = t('home.agroportal_figures', site: $SITE)
       .home-statistics
         .home-statistics-item
           %hr/
@@ -154,14 +154,14 @@
   .home-section
     .home-statistics-container
       .home-support-title
-        %p Supported by
+        %p= t('home.supported_by')
         %hr.home-section-line/
       .home-support-items
         - $HOME_PAGE_LOGOS[:supported_by].each do |logo|
           %a{href:logo[:url], target: "_blanc"}
             %img{src: asset_path(logo[:img_src])}
       .home-support-title
-        %p With the collaboration of
+        %p= t('home.with_collaboration')
         %hr.home-section-line/
       .home-support-items
         - $HOME_PAGE_LOGOS[:with_the_collaboration_of].each do |logo|

--- a/app/views/layouts/_topnav.html.haml
+++ b/app/views/layouts/_topnav.html.haml
@@ -22,17 +22,17 @@
             %input
         - else
           .nav-search-container
-            = render OntologySearchInputComponent.new(placeholder:  "Search in "+portal_name+" ...", scroll_down: false)
+            = render OntologySearchInputComponent.new(placeholder:  t('layout.header.search_prompt', portal_name: portal_name ), scroll_down: false)
 
         - if session[:user].nil?
-          %a.nav-a{:href => "/login"} Login
+          %a.nav-a{:href => "/login"}= t('layout.header.login')
         - else
           = render DropdownButtonComponent.new do |d|
             - d.header do
               = session[:user].username
             - d.with_section(divide: false) do |s|
               - s.item do
-                = link_to(t(:_account_setting), "/account")
+                = link_to(t('layout.header.account_setting'), "/account")
             - d.with_section do |s|
               - s.header do
                 Recently Viewed
@@ -41,26 +41,25 @@
                   = link_to(ont.ontology_name, "/ontologies/#{ont.ontology_acronym}/?p=classes&conceptid=#{CGI.escape(ont.concept)}")
             - d.with_section do |s|
               - s.item do
-                = link_to("Logout", logout_path)
+                = link_to(t('layout.header.logout'), logout_path)
 
-        = select_tag('language', options_for_select([['EN','en'],['FR','fr']]), id: 'language-select', class: 'nav-language',
-          data: { controller: "platform-language", action: "change->platform-language#handleLangChanged" })
+        = portal_language_selector
 
         = render DropdownButtonComponent.new do |d|
           - d.header do
             = link_to("#", id: "supportMenuDropdownLink", class: "nav-link top-nav-nav-link supportMenuDropdownLink", role: "button") do
-              Support
+              = t('layout.header.support')
           - d.with_section(divide: false) do |s|
             - s.item do
-              = link_to(t(:submit_feedback), feedback_path(location: encode_param(request.url)), id: "submitFeedbackMenuItem", class: "pop_window")
+              = link_to(t('layout.header.submit_feedback'), feedback_path(location: encode_param(request.url)), id: "submitFeedbackMenuItem", class: "pop_window")
           - d.with_section do |s|
             - s.header do
-              Documentation
+              = t('layout.header.documentation')
             - s.item do
-              = link_to(t(:_help), "#{$WIKI_HELP_PAGE}", target: "_blank")
+              = link_to(t('layout.header.help'), "#{$WIKI_HELP_PAGE}", target: "_blank")
             - s.item do
-              = link_to(t(:_release_notes), "#{$RELEASE_NOTES}", target: "_blank")
+              = link_to(t('layout.header.release_notes'), "#{$RELEASE_NOTES}", target: "_blank")
             - s.item do
-              = link_to(t(:_publications), $PUBLICATIONS_URL, target: "_blank")
+              = link_to(t('layout.header.publications'), $PUBLICATIONS_URL, target: "_blank")
 
 

--- a/app/views/login/index.html.haml
+++ b/app/views/login/index.html.haml
@@ -1,24 +1,24 @@
-- @title = "Login"
+- @title = t('login.title')
 - unless @errors.nil?
   %div{:style => "color:red;"}
-    Errors On Form
+    = t('login.invalid_login')
     %ul
       - for error in @errors
         %li= error
 .d-flex.justify-content-center
   .login-form
     = form_for(:user, :url => {:controller => 'login',:action=>'create'}) do |f|
-      %p.login-input-title Username or Email
-      = text_field 'user', 'username', class: "login-input email-input", placeholder: "Enter your email"
-      %p.login-input-title Password
-      = password_field 'user','password', :autocomplete => "off", class: "login-input password-input", placeholder: "Enter your password"
+      %p.login-input-title= t('login.username_or_email')
+      = text_field 'user', 'username', class: "login-input email-input", placeholder: t('login.enter_email')
+      %p.login-input-title= t('login.password')
+      = password_field 'user','password', :autocomplete => "off", class: "login-input password-input", placeholder:  t('login.enter_password')
       %a.login-forgot-password{:href => "/lost_pass"}
-        %p Forgot password?
+        %p= t('login.forgot_password')
       .login-button-container
         = render Buttons::RegularButtonComponent.new(id: 'login-button', value: "Login", type:'submit')
       %p.dont-have-account
-        Don't have an account?
-        %a.text-decoration-none{:href => new_user_path} Register
+        = t('login.no_account')
+        %a.text-decoration-none{:href => new_user_path}= t('login.register')
     %hr.divider.w-100
     %div.d-flex.justify-content-center.flew-wrap
       - omniauth_providers_info.each do |provider, config|

--- a/app/views/mappings/index.html.haml
+++ b/app/views/mappings/index.html.haml
@@ -1,13 +1,14 @@
 - @title= t('mappings.title')
-%div#mappings_container.container-fluid.py-4.flex-grow-1
-  %h1.my-1= t('mappings.title')
+%div.container
+  %div#mappings_container.container-fluid.py-4.flex-grow-1
+    %h1.my-1= t('mappings.title')
 
-  %div#mappings_uploader.my-2
-    = link_to_modal t('mappings.upload_mappings') , "/mappings/loader", class: "btn btn-primary btn-block",
-       data: { show_modal_title_value: t('mappings.mappings_bulk_load'), show_modal_size_value: 'modal-xl'}
-  %hr.my-3.w-100
-    #accordionExample.accordion
-      = render partial: 'ontology_mappings'
-      = render partial: 'concept_mappings_selector'
+    %div#mappings_uploader.my-2
+      = link_to_modal t('mappings.upload_mappings') , "/mappings/loader", class: "btn btn-primary btn-block",
+        data: { show_modal_title_value: t('mappings.mappings_bulk_load'), show_modal_size_value: 'modal-xl'}
+    %hr.my-3.w-100
+      #accordionExample.accordion
+        = render partial: 'ontology_mappings'
+        = render partial: 'concept_mappings_selector'
 
 

--- a/app/views/projects/edit.html.haml
+++ b/app/views/projects/edit.html.haml
@@ -1,11 +1,13 @@
 - @title = "Editing Project #{@project.name}"
-%h1{:style => "padding: 10px;"}
-  Editing project
-%p{:style => "padding-left: 10px;"}
-  / TODO_REV: Enable project delete
-  / = link_to("Delete Project", @project, :confirm => "Are you sure?", :method => :delete)
-= form_for(:project, url: project_path(@project.acronym), html: {method: :put}) do |f|
-  = render partial: 'form', locals: { f: f }
+%div.container
+
+  %h1{:style => "padding: 10px;"}
+    Editing project
   %p{:style => "padding-left: 10px;"}
-    = submit_tag "Cancel"
-    = f.submit "Update Project", :class => "blueButton"
+    / TODO_REV: Enable project delete
+    / = link_to("Delete Project", @project, :confirm => "Are you sure?", :method => :delete)
+  = form_for(:project, url: project_path(@project.acronym), html: {method: :put}) do |f|
+    = render partial: 'form', locals: { f: f }
+    %p{:style => "padding-left: 10px;"}
+      = submit_tag "Cancel"
+      = f.submit "Update Project", :class => "blueButton"

--- a/app/views/projects/index.html.haml
+++ b/app/views/projects/index.html.haml
@@ -1,78 +1,78 @@
 - @title = t("projects.title")
+%div.container
+  #DescriptionDialog{:style => "display: none", :title => t("projects.project_description")}
+    %p= t("projects.description_text")
+  %h1.tab_header= t("projects.self")
+  %p.tab_description
+    = t("projects.index.intro", site: "#{$SITE}")
+    = link_to(help_path(anchor: "Projects_Tab"), id: "projects-help", aria: {label: t("projects.view_projects_help")}) do
+      %i.fas.fa-question-circle.fa-lg{aria: {hidden: "true"}, style: "margin-left: .25em"}
 
-#DescriptionDialog{:style => "display: none", :title => t("projects.project_description")}
-  %p= t("projects.description_text")
-%h1.tab_header= t("projects.self")
-%p.tab_description
-  = t("projects.index.intro", site: "#{$SITE}")
-  = link_to(help_path(anchor: "Projects_Tab"), id: "projects-help", aria: {label: t("projects.view_projects_help")}) do
-    %i.fas.fa-question-circle.fa-lg{aria: {hidden: "true"}, style: "margin-left: .25em"}
-
-%div{:style => "padding:10px;"}
-  %span
-    - if session[:user].nil?
-      = button_to t("projects.create_new_project"), "/login", :method => :get
-    - else
-      = button_to t("projects.create_new_project"), new_project_path, :method => :get
-  %br/
-  %br/
-  %table#projects.zebra{:cellpadding => "0", :cellspacing => "0"}
-    %thead
-      %tr
-        %th= t("projects.self")
-        %th= t("projects.description")
-        %th= t("projects.contacts")
-        %th= t("projects.institutions")
-        %th= t("projects.ontologies")
-        - if current_user_admin?
-          %th= t("projects.creator")
-          %th= t("projects.created")
-    %tbody
-      - for project in @projects
+  %div{:style => "padding:10px;"}
+    %span
+      - if session[:user].nil?
+        = button_to t("projects.create_new_project"), "/login", :method => :get
+      - else
+        = button_to t("projects.create_new_project"), new_project_path, :method => :get
+    %br/
+    %br/
+    %table#projects.zebra{:cellpadding => "0", :cellspacing => "0"}
+      %thead
         %tr
-          / Project name, home page, and controls for editors
-          %td{:style => "vertical-align:top;", :width => "30%"}
-            %strong= link_to(project.name, project_path(project.acronym))
-            %br/
-            %span{:style => "font-size:75%; vertical-align:bottom;"}
-              = link_to(t('projects.home_page'), project.homePage, target: "_blank", rel: "nofollow")
-              %span.ui-icon.ui-icon-extlink{:style => "display: inline-block; vertical-align: text-bottom;"}
-              \&nbsp;&nbsp;
-              - if session[:user] && (project.creator == session[:user].id || session[:user].admin?)
-                = link_to(t("projects.edit"), edit_project_path(project.acronym))
-                / TODO_REV: Enable delete project for admins
-              - if current_user_admin?
-                &nbsp;&nbsp;
-                = link_to(t("projects.delete_admin_only"), project_path(project.acronym), :method => :delete, :confirm => t("projects.delete_confirm"))
-          / Project description (may be truncated with a dialog)
-          %td{:style => "vertical-align:top;", :width => "50%"}
-            - if ! project.description.nil?
-              - descLength = 250
-              - if project.description.length < descLength
-                = project.description
-              - else
-                - descShort = smart_truncate(project.description, :words => 20)
-                %span{:style => "cursor:help;", :title => project.description}
-                  = descShort
-          / Contacts
-          %td{:style => "vertical-align:top;", :width => "10%"}
-            = raw project.contacts
-          / Institutions
-          %td{:style => "vertical-align:top;", :width => "8%"}
-            = raw project.institution
-          / Ontologies
-          %td{:style => "vertical-align:top;", :width => "2%"}
-            - ontologyCount = 0
-            - ontologyLabels = ""
-            - for ontology in project.ontologyUsed
-              - ontologyLabels += @ontologies_hash[ontology].name + "\n" rescue next
-              - ontologyCount += 1
-            - if ontologyCount > 0
-              %span{:style => "cursor:help;text-decoration: none; border-bottom:1px dotted;", :title => ontologyLabels}= ontologyCount
-            - else
-              = ontologyCount
+          %th= t("projects.self")
+          %th= t("projects.description")
+          %th= t("projects.contacts")
+          %th= t("projects.institutions")
+          %th= t("projects.ontologies")
           - if current_user_admin?
-            %td
-              = project.creator.map {|c| c.split("/").last}.join(", ")
-            %td
-              = project.created
+            %th= t("projects.creator")
+            %th= t("projects.created")
+      %tbody
+        - for project in @projects
+          %tr
+            / Project name, home page, and controls for editors
+            %td{:style => "vertical-align:top;", :width => "30%"}
+              %strong= link_to(project.name, project_path(project.acronym))
+              %br/
+              %span{:style => "font-size:75%; vertical-align:bottom;"}
+                = link_to(t('projects.home_page'), project.homePage, target: "_blank", rel: "nofollow")
+                %span.ui-icon.ui-icon-extlink{:style => "display: inline-block; vertical-align: text-bottom;"}
+                \&nbsp;&nbsp;
+                - if session[:user] && (project.creator == session[:user].id || session[:user].admin?)
+                  = link_to(t("projects.edit"), edit_project_path(project.acronym))
+                  / TODO_REV: Enable delete project for admins
+                - if current_user_admin?
+                  &nbsp;&nbsp;
+                  = link_to(t("projects.delete_admin_only"), project_path(project.acronym), :method => :delete, :confirm => t("projects.delete_confirm"))
+            / Project description (may be truncated with a dialog)
+            %td{:style => "vertical-align:top;", :width => "50%"}
+              - if ! project.description.nil?
+                - descLength = 250
+                - if project.description.length < descLength
+                  = project.description
+                - else
+                  - descShort = smart_truncate(project.description, :words => 20)
+                  %span{:style => "cursor:help;", :title => project.description}
+                    = descShort
+            / Contacts
+            %td{:style => "vertical-align:top;", :width => "10%"}
+              = raw project.contacts
+            / Institutions
+            %td{:style => "vertical-align:top;", :width => "8%"}
+              = raw project.institution
+            / Ontologies
+            %td{:style => "vertical-align:top;", :width => "2%"}
+              - ontologyCount = 0
+              - ontologyLabels = ""
+              - for ontology in project.ontologyUsed
+                - ontologyLabels += @ontologies_hash[ontology].name + "\n" rescue next
+                - ontologyCount += 1
+              - if ontologyCount > 0
+                %span{:style => "cursor:help;text-decoration: none; border-bottom:1px dotted;", :title => ontologyLabels}= ontologyCount
+              - else
+                = ontologyCount
+            - if current_user_admin?
+              %td
+                = project.creator.map {|c| c.split("/").last}.join(", ")
+              %td
+                = project.created

--- a/app/views/projects/show.html.haml
+++ b/app/views/projects/show.html.haml
@@ -1,27 +1,30 @@
 - @title = "Project #{@project.name}"
-%div{:style => "padding: 1em;"}
-  %h1{:style => "font-size: xx-large;"}= @project.name
-  - if session[:user] && (@project.creator.include?(session[:user].id) || session[:user].admin?)
-    = link_to "Edit Project", edit_project_path(@project.acronym)
-  %br/
-  %br/
-  %p{:style => "margin-bottom: 5px;"}
-    %strong Description:
-    = @project.description
-  %p{:style => "margin-bottom: 5px;"}
-    %strong Institution:
-    = @project.institution
-  %p{:style => "margin-bottom: 5px;"}
-    %strong Contacts:
-    = @project.contacts
-  %p
-    %strong Home Page:
-    - if @project.homePage
-      = link_to @project.homePage, @project.homePage, rel: "nofollow"
-  %h2{:style => "padding-top: 1em;"} Ontologies Used
-  - if @ontologies_used.empty?
-    No ontologies are currently associated with this project
-  %table.zebra{:cellpadding => "0", :cellspacing => "0", :width => "70%"}
-    %ul
-      - for ontology in @ontologies_used
-        %li= link_to(ontology["name"], ontology_path(ontology["acronym"]))
+
+%div.container
+
+  %div{:style => "padding: 1em;"}
+    %h1{:style => "font-size: xx-large;"}= @project.name
+    - if session[:user] && (@project.creator.include?(session[:user].id) || session[:user].admin?)
+      = link_to "Edit Project", edit_project_path(@project.acronym)
+    %br/
+    %br/
+    %p{:style => "margin-bottom: 5px;"}
+      %strong Description:
+      = @project.description
+    %p{:style => "margin-bottom: 5px;"}
+      %strong Institution:
+      = @project.institution
+    %p{:style => "margin-bottom: 5px;"}
+      %strong Contacts:
+      = @project.contacts
+    %p
+      %strong Home Page:
+      - if @project.homePage
+        = link_to @project.homePage, @project.homePage, rel: "nofollow"
+    %h2{:style => "padding-top: 1em;"} Ontologies Used
+    - if @ontologies_used.empty?
+      No ontologies are currently associated with this project
+    %table.zebra{:cellpadding => "0", :cellspacing => "0", :width => "70%"}
+      %ul
+        - for ontology in @ontologies_used
+          %li= link_to(ontology["name"], ontology_path(ontology["acronym"]))

--- a/app/views/recommender/index.html.haml
+++ b/app/views/recommender/index.html.haml
@@ -1,112 +1,112 @@
 - @title=  t('recommender.title')
+%div.container
+  %h2.mt-5= t('recommender.ontology_recommender')
+  %p
+    = t('recommender.intro').html_safe
+    = link_to(Rails.configuration.settings.links[:help_recommender], id: "recommender-help",
+              "aria-label": "View ontology recommender help") do
+      %i.fas.fa-question-circle.fa-lg{"aria-hidden": "true"}
 
-%h2.mt-5= t('recommender.ontology_recommender')
-%p
-  = t('recommender.intro').html_safe
-  = link_to(Rails.configuration.settings.links[:help_recommender], id: "recommender-help",
-            "aria-label": "View ontology recommender help") do
-    %i.fas.fa-question-circle.fa-lg{"aria-hidden": "true"}
+  %form
+    = hidden_field_tag :recommender_sample_text, t('recommender.sample_text')
+    = hidden_field_tag :recommender_sample_keywords,t('recommender.sample_keywords')
+    
+    -# Specify input format
+    %h5= t('input')
+    %div.form-check.form-check-inline
+      %input#radioItText.form-check-input{name: "input_type", type: "radio", value: "1", checked: "checked"}
+      %label.form-check-label{for: "radioItText"}= t('text')
+    %div.form-check.form-check-inline
+      %input#radioItKeywords.form-check-input{name: "input_type", type: "radio", value: "2"} 
+      %label.form-check-label{for: "radioItKeywords"}= t('keywords') + " ( " + t('keywords_separated_by_commas') + " ) "
+    
+    -# Specify output format
+    %h5.pt-3= t('output')
+    %div.form-check.form-check-inline
+      %input#radioOtSingle.form-check-input{name: "output_type", type: "radio", value: "1", checked: "checked"} 
+      %label.form-check-label{for: "radioOtSingle"}= t('ontologies.self')
+    %div.form-check.form-check-inline
+      %input#radioOtSets.form-check-input{name: "output_type", type: "radio", value: "2"} 
+      %label.form-check-label{for: "radioOtSets"}= t('ontology_sets')
+    
+    -# Input text or keywords
+    %div.form-group.mt-4
+      = text_area_tag("inputText", @text, rows: 10, class: "form-control default", placeholder: t('recommender.paste_text_recommendations'), aria: {describedby: "inputTextHelpBlock"})
+      %div.card#inputTextHighlighted
+        %div.card-body
+      %small#inputTextHelpBlock.form-text
+        %a#insertInputLink{href: "javascript:void(0);"}= t('insert_sample_text')
 
-%form
-  = hidden_field_tag :recommender_sample_text, t('recommender.sample_text')
-  = hidden_field_tag :recommender_sample_keywords,t('recommender.sample_keywords')
-  
-  -# Specify input format
-  %h5= t('input')
-  %div.form-check.form-check-inline
-    %input#radioItText.form-check-input{name: "input_type", type: "radio", value: "1", checked: "checked"}
-    %label.form-check-label{for: "radioItText"}= t('text')
-  %div.form-check.form-check-inline
-    %input#radioItKeywords.form-check-input{name: "input_type", type: "radio", value: "2"} 
-    %label.form-check-label{for: "radioItKeywords"}= t('keywords') + " ( " + t('keywords_separated_by_commas') + " ) "
-  
-  -# Specify output format
-  %h5.pt-3= t('output')
-  %div.form-check.form-check-inline
-    %input#radioOtSingle.form-check-input{name: "output_type", type: "radio", value: "1", checked: "checked"} 
-    %label.form-check-label{for: "radioOtSingle"}= t('ontologies.self')
-  %div.form-check.form-check-inline
-    %input#radioOtSets.form-check-input{name: "output_type", type: "radio", value: "2"} 
-    %label.form-check-label{for: "radioOtSets"}= t('ontology_sets')
-  
-  -# Input text or keywords
-  %div.form-group.mt-4
-    = text_area_tag("inputText", @text, rows: 10, class: "form-control default", placeholder: "Paste a paragraph of text or some keywords to use in calculating ontology recommendations", aria: {describedby: "inputTextHelpBlock"})
-    %div.card#inputTextHighlighted
-      %div.card-body
-    %small#inputTextHelpBlock.form-text
-      %a#insertInputLink{href: "javascript:void(0);"}= t('insert_sample_text')
+    %a#advancedOptionsLink{:href => "javascript:void(0);"}= t('show_advanced_options') + " >>"
 
-  %a#advancedOptionsLink{:href => "javascript:void(0);"}= t('show_advanced_options') + " >>"
+    -# Advanced options
+    %div#advancedOptions.optionsBox
+      -# Specify weights
+      %h6= t('weights_configuration')
+      %div.form-row
+        %div.form-group.col-md-2
+          %label{for: "input_wc"}= t('coverage')
+          = number_field_tag("input_wc", "0.55", min: "0", step: "1", class: "form-control")
+        %div.form-group.col-md-2
+          %label{for: "input_wa"}= t('acceptance')
+          = number_field_tag("input_wa", "0.15", min: "0", step: "1", class: "form-control")
+        %div.form-group.col-md-2
+          %label{for: "input_wd"}= t('knowledge_detail')
+          = number_field_tag("input_wd", "0.15", min: "0", step: "1", class: "form-control")
+        %div.form-group.col-md-2
+          %label{for: "input_ws"}= t('specialization')
+          = number_field_tag("input_ws", "0.15", min: "0", step: "1", class: "form-control")
+      -# Specify ontology set size
+      %h6= t('max_ontologies_per_set')
+      %div.form-row
+        %div.form-group.col-md-2
+          = number_field_tag("input_max_ontologies", "3", in: 2...5, class: "form-control")
+      -# Specify ontologies
+      %div#ontologyPicker
+        = render(partial: "shared/ontology_picker")
 
-  -# Advanced options
-  %div#advancedOptions.optionsBox
-    -# Specify weights
-    %h6= t('weights_configuration')
-    %div.form-row
-      %div.form-group.col-md-2
-        %label{for: "input_wc"}= t('coverage')
-        = number_field_tag("input_wc", "0.55", min: "0", step: "1", class: "form-control")
-      %div.form-group.col-md-2
-        %label{for: "input_wa"}= t('acceptance')
-        = number_field_tag("input_wa", "0.15", min: "0", step: "1", class: "form-control")
-      %div.form-group.col-md-2
-        %label{for: "input_wd"}= t('knowledge_detail')
-        = number_field_tag("input_wd", "0.15", min: "0", step: "1", class: "form-control")
-      %div.form-group.col-md-2
-        %label{for: "input_ws"}= t('specialization')
-        = number_field_tag("input_ws", "0.15", min: "0", step: "1", class: "form-control")
-    -# Specify ontology set size
-    %h6= t('max_ontologies_per_set')
-    %div.form-row
-      %div.form-group.col-md-2
-        = number_field_tag("input_max_ontologies", "3", in: 2...5, class: "form-control")
-    -# Specify ontologies
-    %div#ontologyPicker
-      = render(partial: "shared/ontology_picker")
+    %div.my-4
+      = submit_tag(t('get_recommendations'), id: "recommenderButton", type: "button", class: "btn btn-primary")
+      = submit_tag("Edit Input", id: "editButton", type: "button", style: "display: none;", class: "btn btn-primary")
+      = content_tag(:span, class: "recommenderSpinner") do
+        = image_tag("spinners/spinner_000000_16px.gif", style: "vertical-align: middle;")
 
-  %div.my-4
-    = submit_tag(t('get_recommendations'), id: "recommenderButton", type: "button", class: "btn btn-primary")
-    = submit_tag("Edit Input", id: "editButton", type: "button", style: "display: none;", class: "btn btn-primary")
-    = content_tag(:span, class: "recommenderSpinner") do
-      = image_tag("spinners/spinner_000000_16px.gif", style: "vertical-align: middle;")
+  %div.row#recommenderErrorsDisplay.mb-4
+    %div.col
+      %span.notTextError
+        = t('recommender.ontology_recommendation_input')
+        %br/
+      %span.sumWeightsError
+        = t('recommender.weight_sum_greater_than_zero')
+        %br/
+      %span.rangeWeightsError
+        = t('recommender.weights_greater_than_zero')
+        %br/
+      %span.invalidWeightsError
+        = t('recommender.valid_numeric_weights')
+        %br/
+      %span.invalidMaxOntError
+        = t('recommender.valid_integer_max_ontologies_per_set')
+        %br/
+      %span.maxOntologiesError
+        = t('recommender.valid_max_ontologies_per_set_range')
+        %br/
+      %span.generalError
+        = t('recommender.recommendation_error')
+        %br/
+      %span#noResults
+        = t('recommender.no_recommendations')
+        %br/
+      %span#noResultsSets
+        = t('recommender.no_sets_recommended')
+        %br/
+      %span.inputSizeError
+        = t('recommender.text_length_limit')
 
-%div.row#recommenderErrorsDisplay.mb-4
-  %div.col
-    %span.notTextError
-      = t('recommender.ontology_recommendation_input')
-      %br/
-    %span.sumWeightsError
-      = t('recommender.weight_sum_greater_than_zero')
-      %br/
-    %span.rangeWeightsError
-      = t('recommender.weights_greater_than_zero')
-      %br/
-    %span.invalidWeightsError
-      = t('recommender.valid_numeric_weights')
-      %br/
-    %span.invalidMaxOntError
-      = t('recommender.valid_integer_max_ontologies_per_set')
-      %br/
-    %span.maxOntologiesError
-      = t('recommender.valid_max_ontologies_per_set_range')
-      %br/
-    %span.generalError
-      = t('recommender.recommendation_error')
-      %br/
-    %span#noResults
-      = t('recommender.no_recommendations')
-      %br/
-    %span#noResultsSets
-      = t('recommender.no_sets_recommended')
-      %br/
-    %span.inputSizeError
-      = t('recommender.text_length_limit')
-
-%div.row#resultsDisplay
-  %div.col
-    %h5#resultsHeader
-    %div#recommender-results.mb-5
+  %div.row#resultsDisplay
+    %div.col
+      %h5#resultsHeader
+      %div#recommender-results.mb-5
 
 :javascript
   window.addEventListener("load", function() {

--- a/app/views/users/_form.html.haml
+++ b/app/views/users/_form.html.haml
@@ -5,50 +5,53 @@
         %img.lost-password-arrowback{:src => "#{asset_path("arrow-back.svg")}"}
       .register-title-container
         %h2.register-title
-          Create new account
+          = t('register.create_account')
         %hr#register-title-line/
       %div
     .register-double-input
       .register-first-input
         %p.register-input-title
-          First name
+          = t('register.first_name')
           %font{:color => "red"} *
         = text_field :user, :firstName, value: @user.firstname, class: "register-input-short"
       %div
         %p.register-input-title
-          Last name
+          = t('register.last_name')
           %font{:color => "red"} *
         = text_field :user, :lastName, value: @user.lastname, class: "register-input-short"
     %p.register-input-title
-      Username
+      = t('register.username')
       %font{:color => "red"} *
     = text_field :user, :username, value: @user.username, class: "register-input-long"
     %p.register-input-title
       ORCID ID
-      %font.register-optional (optional)
+      %font.register-optional 
+      = t('register.optional')
     %img.register-input-icon{:src => "#{asset_path("orcid.svg")}"}/
     = text_field :user, :orcidId, value: @user.orcidId, class: "register-input-long register-input-with-icon"
     %p.register-input-title
       Github ID
-      %font.register-optional (optional)
+      %font.register-optional 
+      = t('register.optional')
     %img.register-input-icon{:src => "#{asset_path("github-icon.svg")}"}/
     = text_field :user, :githubId, value: @user.githubId, class: "register-input-long register-input-with-icon"
     %p.register-input-title
-      Email
+      = t('register.email')
       %font{:color => "red"} *
     = text_field :user, :email, value: @user.email, class: "register-input-long"
     %p.register-input-title
-      Password
+      = t('register.password')
       %font{:color => "red"} *
     = password_field :user, :password, class: "register-input-long"
     %p.register-input-title
-      Confirm password
+      = t('register.confirm_password')
       %font{:color => "red"} *
     = password_field :user, :password_confirmation, class: "register-input-long"
     - if using_captcha?
       = recaptcha_tags
     .d-flex
       %input#user_register_mail_list{:checked => "checked", :name => "user[register_mail_list]", :type => "checkbox", :value => "1"}/
-      %p#register-check-text Register for the AgroPortal's mailing list
+      %p#register-check-text 
+        = t('register.mailing_list')
     .register-button-container
-      = render Buttons::PrimaryButtonComponent.new(type: "submit", value: "Register")
+      = render Buttons::RegularButtonComponent.new(id: 'register-button', value: "Register", type:'submit')

--- a/app/views/users/new.html.haml
+++ b/app/views/users/new.html.haml
@@ -1,8 +1,8 @@
-- @title = "Register"
+- @title = t('register.title')
 = form_for(:user, :url => users_path) do |f|
   - unless @errors.nil?
     .enable-lists{:style => "color: red; padding: 1em;"}
-      Errors creating your account:
+      = t('register.account_errors')
       %ul
         - for error in @errors
           %li= error

--- a/config/application.rb
+++ b/config/application.rb
@@ -12,7 +12,7 @@ module BioportalWebUi
     config.load_defaults 7.0
 
     # permitted locales available for the application
-    config.i18n.available_locales = [:en, :fr]
+    config.i18n.available_locales = [:en, :fr, :it, :de]
     config.i18n.default_locale = :en
 
 

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -1,0 +1,406 @@
+---
+de:
+  activaterecord:
+    errors:
+      models:
+        license:
+          attributes:
+            encrypted_key:
+              invalid_license_key: is an invalid license key
+              no_appliance_id_for_comparison: Could not be validated. Unable to retrieve virtual appliance ID.
+              appliance_id_mismatch: is an appliance id mismatch
+
+  date:
+    formats:
+      year_month_day_concise: "%Y-%m-%d" # 2017-03-01
+      month_day_year: "%b %-d, %Y" # Mar 1, 2017
+      monthfull_day_year: "%B %-d, %Y" # March 1, 2017
+      
+  additional_parameters: Zusätzliche Parameter werden erklärt unter
+  admin:
+    licenses:
+      create:
+        success: Lizenz erfolgreich verlängert!
+  all: Alle
+  annotator:
+    annotate_text_prompt: Zu beschriftenden Text eingeben oder einfügen
+    annotations_result: Anmerkungen
+    fast_context: FastContext
+    filters:
+      confidence_threshold: Filterkonfidenzschwellenwert
+      confidence_threshold_help: Geben Sie die Mindestposition in der Punkteverteilung
+        an (zwischen 1 und 100)
+      exclude_numbers: Nummern ausschließen
+      exclude_synonyms: Synonyme ausschließen
+      include_mappings: Mappings einbeziehen
+      match_longest_only: Nur das längste Spiel
+      match_partial_words: Erkennen von Wortteilen
+      max_hierarchy_level: Vorfahren bis zur Ebene einbeziehen
+      score: Punktzahl einbeziehen
+      score_help: Bewertung von Anmerkungen nach der früheren NCBO 2009-Maßnahme (alt)
+        oder Bewertung von Anmerkungen nach der C-Value-Maßnahme (cvalue) oder Bewertung
+        von Anmerkungen nach der C-Value-Maßnahme mit Hierarchieerweiterung (cvalueh)
+      score_threshold: Filter nach Schwellenwert
+      score_threshold_help: Mindestpunktzahl für Anmerkungen festlegen
+    get_annotator: Anmerkungen erhalten
+    index:
+      fast_context:
+        tooltip: Aktivieren Sie FastContext, um zu erkennen, ob ein Konzept verneint
+          wurde (bejaht, verneint), wer das gefundene Konzept erlebt hat (Patient,
+          andere), wann das kommentierte Konzept aufgetreten ist (kürzlich, historisch,
+          hypothetisch) und/oder ob das kommentierte Konzept unsicher ist (sicher,
+          unsicher).
+      intro: Annotationen für biomedizinische Texte mit Ontologieklassen erhalten
+      lemmatize:
+        tooltip: Aktivieren Sie Lemmatize, um eingereichten Text zu lemmatisieren
+          und ein lemmatisiertes Wörterbuch für Anmerkungen zu verwenden
+      sample_text: Das Melanom ist ein bösartiger Tumor der Melanozyten, der hauptsächlich
+        in der Haut, aber auch im Darm und im Auge vorkommt.
+    lemmatize: Lemmatisieren
+    results_filtered_by: Die Ergebnisse werden gefiltert nach
+    select: Wählen Sie %{name}
+    start_typing_to_select: Beginnen Sie mit der Eingabe, um %{type} auszuwählen oder
+      lassen Sie es leer, um alle zu verwenden
+    title: Kommentator
+    umls:
+      semantic_groups: UMLS Semantische Gruppen
+      semantic_types: UMLS-Semantische Typen
+  certainty: Gewissheit
+  class: Klasse
+  clear_selection: Auswahl löschen
+  concepts:
+    request_term:
+      new_term_instructions: |
+        <p>Diese Ontologie ist in OntoloBridge integriert und ermöglicht es den Nutzern der Gemeinschaft, Ergänzungen zur öffentlichen Ontologie vorzuschlagen. Füllen Sie die nachstehende Vorlage aus, um eine Begriffsanfrage direkt an den Ontologiemanager zu senden.</p>
+          <blockquote>
+            <p>Begriffsbezeichnung (erforderlich)<br>Vorgeschlagener Begriffsname. Wenn ein Begriff mit mehr als einem Synonym beschrieben werden kann, geben Sie hier nur den bevorzugten Namen ein.</p>
+          </blockquote>
+          <blockquote>
+            <p>Begriffsbeschreibung (erforderlich)<br>Eine kurze Definition, Beschreibung oder Verwendung des vorgeschlagenen Begriffs. Synonyme von weiteren Begriffen können in diesem Abschnitt aufgeführt werden.</p>
+          </blockquote>
+          <blockquote>
+            <p>Superclass (erforderlich)<br>Der übergeordnete Begriff des vorgeschlagenen Begriffs. Der übergeordnete Begriff muss ein bestehender Eintrag in der aktuellen Ontologie sein. Die Oberklasse kann direkt aus dem Bioportal-Klassenbaum ausgewählt werden.</p>
+          </blockquote>
+          <blockquote>
+            <p>Referenzen (optional)<br>Bieten Sie Belege für die Existenz des gesuchten Begriffs, wie Pubmed IDs von Artikeln oder Links zu anderen Ressourcen, die den Begriff beschreiben.</p>
+          </blockquote>
+          <blockquote>
+            <p>Begründung (optional)<br>Geben Sie hier zusätzliche Informationen über den gesuchten Begriff an.</p>
+          </blockquote>
+  context: Kontext
+  coverage: Erfassungsbereich
+  filter: Filter
+  format_results: Ergebnisse formatieren als
+  get_json_version: Abrufen der json-Version
+  get_recommendations: Empfehlungen erhalten
+  help: Hilfe
+  home:
+    agroportal_figures: "%{site} in Zahlen:"
+    benefit1: Entdecken Sie neue Erkenntnisse und Zusammenhänge, indem Sie andere
+      Ontologien im Repository erforschen.
+    benefit2: Tragen Sie zum Wachstum und zur Entwicklung Ihres Bereichs bei, indem
+      Sie neue Konzepte und Kategorien hinzufügen.
+    benefit3: Verwenden Sie die Versionskontrolle, um die Änderungen an Ihrer Ontologie
+      im Laufe der Zeit zu verwalten und mit anderen Benutzern zusammenzuarbeiten.
+    benefit4: Holen Sie sich Feedback und Vorschläge von anderen Benutzern, die Ihre
+      Ontologie überprüfen und kommentieren können.
+    benefit5: Holen Sie sich den FAIR Score und die Metriken für Ihre Ontologie.
+    fair_details: Siehe Details
+    fairness: FAIR-Punkte
+    get_annotations: Anmerkungen erhalten
+    get_recommendations: Empfehlungen erhalten
+    index:
+      tagline: Die Heimat von Vokabularen und Ontologien in der Agrarwissenschaft
+        und verwandten Bereichen.
+      title: Willkommen bei der %{organization}
+      welcome: Willkommen auf der %{site},
+    ontology_upload: Möchten Sie eine Ontologie hochladen?
+    ontology_upload_benefits: 'Indem Sie Ihre Ontologie auf %{site} hochladen, können
+      Sie:'
+    ontology_upload_button: Ontologie hochladen
+    ontology_upload_desc: Das Hochladen einer Ontologie ist eine Möglichkeit, Ihr
+      Fachwissen mit anderen zu teilen.
+    paste_text_prompt: Einfügen eines Textabsatzes oder einiger Schlüsselwörter ...
+    recommender_annotator: Empfehlungsgeber und Kommentator
+    supported_by: Unterstützt von
+    twitter_news: Twitter-Nachrichten
+    with_collaboration: In Zusammenarbeit mit der
+  input: Eingabe
+  insert_sample_text: Beispieltext einfügen
+  keywords: Schlüsselwörter
+  keywords_separated_by_commas: Schlüsselwörter durch Kommas getrennt
+  knowledge_detail: Wissen Detail
+  landscape:
+    average_metrics: Durchschnittliche Metriken
+    category: Kategorie
+    filter_network: Netzwerk filtern
+    funding_endorsing_organizations: Organisationen, die die meisten Ontologien finanzieren
+      und befürworten
+    group: Gruppe
+    groups_and_categories: Gruppen und Kategorien
+    intro: Visualisierung von Daten, die aus im Portal gespeicherten Ontologien abgerufen
+      werden
+    more_properties_charts: Weitere Eigenschaftsdiagramme
+    most_active_ontologies: Die aktivsten Ontologien
+    most_active_organizations: Die aktivsten Organisationen
+    most_active_people: Die aktivsten Menschen
+    most_active_people_as_reviewer: Die aktivsten Personen als Gutachter
+    most_mentioned_people: Meistgenannte Personen als Kontaktperson, Ersteller, Mitwirkender
+      oder Kurator
+    most_mentioned_people_as_reviewer: Personen, die Notizen, Rezensionen und Projekte
+      veröffentlicht haben
+    ontologies_activity_on: Ontologie-Aktivität auf %{site}
+    ontologies_by: Ontologien nach %{type}
+    ontologies_contributors: Beiträge zur Ontologieentwicklung
+    ontologies_count_by_catalog: Anzahl der Ontologien in jedem Datenkatalog
+    ontologies_formats: Verwendetes Format
+    ontologies_languages: Natürliche Sprachen der Ontologien
+    ontologies_licenses: Von Ontologien verwendete Lizenzen
+    ontologies_with_notes_reviews_projects: Ontologien mit Notizen, Bewertungen und
+      Projekten
+    ontology_fairness_evaluator: Ontologie FAIRness Evaluator (O'FAIRe)
+    ontology_formality_levels: Formalitätsebenen von Ontologien
+    ontology_properties_pie_charts: Kreisdiagramme für die in Ontologien verwendeten
+      Eigenschaften
+    ontology_relations_network: Ontologie-Beziehungsnetz
+    ontology_tools: Meistgenutzte Tools zur Erstellung von Ontologien
+    owl_ontology_author_uris: URIs für Autoreneigenschaften, die für OWL-Ontologien
+      verwendet werden
+    owl_ontology_definition_uris: URIs für Definitionsmerkmale, die für OWL-Ontologien
+      verwendet werden
+    owl_ontology_preflabel_uris: URIs für prefLabel-Eigenschaften, die für OWL-Ontologien
+      verwendet werden
+    owl_ontology_synonym_uris: URIs für synonyme Eigenschaften, die für OWL-Ontologien
+      verwendet werden
+    properties_usage_proportion: Der Anteil der verwendeten Eigenschaften in den gespeicherten
+      Ontologien
+    properties_use: Nutzung der Immobilie
+    relations_between_stored_ontologies: Beziehungen zwischen gespeicherten Ontologien
+      im Portal
+    size: Größe
+    title: "%{site} Landschaft"
+  layout:
+    header:
+      account_setting: Kontoeinstellungen
+      annotator: Kommentator
+      browse: Durchsuchen
+      documentation: Dokumentation
+      help: Hilfe
+      landscape: Landschaft
+      login: Anmeldung
+      logout: abmeldung
+      mappings: Mappings
+      publications: Veröffentlichungen
+      release_notes: Anmerkungen zur Veröffentlichung
+      search_prompt: Suche in %{portal_name} ...
+      submit_feedback: Feedback senden
+      support: unterstützung
+  login:
+    enter_email: Ihre E-Mail eingeben
+    enter_password: Geben Sie Ihr Passwort ein
+    forgot_password: Passwort vergessen?
+    invalid_login: Fehler im Formular
+    no_account: Sie haben noch kein Konto?
+    password: Passwort
+    register: Register
+    title: Anmeldung
+    username_or_email: Benutzername oder E-Mail
+  mappings:
+    find_mappings: Zuordnungen einer Klasse/eines Konzepts finden
+    intro: Mappings zwischen Klassen verschiedener Ontologien durchsuchen
+    loading_mappings: Mappings laden...
+    mappings_bulk_load: Mapping Bulk Load
+    no_mappings_available: Keine Mappings verfügbar
+    title: Korrespondenzen
+    upload_mappings: Mappings hochladen
+  matched_class: Abgestimmte Klasse
+  matched_ontology: abgestimmte Ontologie
+  max_ontologies_per_set: Maximale Anzahl von Ontologien pro Satz
+  nbco_annotatosplus:
+    annotations: Anmerkungen
+    enter_paste_text_to_annotate: 'Geben Sie den zu beschriftenden Text ein oder fügen
+      Sie ihn ein:'
+    exclude_numbers: Nummern ausschließen
+    exclude_synonyms: Synonyme ausschließen
+    fast_context:
+      help: 'Aktivieren Sie FastContext, um festzustellen: ob ein Konzept verneint
+        wurde (bejaht, verneint), wer das gefundene Konzept erlebt hat (Patient, andere),
+        wann das kommentierte Konzept aufgetreten ist (kürzlich, historisch, hypothetisch)
+        und/oder ob das kommentierte Konzept unsicher ist (sicher, unsicher).'
+      title: FastContext
+    filters:
+      additional_parameters_explained_at: 'Weitere Parameter werden auf der Seite
+        erläutert:'
+      by:
+        certainty: Gewissheit
+        class: Klasse
+        experiencer: Erlebnisträger
+        filter: Filter
+        match_context: Kontext
+        match_type: Typ
+        matched_class: Assoziierte Klasse
+        matched_ontology: Assoziierte Ontologie
+        negation: Negation
+        ontology: Ontologie
+        score: Ergebnis
+        temporality: Zeitlichkeit
+        title: Die Ergebnisse werden gefiltert nach
+        umls_sem_type: UMLS-Semantischer Typ
+      confidence_threshold: Vertrauensschwelle filtern
+      confidence_threshold_help: Geben Sie die Mindestposition in der Punkteverteilung
+        an (zwischen 1 und 100)
+      format_results_as: 'Ergebnisse formatieren als:'
+      reproduce_results_using: Reproduzieren Sie diese Ergebnisse mit der
+      score_threshold: Filter nach Schwellenwert
+      score_threshold_help: Geben Sie den Mindestwert für die Bewertung von Anmerkungen
+        an
+    include_ancestors_up_to_level: Vorfahren bis zur Ebene einbeziehen
+    include_mappings: Mappings einbeziehen
+    include_score: Punktzahl einbeziehen
+    index:
+      intro: |
+        Der NCBO Annotator+ ist ein Proxy, der den NCBO Annotator Web Service auf dem NCBO BioPortal aufruft.
+           <br/><br/>
+           Tchechmedjiev, A., Abdaoui, A., Emonet, V., Melzi, S., Jonnagaddala, J., & Jonquet, C. (2018). <a href="https://doi.org/10.1093/bioinformatics/bty009" target="_blank">Enhanced features for annotating and indexing clinical text with NCBO Annotator+</a>. Bioinformatics, 34(11), 1962-1965.
+           </br><br/>
+           Wenn Sie die API verwenden, geben Sie bitte einen gültigen NCBO BioPortal API-Schlüssel an und greifen Sie auf den Dienst unter <a href="http://services.bioportal.lirmm.fr/ncbo_annotatorplus">http://services.bioportal.lirmm. de/ncbo_annotatorplus </a></br> zu
+           Der an NCBO Annotator+ übermittelte Text muss in englischer Sprache verfasst sein.
+      sample_text: Das Melanom ist ein bösartiger Tumor der Melanozyten, der hauptsächlich
+        in der Haut, aber auch im Darm und im Auge vorkommt.
+      title: NCBO Annotator +
+    insert_sample_text: Beispieltext einfügen
+    match_longest_only: Nur das längste Spiel
+    match_partial_words: Teilwörter zuordnen
+    recognizer: Erkennung von Entitäten
+    score_help: Bewertung von Anmerkungen nach der früheren NCBO 2009-Maßnahme (alt)
+      oder Bewertung von Anmerkungen nach der C-Value-Maßnahme (cvalue) oder Bewertung
+      von Anmerkungen nach der C-Value-Maßnahme mit Hierarchieerweiterung (cvalueh)
+    select: Wählen Sie %{name}
+    select_ontologies: Beginnen Sie mit der Eingabe, um Ontologien auszuwählen, oder
+      lassen Sie das Feld leer, um alle Ontologien zu verwenden
+    select_ontologies_list: Ontologien auswählen
+    show_advanced_options: Erweiterte Optionen anzeigen
+    start_typing_to_select: Beginnen Sie mit der Eingabe, um %{type} auszuwählen oder
+      lassen Sie es leer, um alle zu verwenden
+    umls:
+      semantic_groups: UMLS Semantische Gruppen
+      semantic_types: UMLS-Semantische Typen
+  negation: verneinung
+  none: keine
+  ontologies:
+    ontology_search_prompt: 'Suche nach einer Ontologie oder einem Konzept (Beispiel:
+      Agrovoc ...)'
+    self: Ontologien
+  ontology: Ontologie
+  ontology_details:
+    concept:
+      definitions: Definitionen
+      id: ID
+      in_schemes: In Schemata
+      member_of: Mitglied von
+      no_preferred_name_for_selected_language: Kein bevorzugter Name für die gewählte
+        Sprache.
+      obsolete: Veraltet
+      preferred_name: Bevorzugter Name
+      synonyms: Synonyme
+      type: Typ
+    metadata:
+      additional_metadata: Zusätzliche Metadaten
+  ontology_sets: Ontologie-Sets
+  output: Ausgabe
+  projects:
+    contacts: Kontakte
+    create_new_project: Neues Projekt erstellen
+    created: Erstellt
+    creator: Benutzer
+    delete_admin_only: Löschen (nur für Administratoren)
+    delete_confirm: Sind Sie sicher?
+    description: Beschreibung
+    description_text: Beschreibung Text
+    edit: Bearbeiten
+    home_page: Hauptseite
+    index:
+      intro: Durchsuchen Sie eine Auswahl von Projekten, die %{site} Ressourcen verwenden
+    institutions: Einrichtungen
+    ontologies: Ontologien
+    project_description: Beschreibung des Projekts
+    self: Projekte
+    title: Liste der Projekte
+    view_projects_help: Projekte anzeigen Hilfe
+  recommender:
+    intro: Empfehlungen für die relevantesten Ontologien anhand eines Auszugs aus
+      einem biomedizinischen Text oder einer Liste von Schlüsselwörtern erhalten
+    no_recommendations: Keine Empfehlungen gefunden
+    no_sets_recommended: Es gibt keine empfohlenen Ontologiesätze für die angegebene
+      Eingabe. Bitte versuchen Sie die Ausgabe 'Ontologien'.
+    ontology_recommendation_input: Bitte fügen Sie einen Textabschnitt oder einige
+      Schlüsselwörter ein, um Ontologieempfehlungen zu berechnen.
+    ontology_recommender: Ontologie-Empfehlungsprogramm
+    paste_text_recommendations: Fügen Sie einen Textabschnitt oder einige Schlüsselwörter
+      ein, die bei der Berechnung der Ontologieempfehlungen verwendet werden sollen
+    recommendation_error: Problem beim Abrufen von Empfehlungen, bitte versuchen Sie
+      es erneut
+    text_length_limit: Bitte verwenden Sie weniger als 500 Wörter. Wenn Sie längere
+      Texte kommentieren müssen, können Sie den Webdienst für Empfehlungen nutzen.
+    title: empfehlungsgeber
+    valid_integer_max_ontologies_per_set: Die maximale Anzahl von Ontologien pro Satz
+      muss ein gültiger ganzzahliger Wert sein
+    valid_max_ontologies_per_set_range: Die maximale Anzahl von Ontologien pro Satz
+      muss zwischen 2 und 4 liegen
+    valid_numeric_weights: Alle Gewichte müssen gültige numerische Werte sein
+    weight_sum_greater_than_zero: Die Summe der Gewichte muss größer als Null sein
+    weights_greater_than_zero: Alle Gewichte müssen größer als oder gleich Null sein
+  register:
+    account_errors: 'Fehler bei der Erstellung Ihres Kontos:'
+    confirm_password: Bestätigen Sie das Passwort
+    create_account: Neues Konto erstellen
+    email: E-Mail
+    first_name: Vornamen
+    last_name: Nachname
+    mailing_list: Registrieren Sie sich für die Mailingliste des AgroPortal
+    optional: "(fakultativ)"
+    password: Passwort
+    title: Register
+    username: Benutzername
+  reproduce_results: Reproduzieren Sie diese Ergebnisse mit der
+  score: Ergebnis
+  search:
+    categories: Kategorien
+    class_search: Klasse suchen
+    classes_with_definitions: Klassen mit Definitionen
+    hide_advanced_options: Erweiterte Optionen ausblenden
+    include_in_search: In die Suche einbeziehen
+    index:
+      categories_placeholder: Beginnen Sie mit der Eingabe, um Kategorien auszuwählen,
+        oder lassen Sie das Feld leer, um alle zu verwenden
+      obsolete_definition: 'Eine Klasse, die von den Autoren der Ontologie als veraltet
+        gekennzeichnet wurde und deren Verwendung nicht empfohlen wird. Diese Klassen
+        werden oft in Ontologien belassen (anstatt sie ganz zu löschen), damit bestehende
+        Systeme, die von ihnen abhängen, weiterhin funktionieren
+
+        '
+      property_definition: Eine benannte Assoziation zwischen zwei Entitäten. Beispiele
+        sind "Definition" (eine Beziehung zwischen einer Klasse und Text) und "Teil
+        von" (eine Beziehung zwischen zwei Klassen).
+      search_keywords_placeholder: Geben Sie eine Klasse ein, z. B. Melanom
+    narrow_search_to: Suche eingrenzen auf
+    obsolete_classes: Überholte Klassen
+    ontologies: Ontologien
+    ontology_views: Ontologie-Ansichten
+    property_values: Immobilienwerte
+    show_advanced_options: Erweiterte Optionen anzeigen
+    title: Suche
+    view_search_documentation: Dokumentation zur Suche anzeigen
+  select_from_list: Aus Liste auswählen
+  select_ontologies: Beginnen Sie mit der Eingabe, um Ontologien auszuwählen, oder
+    lassen Sie sie leer, um alle zu verwenden
+  select_ontologies_list: Ontologien auswählen
+  show_advanced_options: Erweiterte Optionen anzeigen
+  specialization: Spezialisierung
+  temporality: Zeitlichkeit
+  text: Text
+  type: Typ
+  umls_sem_type: UMLS Sem Typ
+  view_fair_scores_definitions: Definitionen für faire Noten anzeigen
+  visits: Besuche
+  weights_configuration: Gewichte Konfiguration

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,423 +1,5 @@
+---
 en:
-  nbco_annotatosplus:
-    score_help: "Score annotations following previous NCBO 2009 measure (old) or Score annotations following C-Value measure (cvalue) or Score annotations following C-Value measure with hierarchy expansion (cvalueh)"
-    start_typing_to_select: "Start typing to select %{type} or leave blank to use all"
-    include_ancestors_up_to_level: "Include ancestors up to level"
-    include_score: "Include score"
-
-    recognizer: "Entity recognition"
-
-    enter_paste_text_to_annotate: "Enter or paste the text to annotate:"
-
-    show_advanced_options: "Show advanced options"
-    insert_sample_text: "Insert sample text"
-    match_longest_only: "Match longest only"
-    match_partial_words: "Match partial words"
-    include_mappings: "Include mappings"
-    exclude_numbers: "Exclude numbers"
-    exclude_synonyms: "Exclude synonyms"
-    select_ontologies: "Start typing to select ontologies or leave blank to use all ontologies"
-    select_ontologies_list: "Select ontologies"
-
-    umls:
-      semantic: "UMLS Semantic"
-      semantic_types: "UMLS Semantic Types"
-      semantic_groups: "UMLS Semantic Groups"
-
-    select: "Select %{name}"
-
-    fast_context:
-      title: "FastContext"
-      help: "Activate FastContext to detect: if a concept has been negated (affirmed, negated), who experienced the concept found (patient, other), when the annotated concept occurred (recent, historical, hypothetical), and/or if the annotated concept is uncertain (certain, uncertain)."
-
-    annotations: "Annotations"
-
-    filters:
-      by:
-        filter: "Filter"
-        title: "Results are filtered by"
-        class: "Class"
-        ontology: "Ontology"
-        match_type: "Type"
-        match_context: "Context"
-        matched_class: "Associated Class"
-        matched_ontology: "Associated Ontology"
-        umls_sem_type: "UMLS Semantic Type"
-        score: "Score"
-        negation: "Negation"
-        experiencer: "Experiencer"
-        temporality: "Temporality"
-        certainty: "Certainty"
-
-      additional_parameters_explained_at: "Additional parameters are explained on the page:"
-      format_results_as: "Format results as:"
-      reproduce_results_using: "Reproduce these results using the"
-      match_longest_only: "Match longest only"
-      match_partial_words: "Recognize partial words"
-      include_mappings: "Include mappings"
-      exclude_numbers: "Exclude numbers"
-      exclude_synonyms: "Exclude synonyms"
-      max_hierarchy_level: "Include ancestors up to level"
-      score: "Include score"
-      score_help: "Score annotations according to the previous NCBO 2009 measure (old) or score annotations using the C-Value measure (cvalue) or score annotations using the C-Value measure with hierarchy expansion (cvalueh)"
-      score_threshold: "Filter by score threshold"
-      score_threshold_help: "Specify the minimum score value for annotations"
-      confidence_threshold: "Filter confidence threshold"
-      confidence_threshold_help: "Specify the minimum position in the scores distribution (between 1 and 100)"
-      entity_recognizer: "entity recognition tool"
-
-    index:
-      title: "NCBO Annotator +"
-      intro: >
-        The NCBO Annotator+ is a proxy calling the NCBO Annotator web service on the NCBO BioPortal.
-           <br/><br/>
-           Tchechmedjiev, A., Abdaoui, A., Emonet, V., Melzi, S., Jonnagaddala, J., & Jonquet, C. (2018). <a href="https://doi.org/10.1093/bioinformatics/bty009" target="_blank">Enhanced features for annotating and indexing clinical text with NCBO Annotator+</a>. Bioinformatics, 34(11), 1962-1965.
-           </br><br/>
-           If you are using the API, please provide a valid NCBO BioPortal API key and access the service at <a href="http://services.bioportal.lirmm.fr/ncbo_annotatorplus">http://services.bioportal.lirmm. en/ncbo_annotatorplus </a></br>
-           Text submitted to NCBO Annotator+ must be in English.
-      sample_text: Melanoma is a malignant tumor of melanocytes found mainly in the skin but also in the intestine and the eye.
-
-  search:
-    title: "Search"
-    class_search: "Class Search"
-    show_advanced_options: "Show Advanced Options"
-    hide_advanced_options: "Hide Advanced Options"
-    view_search_documentation: "View Search Documentation"
-    include_in_search: "Include in Search"
-    narrow_search_to: "Narrow Search to"
-    categories: "Categories"
-    property_values: "Property Values"
-    obsolete_classes: "Obsolete Classes"
-    ontology_views: "Ontology Views"
-    exact_matches: "Exact Matches"
-    classes_with_definitions: "Classes with Definitions"
-    ontologies: "Ontologies"
-    index:
-      intro: "Search for a class across multiple ontologies"
-      search_keywords_placeholder: "Enter a class, e.g. Melanoma"
-      categories_placeholder: "Start typing to select categories or leave blank to use all"
-      property_definition: "A named association between two entities. Examples are 'definition' (a relationship between a class and text) and 'part of' (a relationship between two classes)."
-      obsolete_definition: >
-        A class that the ontology authors have flagged as obsolete and recommend not to use. These classes are often left in ontologies (rather than being deleted entirely) so that existing systems that depend on them continue to function."
-
-  projects:
-    projects:
-    title: "Projects List"
-    project_description: "Project Description"
-    description_text: "Description Text"
-    view_projects_help: "View Projects Help"
-    create_new_project: "Create New Project"
-
-    self: "Projects"
-    description: "Description"
-    contacts: "Contacts"
-    institutions: "Institutions"
-    ontologies: "Ontologies"
-    creator: "User"
-    created: "Created"
-    home_page: "Home Page"
-    edit: "Edit"
-    delete_admin_only: "Delete (admin only)"
-    delete_confirm: "Are you sure?"
-
-    index:
-      intro: "Browse a selection of projects that use %{site} resources"
-
-  landscape:
-    title: "%{site} Landscape"
-    intro: Visualize data retrieved from ontologies stored in the portal
-    groups_and_categories: Groups and Categories
-    ontologies_by: "Ontologies by %{type}"
-    ontologies_count_by_catalog: Number of ontologies in each data catalog
-    properties_use: Property Usage
-    properties_usage_proportion: The proportion of properties usage among stored ontologies
-    ontologies_languages: Natural languages of ontologies
-    ontologies_licenses: Licenses used by ontologies
-    ontology_tools: Most used tools to build ontologies
-    more_properties_charts: More properties charts
-    ontology_properties_pie_charts: Pie charts for the properties used in ontologies
-    owl_ontology_preflabel_uris: URIs for prefLabel properties used for OWL ontologies
-    owl_ontology_synonym_uris: URIs for synonym properties used for OWL ontologies
-    owl_ontology_definition_uris: URIs for definition properties used for OWL ontologies
-    owl_ontology_author_uris: URIs for author properties used for OWL ontologies
-    ontology_types: Ontology types
-    ontology_formality_levels: Formality levels of ontologies
-    ontologies_formats: Format used
-    ontologies_contributors: Contributors to ontology development
-    most_active_people: Most active people
-    most_mentioned_people: Most mentioned people as contact, creator, contributor or curator
-    most_active_organizations: Most active organizations
-    funding_endorsing_organizations: Organizations funding and endorsing the most ontologies
-    ontologies_activity_on: "Ontology Activity on %{site}"
-    most_active_people_as_reviewer: "Most active people as reviewers"
-    most_mentioned_people_as_reviewer: People who published notes, reviews, and projects
-    most_active_ontologies: "Most active ontologies"
-    ontologies_with_notes_reviews_projects: "Ontologies with notes, reviews, and projects"
-    ontology_relations_network: "Ontology Relations Network"
-    relations_between_stored_ontologies: "Relations between stored ontologies in the portal"
-    filter_network: "Filter network"
-    ontology_fairness_evaluator: "Ontology FAIRness Evaluator (O’FAIRe)"
-    average_metrics: "Average metrics"
-    group: Group
-    category: Category
-    size: Size
-
-  home:
-    find_ontology: "Find an ontology"
-    search_class: "Search Class"
-    browse_by_group: "Browse by Group"
-    browse_ontologies: "Browse ontologies"
-    comprehensive_repository: "the most comprehensive repository of biomedical ontologies in the world"
-    advanced_search: "Advanced Search"
-    ontology_visits: "Ontology visits"
-    fair_scores: "FAIR Scores"
-    clear_selection: "Clear Selection"
-    latest_notes: "Latest Notes"
-    ontologies: "Ontologies"
-    classes: "Classes"
-    individuals: "People"
-    projects: "Projects"
-    users: "Users"
-    no_recent_notes: "No recent notes were submitted"
-    supported_by: "Supported by"
-    with_collaboration: "With the collaboration of"
-    index:
-      find_ontology_placeholder: Start typing the ontology name, then choose from
-      query_placeholder: Enter a class, eg Melanoma
-      tagline: The home of vocabularies and ontologies in agronomy and related fields.
-      title: Welcome to the %{organization}
-      welcome: Welcome to %{site},
-    help:
-      welcome: Welcome to the %{site} of the National Center for Biomedical Ontology. %{site} is a web application for accessing and sharing biomedical ontologies.
-      getting_started: >
-        %{site} allows users to browse, upload, download, search, comment, and create mappings for ontologies.
-      browse: >
-        Users can browse and explore individual ontologies by navigating either in a tree structure or in an animated graphical view. Users can also view mappings and
-          ontology metadata and ontology download. Additionally, logged in users can submit a new ontology to the library.
-      rest_examples_html: View documentation and examples for the <a href="http://data.bioontology.org/documentation" target="_blank">%{site} REST API</a>.
-      announce_list_html: >
-        To receive notices of new releases or site outages, please subscribe to
-        <a href="https://mailman.stanford.edu/mailman/listinfo/bioontology-support" target="_blank">bioontology support list</a>.
-
-  recommend:
-    intro: Get recommendations for the most relevant ontologies from an excerpt of a biomedical text or a list of keywords
-    title: "recommender"
-    ontology_recommender: "Ontology Recommender"
-    ontology_recommendation_input: "Please paste a paragraph of text or some keywords to compute ontology recommendations."
-    weight_sum_greater_than_zero: "The sum of weights must be greater than zero"
-    weights_greater_than_zero: "All weights must be greater than or equal to zero"
-    valid_numeric_weights: "All weights must be valid numeric values"
-    valid_integer_max_ontologies_per_set: "Max ontologies per set must be a valid integer value"
-    valid_max_ontologies_per_set_range: "Max ontologies per set must be a number between 2 and 4"
-    recommendation_error: "Problem retrieving recommendations, please try again"
-    no_recommendations: "No recommendations found"
-    no_sets_recommended: "There are no recommended ontology sets for the provided input. Please try the 'Ontologies' output."
-    text_length_limit: "Please use less than 500 words. If you need to annotate longer pieces of text, you can use the recommendation web service."
-
-  mappings:
-    title: "Correspondences"
-    upload_mappings: "Upload mappings"
-    mappings_bulk_load: "Mapping Bulk Load"
-    intro: "Browse mappings between classes of different ontologies"
-    no_mappings_available: "No mappings available"
-    loading_mappings: "Loading mappings..."
-    find_mappings: "Find mappings of a class/concept"
-    view_mappings_help: "View mappings help"
-    select_class: "Start typing to select a class"
-    select_ontologies: "Start typing to select ontologies or leave blank to use all ontologies"
-    select_semantic_types: "Select UMLS semantic types"
-    select_semantic_types_help: "Start typing to select UMLS semantic types or leave blank to use all types"
-    select_semantic_groups: "Select UMLS semantic groups"
-    select_semantic_groups_help: "Start typing to select UMLS semantic groups or leave blank to use all groups"
-    include_ancestors_up_to_level: "Include ancestors up to level"
-    include_score: "Include score"
-
-  annotator:
-    title: "Annotator"
-    get_annotator: "Get annotations"
-    filters:
-      match_longest_only: "Match longest only"
-      match_partial_words: "Recognize partial words"
-      include_mappings: "Include Mappings"
-      exclude_numbers: "Exclude Numbers"
-      exclude_synonyms: "Exclude synonyms"
-      max_hierarchy_level: "Include ancestors up to level"
-      score: "Include score"
-      score_help: "Score annotations following previous NCBO 2009 measure (old) or Score annotations following C-Value measure (cvalue) or Score annotations following C-Value measure with hierarchy expansion (cvalueh)"
-      score_threshold: "Filter by score threshold"
-      score_threshold_help: "Specify minimum score value for annotations"
-      confidence_threshold: "Filter Confidence Threshold"
-      confidence_threshold_help: "Specify the minimum position in the score distribution (between 1 and 100)"
-      recognizer recognizer: "entity recognition tool"
-    start_typing_to_select: "Start typing to select %{type} or leave blank to use all"
-    select: "Select %{name}"
-    enter_or_paste_text: "Enter or paste text to annotate"
-    fast_context: "FastContext"
-    lemmatize: "Lemmatize"
-    annotations_result: "Annotations"
-    results_filtered_by: "Results are filtered by"
-
-    umls:
-      semantic_types: "UMLS Semantic Types"
-      semantic_groups: "UMLS Semantic Groups"
-    index:
-      intro: Get annotations for biomedical text with ontology classes
-      annotatorplus_html: <em>Check out the beta version of <a href="%{annotatorplus_href}">AnnotatorPlus</a>; a new version of the Annotator with added support for negation, and more!</em>
-      fast_context:
-        tooltip: "Enable FastContext to detect: if a concept was denied (affirmed, denied), who experienced the found concept (patient, other), when the annotated concept occurred (recent, historical, hypothetical), and/ or if the annotated concept is uncertain (certain, uncertain)."
-      lemmatize:
-        tooltip: "Enable Lemmatize to lemmatize submitted text and use a lemmatized dictionary for annotations"
-      sample_text: Melanoma is a malignant tumor of melanocytes found mainly in the skin but also in the intestine and the eye.
-
-  ontology_details:
-     metadata:
-       details: "Details"
-       acronym: "Acronym"
-       visibility: "Visibility"
-       viewing_restriction: "Viewing Restriction"
-       view_of_ontology: "View of ontology"
-       description: "Description"
-       status: "Status"
-       format: "Format"
-       contact: "Contact"
-       categories: "Categories"
-       groups: "Groups"
-       pull_url: "Pull URL"
-       submissions: "Submissions"
-       links: "Links"
-       add_submission: "Add Submission"
-       views_of: "Views of"
-       create_new_view: "Create a new view"
-       no_views_of: "No views of %{name} available"
-       go_to_rest_api_json_entry: "Go to REST API JSON Entry"
-       get_my_metadata_back: "Get my metadata back"
-       n_triple: "N-Triple"
-       json_ld: "JSON-LD"
-       rdf_xml: "RDF/XML"
-       view_individual_metrics_definitions: "View individual metrics definitions"
-       metrics: "Metrics"
-       metrics_not_calculated_yet: "We have not yet calculated metrics for"
-       classes: "Classes"
-       individuals: "Individuals"
-       properties: "Properties"
-       max_depth: "Maximum depth"
-       max_children: "Maximum number of children"
-       avg_children: "Average number of children"
-       single_child_classes: "Classes with a single child"
-       many_children_classes: "Classes with more than 25 children"
-       no_definition_classes: "Classes without definition"
-       visits: "Visits"
-       download_as_csv: "Download as CSV"
-       projects_using: "Projects Using"
-       no_projects_using: "No projects are using"
-       create_new_project: "Create a new project"
-       additional_metadata: "Additional Metadata"
-
-     concept:
-       no_preferred_name_for_selected_language: "No preferred name for selected language."
-       no_synonym_name_for_selected_language: "No Synonym for selected language."
-       no_definitions_for_selected_language: "No Definitions for selected language."
-       preferred_name: "Preferred name"
-       id: "ID"
-       synonyms: "Synonyms"
-       definitions: "Definitions"
-       obsolete: "Obsolete"
-       member_of: "Member of"
-       in_schemes: "In Schemes"
-       type: "Type"
-       no_value_for_selected_language: "No value for selected language."
-  
-  layout:
-    header:
-      browse: "Browse"
-      search: "Search"
-      mappings: "Mappings"
-      recommend: "Recommend"
-      annotator: "Annotator"
-      ncbo_annotator_plus: "NCBO Annotator+"
-      projects: "Projects"
-      landscape: "Landscape"
-      login: "Login"
-      account_setting: "Account Settings"
-      submit_feedback: "Send Feedback"
-      help: "Help"
-      release_notes: "Release Notes"
-      publications: "Publications"
-    footer:
-      products: Products
-      ontoportal: OntoPortal
-      release_notes: Release Notes
-      api: API
-      sparql: SPARQL
-      support: Support
-      contact_us: Contact Us
-      wiki: Wiki
-      documentation: Documentation
-      agreements: Agreements
-      terms: Terms
-      privacy_policy: Privacy Policy
-      cite_us: Cite Us
-      acknowledgments: Acknowledgments
-      about: About
-      about_us: About Us
-      projects: Projects
-      team: Team
-      copyright_html: Copyright &copy; 2005-2022, Leland Stanford Junior University Board of Trustees. All rights reserved.
-      grant_html: >
-        <strong>%{site}</strong> is currently being developed as part of the <a href="http://www.d2kab.org">ANR D2KAB project</a> (<a href="http:/ / www.agence-nationale-recherche.fr/Projet-ANR-18-CE23-0017">ANR-18-CE23-0017</a>). It receives or has also received support from the <a href="http://www.lirmm.fr/sifr">ANR SIFR project</a> (<a href="https://anr.fr/Projet- ANR- 12-JS02-0010">ANR-12-JS02-0010</a>), European Union <a href="http://www.lirmm.fr/sifr">Project H2020-MSCA SIFRm</a > (<a href="https://cordis.europa.eu/project/id/701771">N° 701771</a>), the <a href="https://www.lirmm.fr/numev /"> Labex NUMEV</a> (ANR-10-LABX-20), the <ahref="http://www.ibc-montpellier.fr/">Montpellier IBC project</a> (ANR-11 -BINF0002) , the <a href="https://www.agropolis-fondation.fr/The-LabEx-AGRO?lang=fr">Agro Labex</a> (ANR-10-LABX-0001) as well than the University of Montpellier and the CNRS.
-    notes:
-      license_contact: >
-        For more information, email <a href="mailto:support@ontoportal.org">support@ontoportal.org</a> or
-          visit <a href="https://ontoportal.org/licensing" target="_blank">https://ontoportal.org/licensing</a>.
-      license_obtain: >
-        If you are the owner of this OntoPortal installation, you can visit
-          <a href="https://license.ontoportal.org" target="_blank">https://license.ontoportal.org</a> to obtain a license.
-      license_expired: >
-        We're sorry, but the license for this OntoPortal installation has expired. If you are the owner of this OntoPortal installation,
-         please visit <a href="https://license.ontoportal.org" target="_blank">https://license.ontoportal.org</a> to renew your license.
-      license_trial:
-        one: This OntoPortal appliance installation is a trial license, which will expire in 1 day.
-        other: This OntoPortal appliance installation is a trial license, which will expire in %{count} days.
-  # Other
-
-  about: >
-    <div class='about p-2'>
-    <h2>Summary</h2>
-    <p>
-    Many vocabularies and ontologies are produced to represent and annotate agronomic data. It is therefore necessary to have a common platform to identify them, host them and use them in agro-informatics applications. The AgroPortal project aims to provide a repository of reference ontologies for agronomy, by reusing the NCBO BioPortal technology. The scientific results and the experience of the biomedical field are thus exploited and transposed in the field of agronomy, including plants, food, the environment and possibly animal sciences. We propose an ontology portal that offers ontology hosting, search, versioning, visualization, commenting, recommendation, allows semantic annotation, as well as storing and exploiting alignments of ontologies. All this in an infrastructure fully compliant with the Semantic Web. The AgroPortal project pays particular attention to meeting the requirements of the agronomic community in terms of ontology formats (e.g. SKOS, trait dictionaries) or supported functionalities. The AgroPortal project is based on five agronomic use cases that participate in the design and orientation of the platform. AgroPortal already offers a robust and stable reference repository, of great value for the field of agronomy.
-    </p>
-    <h2>Use cases</h2>
-    <ul class="bulletlist m-3">
-    <li class="bulletlist"><a href="http://www.agrold.org">IBC Rice Genomics & AgroLD Project</a> (P. Larmande): Data integration and knowledge management related to rice</ li>
-    <li class="bulletlist"><a href="https://www.rd-alliance.org/groups/wheat-data-interoperability-wg.html">RDA Wheat Data Interoperability Working Group</a> ( E. Dzalé-Yeumo): Common framework for the publication of wheat data</li>
-    <li class="bulletlist"><a href="http://lovinra.inra.fr">LovInra: Open Vocabularies Linked Inra</a> (S. Aubin): Vocabularies produced by INRA scientists< /li>
-    <li class="bulletlist"><a href="http://www.cropontology.org">Crop Ontology Project</a> (E. Arnaud): Ontologies to describe crop germplasm and traits</li >
-    <li class="bulletlist"><a href="http://vest.agrisemantics.org">GODAN global map of agrifood data standards</a> (V. Pesce): VEST/AgroPortal MAP of standards</ li>
-    </ul>
-    <br>
-    <h2>New Features</h2>
-    <p>
-    See the <a href="https://github.com/agroportal/documentation/wiki/Release-notes">release-notes</a>
-    </p>
-    <br>
-    <h2>Partners</h2>
-    <p>The National Center for Biomedical Ontology (NCBO), the Research Institute for Development (IRD), Research Data Alliance (RDA),
-     Bioversity International, Food & Agriculture Organization (FAO), Global Open Data for Agriculture & Nutrition (Godan Action), National Institute for Agronomic Research (INRA)</p>
-    <h2>thanks</h2>
-    <p>The AgroPortail is partly produced as part of the Semantic Indexing of French Biomedical Resources project (<a href="www.lirmm.fr/sifr">SIFR</a>)
-     who have received funding from the EU H2020 research and innovation program under Marie Sklodowska-Curie (grant 701771)
-     and the National Research Agency (ANR-12-JS02-01001 grant), Labex NUMEV (ANR-10-LABX-20 grant),
-     the Institute of Computational Biology of Montpellier (grant ANR-11-BINF-0002) as well as by the University of Montpellier and the CNRS.
-     We also thank the National Center of Biomedical Ontologies for their help and the time spent with us in the deployment of the AgroPortail.</p>
-    <h2>Team</h2>
-    To contact us: firstname.lastname@lirmm.fr
-    <ul class="bulletlist m-3">
-    <li class="bulletlist"><b>Clément Jonquet</b>, researcher at LIRMM (Univ. of Montpellier, France), principal investigator of the AgroPortal project</li>
-    <li class="bulletlist"><b>Anne Toulet</b>, researcher at LIRMM (Univ. of Montpellier, France)</li>
-    <li class="bulletlist"><b>Vincent Emonet</b>, engineer at LIRMM (Univ. of Montpellier, France)</li>
-    </ul>
-    </div>
-
   activaterecord:
     errors:
       models:
@@ -428,33 +10,65 @@ en:
               no_appliance_id_for_comparison: Could not be validated. Unable to retrieve virtual appliance ID.
               appliance_id_mismatch: is an appliance id mismatch
 
-  admin:
-    licenses:
-      create:
-        success: License renewed successfully!
-
   date:
     formats:
       year_month_day_concise: "%Y-%m-%d" # 2017-03-01
       month_day_year: "%b %-d, %Y" # Mar 1, 2017
       monthfull_day_year: "%B %-d, %Y" # March 1, 2017
 
-  ontologies:
-    self: "Ontologies"
-    loading: Loading ontologies
-    intro: Browse the Ontology Library
-    please_wait: Please wait..
-    browse: Explore
-    welcome_admin: Welcome admin
-    admin_help: This color indicates features reserved for administrators
-    debug_info: Debug Info
-    submit_new_ontology: Submit a new ontology
-    entry_type: Entry Type
-    uploaded_in_the_last: Uploaded in the last
-
+  additional_parameters: 'Additional Parameters Explained at '
+  admin:
+    licenses:
+      create:
+        success: License renewed successfully!
+  all: All
+  annotator:
+    annotate_text_prompt: Enter or paste text to be annotated
+    annotations_result: Annotations
+    fast_context: FastContext
+    filters:
+      confidence_threshold: Filter Confidence Threshold
+      confidence_threshold_help: Specify the minimum position in the score distribution
+        (between 1 and 100)
+      exclude_numbers: Exclude Numbers
+      exclude_synonyms: Exclude synonyms
+      include_mappings: Include Mappings
+      match_longest_only: Match longest only
+      match_partial_words: Recognize partial words
+      max_hierarchy_level: Include ancestors up to level
+      score: Include score
+      score_help: Score annotations following previous NCBO 2009 measure (old) or
+        Score annotations following C-Value measure (cvalue) or Score annotations
+        following C-Value measure with hierarchy expansion (cvalueh)
+      score_threshold: Filter by score threshold
+      score_threshold_help: Specify minimum score value for annotations
+    get_annotator: Get annotations
+    index:
+      fast_context:
+        tooltip: 'Enable FastContext to detect: if a concept was denied (affirmed,
+          denied), who experienced the found concept (patient, other), when the annotated
+          concept occurred (recent, historical, hypothetical), and/ or if the annotated
+          concept is uncertain (certain, uncertain).'
+      intro: Get annotations for biomedical text with ontology classes
+      lemmatize:
+        tooltip: Enable Lemmatize to lemmatize submitted text and use a lemmatized
+          dictionary for annotations
+      sample_text: Melanoma is a malignant tumor of melanocytes found mainly in the
+        skin but also in the intestine and the eye.
+    lemmatize: Lemmatize
+    results_filtered_by: Results are filtered by
+    select: Select %{name}
+    start_typing_to_select: Start typing to select %{type} or leave blank to use all
+    title: Annotator
+    umls:
+      semantic_groups: UMLS Semantic Groups
+      semantic_types: UMLS Semantic Types
+  certainty: Certainty
+  class: Class
+  clear_selection: Clear Selection
   concepts:
     request_term:
-      new_term_instructions: >
+      new_term_instructions: |
         <p>This ontology integrates with OntoloBridge, allowing community users to suggest additions to the public ontology. Complete the template below to submit a term request directly to the Ontology Manager.</p>
           <blockquote>
             <p>Term label (required)<br>Suggested term name. If a term can be described with more than one synonym, enter only the preferred name here.</p>
@@ -471,93 +85,303 @@ en:
           <blockquote>
             <p>Justification (optional)<br>Provide here any additional information about the requested term.</p>
           </blockquote>
+  context: Context
+  coverage: Coverage
+  filter: Filter
+  format_results: 'Format results as '
+  get_json_version: Get the json version
+  get_recommendations: Get recommendations
+  help: Help
+  home:
+    agroportal_figures: "%{site} in figures:"
+    benefit1: Discover new insights and connections by exploring other ontologies
+      in the repository.
+    benefit2: Contribute to the growth and development of your domain by adding new
+      concepts and categories.
+    benefit3: Use version control to manage the changes to your ontology over time
+      and collaborate with other users.
+    benefit4: Get feedback and suggestions from other users who can review and comment
+      on your ontology.
+    benefit5: Get the FAIR score and metrics for your ontology.
+    fair_details: See details
+    fairness: FAIR Scores
+    get_annotations: Get annotations
+    get_recommendations: Get recommendations
+    index:
+      tagline: The home of vocabularies and ontologies in agronomy and related fields.
+      title: Welcome to the %{organization}
+      welcome: Welcome to %{site},
+    ontology_upload: Wanna upload an ontology?
+    ontology_upload_benefits: 'By uploading your ontology to %{site}, you can:'
+    ontology_upload_button: Upload ontology
+    ontology_upload_desc: Uploading an ontology is a way of sharing your domain knowledge
+      with others.
+    paste_text_prompt: Paste a paragraph of text or some keywords ...
+    recommender_annotator: Recommender and annotator
+    supported_by: Supported by
+    twitter_news: Twitter news
+    with_collaboration: With the collaboration of
+  input: Input
+  insert_sample_text: Insert sample text
+  keywords: Keywords
+  keywords_separated_by_commas: Keywords separated by commas
+  knowledge_detail: Knowledge Detail
+  landscape:
+    average_metrics: Average metrics
+    category: Category
+    filter_network: Filter network
+    funding_endorsing_organizations: Organizations funding and endorsing the most
+      ontologies
+    group: Group
+    groups_and_categories: Groups and Categories
+    intro: Visualize data retrieved from ontologies stored in the portal
+    more_properties_charts: More properties charts
+    most_active_ontologies: Most active ontologies
+    most_active_organizations: Most active organizations
+    most_active_people: Most active people
+    most_active_people_as_reviewer: Most active people as reviewers
+    most_mentioned_people: Most mentioned people as contact, creator, contributor
+      or curator
+    most_mentioned_people_as_reviewer: People who published notes, reviews, and projects
+    ontologies_activity_on: Ontology Activity on %{site}
+    ontologies_by: Ontologies by %{type}
+    ontologies_contributors: Contributors to ontology development
+    ontologies_count_by_catalog: Number of ontologies in each data catalog
+    ontologies_formats: Format used
+    ontologies_languages: Natural languages of ontologies
+    ontologies_licenses: Licenses used by ontologies
+    ontologies_with_notes_reviews_projects: Ontologies with notes, reviews, and projects
+    ontology_fairness_evaluator: Ontology FAIRness Evaluator (O’FAIRe)
+    ontology_formality_levels: Formality levels of ontologies
+    ontology_properties_pie_charts: Pie charts for the properties used in ontologies
+    ontology_relations_network: Ontology Relations Network
+    ontology_tools: Most used tools to build ontologies
+    owl_ontology_author_uris: URIs for author properties used for OWL ontologies
+    owl_ontology_definition_uris: URIs for definition properties used for OWL ontologies
+    owl_ontology_preflabel_uris: URIs for prefLabel properties used for OWL ontologies
+    owl_ontology_synonym_uris: URIs for synonym properties used for OWL ontologies
+    properties_usage_proportion: The proportion of properties usage among stored ontologies
+    properties_use: Property Usage
+    relations_between_stored_ontologies: Relations between stored ontologies in the
+      portal
+    size: Size
+    title: "%{site} Landscape"
+  layout:
+    header:
+      account_setting: Account Settings
+      annotator: Annotator
+      browse: Browse
+      documentation: Documentation
+      help: Help
+      landscape: Landscape
+      login: Login
+      logout: logout
+      mappings: Mappings
+      publications: Publications
+      release_notes: Release Notes
+      search_prompt: Search in %{portal_name} ...
+      submit_feedback: Send Feedback
+      support: support
+  login:
+    enter_email: Enter your email
+    enter_password: Enter your password
+    forgot_password: Forgot password?
+    invalid_login: Errors On Form
+    no_account: Don't have an account?
+    password: Password
+    register: Register
+    title: Login
+    username_or_email: Username or Email
+  mappings:
+    find_mappings: Find mappings of a class/concept
+    intro: Browse mappings between classes of different ontologies
+    loading_mappings: Loading mappings...
+    mappings_bulk_load: Mapping Bulk Load
+    no_mappings_available: No mappings available
+    title: Correspondences
+    upload_mappings: Upload mappings
+  matched_class: Matched class
+  matched_ontology: matched ontology
+  max_ontologies_per_set: Maximum number of ontologies per set
+  nbco_annotatosplus:
+    annotations: Annotations
+    enter_paste_text_to_annotate: 'Enter or paste the text to annotate:'
+    exclude_numbers: Exclude numbers
+    exclude_synonyms: Exclude synonyms
+    fast_context:
+      help: 'Activate FastContext to detect: if a concept has been negated (affirmed,
+        negated), who experienced the concept found (patient, other), when the annotated
+        concept occurred (recent, historical, hypothetical), and/or if the annotated
+        concept is uncertain (certain, uncertain).'
+      title: FastContext
+    filters:
+      additional_parameters_explained_at: 'Additional parameters are explained on
+        the page:'
+      by:
+        certainty: Certainty
+        class: Class
+        experiencer: Experiencer
+        filter: Filter
+        match_context: Context
+        match_type: Type
+        matched_class: Associated Class
+        matched_ontology: Associated Ontology
+        negation: Negation
+        ontology: Ontology
+        score: Score
+        temporality: Temporality
+        title: Results are filtered by
+        umls_sem_type: UMLS Semantic Type
+      confidence_threshold: Filter confidence threshold
+      confidence_threshold_help: Specify the minimum position in the scores distribution
+        (between 1 and 100)
+      format_results_as: 'Format results as:'
+      reproduce_results_using: Reproduce these results using the
+      score_threshold: Filter by score threshold
+      score_threshold_help: Specify the minimum score value for annotations
+    include_ancestors_up_to_level: Include ancestors up to level
+    include_mappings: Include mappings
+    include_score: Include score
+    index:
+      intro: |
+        The NCBO Annotator+ is a proxy calling the NCBO Annotator web service on the NCBO BioPortal.
+           <br/><br/>
+           Tchechmedjiev, A., Abdaoui, A., Emonet, V., Melzi, S., Jonnagaddala, J., & Jonquet, C. (2018). <a href="https://doi.org/10.1093/bioinformatics/bty009" target="_blank">Enhanced features for annotating and indexing clinical text with NCBO Annotator+</a>. Bioinformatics, 34(11), 1962-1965.
+           </br><br/>
+           If you are using the API, please provide a valid NCBO BioPortal API key and access the service at <a href="http://services.bioportal.lirmm.fr/ncbo_annotatorplus">http://services.bioportal.lirmm. en/ncbo_annotatorplus </a></br>
+           Text submitted to NCBO Annotator+ must be in English.
+      sample_text: Melanoma is a malignant tumor of melanocytes found mainly in the
+        skin but also in the intestine and the eye.
+      title: NCBO Annotator +
+    insert_sample_text: Insert sample text
+    match_longest_only: Match longest only
+    match_partial_words: Match partial words
+    recognizer: Entity recognition
+    score_help: Score annotations following previous NCBO 2009 measure (old) or Score
+      annotations following C-Value measure (cvalue) or Score annotations following
+      C-Value measure with hierarchy expansion (cvalueh)
+    select: Select %{name}
+    select_ontologies: Start typing to select ontologies or leave blank to use all
+      ontologies
+    select_ontologies_list: Select ontologies
+    show_advanced_options: Show advanced options
+    start_typing_to_select: Start typing to select %{type} or leave blank to use all
+    umls:
+      semantic_groups: UMLS Semantic Groups
+      semantic_types: UMLS Semantic Types
+  negation: negation
+  none: none
+  ontologies:
+    ontology_search_prompt: 'Search for an ontology or concept (Ex: Agrovoc ...)'
+    self: Ontologies
+  ontology: Ontology
+  ontology_details:
+    concept:
+      definitions: Definitions
+      id: ID
+      in_schemes: In Schemes
+      member_of: Member of
+      no_preferred_name_for_selected_language: No preferred name for selected language.
+      obsolete: Obsolete
+      preferred_name: Preferred name
+      synonyms: Synonyms
+      type: Type
+    metadata:
+      additional_metadata: Additional Metadata
+  ontology_sets: Ontology sets
+  output: Output
+  projects:
+    contacts: Contacts
+    create_new_project: Create New Project
+    created: Created
+    creator: User
+    delete_admin_only: Delete (admin only)
+    delete_confirm: Are you sure?
+    description: Description
+    description_text: Description Text
+    edit: Edit
+    home_page: Home Page
+    index:
+      intro: Browse a selection of projects that use %{site} resources
+    institutions: Institutions
+    ontologies: Ontologies
+    project_description: Project Description
+    self: Projects
+    title: Projects List
+    view_projects_help: View Projects Help
+  recommender:
+    intro: Get recommendations for the most relevant ontologies from an excerpt of
+      a biomedical text or a list of keywords
+    no_recommendations: No recommendations found
+    no_sets_recommended: There are no recommended ontology sets for the provided input.
+      Please try the 'Ontologies' output.
+    ontology_recommendation_input: Please paste a paragraph of text or some keywords
+      to compute ontology recommendations.
+    ontology_recommender: Ontology Recommender
+    paste_text_recommendations: Paste a paragraph of text or some keywords to use
+      in calculating ontology recommendations
+    recommendation_error: Problem retrieving recommendations, please try again
+    text_length_limit: Please use less than 500 words. If you need to annotate longer
+      pieces of text, you can use the recommendation web service.
+    title: recommender
+    valid_integer_max_ontologies_per_set: Max ontologies per set must be a valid integer
+      value
+    valid_max_ontologies_per_set_range: Max ontologies per set must be a number between
+      2 and 4
+    valid_numeric_weights: All weights must be valid numeric values
+    weight_sum_greater_than_zero: The sum of weights must be greater than zero
+    weights_greater_than_zero: All weights must be greater than or equal to zero
+  register:
+    account_errors: 'Errors creating your account:'
+    confirm_password: Confirm password
+    create_account: Create new account
+    email: Email
+    first_name: First name
+    last_name: Last name
+    mailing_list: Register for the AgroPortal's mailing list
+    optional: "(Optional)"
+    password: Password
+    title: Register
+    username: Username
+  reproduce_results: 'Reproduce these results using the '
+  score: Score
+  search:
+    categories: Categories
+    class_search: Class Search
+    classes_with_definitions: Classes with Definitions
+    hide_advanced_options: Hide Advanced Options
+    include_in_search: Include in Search
+    index:
+      categories_placeholder: Start typing to select categories or leave blank to
+        use all
+      obsolete_definition: 'A class that the ontology authors have flagged as obsolete
+        and recommend not to use. These classes are often left in ontologies (rather
+        than being deleted entirely) so that existing systems that depend on them
+        continue to function."
 
-  # General
-
-  showing: Display
-  of: of
-  sort: Sort
-  popular: Popular
-  name: Name
-  classes_count: Number of classes
-  instances_concepts_count: Number of instances/concepts
-  Notes: Notes
-  upload_date: Upload date
-  release_date: Release date
-  fair_score: FAIR score
-  search_rank: Search Rank
-  no_matches: No matches!
-  uploaded: Uploaded
-  view_of: View of
-  view: View
-  summary_only: Summary only
-  groups: Groups
-  categories: Categories
-  admins: Administrators
-  status: Status
-  no_submissions_available: No submissions available
-  classes: classes
-
-  category: Category
-  group: Group
-  size: size
-  ontology_content: Ontology content
-  natural_language: Natural language
-  formality_levels: Formality levels
-  is_of_type: Is of type
-  missing_status: Missing Status
-  types: Types
-  artifacts: Artifacts
-  formats: formats
-  selected_ontologies: Selected ontologies
-  all: "All"
-  none: "none"
-  keywords: "Keywords"
-  keywords_separated_by_commas: "Keywords separated by commas"
-  see_details: "See details"
-  view_fair_scores_definitions: "View fair scores definitions"
-  get_json_version: "Get the json version"
-  select_ontologies: "Start typing to select ontologies or leave blank to use them all"
-  clear_selection: "Clear Selection"
-  select_from_list: "Select from list"
-  more: "More"
-  statistics: "Statistics"
-  average: "Average"
-  min: "Min"
-  max: "Max"
-  median: "Median"
-  slices: "Slices"
-  help: "Help"
-  or: "Or"
-  show_advanced_options: "Show advanced options"
-  insert_sample_text: "Insert sample text"
-  class: "Class"
-  filter: "Filter"
-  ontology: "Ontology"
-  type: "Type"
-  context: "Context"
-  umls_sem_type: "UMLS Sem Type"
-  matched_ontology: "matched ontology"
-  matched_class: "Matched class"
-  score: "Score"
-  negation: "negation"
-  experience: "Experience"
-  temporality: "Temporality"
-  certainty: "Certainty"
-  format_results: "Format results as "
-  reproduce_results: "Reproduce these results using the "
-  additional_parameters: "Additional Parameters Explained at "
-  input: "Input"
-  text: "Text"
-  output: "Output"
-  ontology_sets: "Ontology sets"
-  insert_sample_input: "Insert sample input"
-  weights_configuration: "Weights Configuration"
-  coverage: "Coverage"
-  accept: "Accept"
-  knowledge_detail: "Knowledge Detail"
-  specialization: "Specialization"
-  max_ontologies_per_set: "Maximum number of ontologies per set"
-  paste_input_text: "Paste a paragraph of text or keywords to use in calculating ontology recommendations"
-  get_recommendations: "Get recommendations"
-  select_ontologies_list: "Select ontologies"
+        '
+      property_definition: A named association between two entities. Examples are
+        'definition' (a relationship between a class and text) and 'part of' (a relationship
+        between two classes).
+      search_keywords_placeholder: Enter a class, e.g. Melanoma
+    narrow_search_to: Narrow Search to
+    obsolete_classes: Obsolete Classes
+    ontologies: Ontologies
+    ontology_views: Ontology Views
+    property_values: Property Values
+    show_advanced_options: Show Advanced Options
+    title: Search
+    view_search_documentation: View Search Documentation
+  select_from_list: Select from list
+  select_ontologies: Start typing to select ontologies or leave blank to use them
+    all
+  select_ontologies_list: Select ontologies
+  show_advanced_options: Show advanced options
+  specialization: Specialization
+  temporality: Temporality
+  text: Text
+  type: Type
+  umls_sem_type: UMLS Sem Type
+  view_fair_scores_definitions: View fair scores definitions
+  visits: Visits
+  weights_configuration: Weights Configuration

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -1,421 +1,5 @@
+---
 fr:
-
-  nbco_annotatosplus:
-    score_help: "Annotations de score suivant la mesure NCBO 2009 précédente (ancienne) ou Annotations de score suivant la mesure C-Value (cvalue) ou Annotations de score suivant la mesure C-Value avec expansion de la hiérarchie (cvalueh)"
-    start_typing_to_select: "Commencez à taper pour sélectionner %{type} ou laissez vide pour tout utiliser"
-    include_ancestors_up_to_level: "Inclure les ancêtres jusqu'au niveau"
-    include_score: "Inclure le score"
-
-    recognizer: "Reconnaissance d'entité"
-
-    enter_paste_text_to_annotate: "Entrez ou collez le texte à annoter :"
-
-    show_advanced_options: "Afficher les options avancées"
-    insert_sample_text: "Insérer un exemple de texte"
-    match_longest_only: "Correspondance la plus longue seulement"
-    match_partial_words: "Correspondance de mots partiels"
-    include_mappings: "Inclure les correspondances"
-    exclude_numbers: "Exclure les nombres"
-    exclude_synonyms: "Exclure les synonymes"
-    select_ontologies: "Commencez à taper pour sélectionner des ontologies ou laissez vide pour utiliser toutes les ontologies"
-    select_ontologies_list: "Sélectionnez les ontologies"
-
-    umls:
-      semantic: "sémantique UMLS"
-      semantic_types: "Types sémantiques UMLS"
-      semantic_groups: "Groupes sémantiques UMLS"
-
-    select: "Sélectionnez %{name}"
-
-    fast_context:
-      title: "FastContext"
-      help: "Activer FastContext pour détecter : si un concept a été nié (affirmé, nié), qui a vécu le concept trouvé (patient, autre), quand le concept annoté s'est produit (récent, historique, hypothétique), et/ou si le concept annoté est incertain (certain, incertain)."
-
-    annotations: "Annotations"
-
-    filters:
-      by:
-        filter: "Filtrer"
-        title: "Les résultats sont filtrés par"
-        class: "Classe"
-        ontology: "Ontologie"
-        match_type: "Type"
-        match_context: "Contexte"
-        matched_class: "Classe associée"
-        matched_ontology: "Ontologie associée"
-        umls_sem_type: "Type sémantique UMLS"
-
-        score: "Score"
-        negation: "Négation"
-        experiencer: "Expérience"
-        temporality: "Temporalité"
-        certainty: "Certitude"
-
-      additional_parameters_explained_at: "Des paramètres supplémentaires sont expliqués à la page :"
-      format_results_as: "Formater les résultats en tant que :"
-      reproduce_results_using: "Reproduire ces résultats en utilisant le"
-      match_longest_only: "Correspond le plus long uniquement"
-      match_partial_words: "Reconnaître des mots partiels"
-      include_mappings: "Inclure les mappages"
-      exclude_numbers: "Exclure des numéros"
-      exclude_synonyms: "Exclure les synonymes"
-      max_hierarchy_level: "Inclure les ancêtres jusqu'au niveau"
-      score: "Inclure le score"
-      score_help: "Annotations de score suivant la mesure NCBO 2009 précédente (ancienne) ou Annotations de score suivant la mesure C-Value (cvalue) ou Annotations de score suivant la mesure C-Value avec expansion de la hiérarchie (cvalueh)"
-      score_threshold: "Filtrer par seuil de score"
-      score_threshold_help: "Spécifier la valeur de score minimum pour les annotations"
-      confidence_threshold: "Seuil de confiance du filtre"
-      confidence_threshold_help: "Spécifiez la position minimale dans la distribution des scores (entre 1 et 100)"
-      recognizer de reconnaissance: "outil de reconnaissance d'entité"
-
-    index:
-      title: "NCBO Annotator +"
-      intro: >
-        Le NCBO Annotator+ est un proxy appelant le service Web NCBO Annotator sur le NCBO BioPortal.
-          <br/><br/>
-          Tchechmedjiev, A., Abdaoui, A., Emonet, V., Melzi, S., Jonnagaddala, J., & Jonquet, C. (2018). <a href="https://doi.org/10.1093/bioinformatics/bty009" target="_blank">Fonctionnalités améliorées pour annoter et indexer le texte clinique avec NCBO Annotator+</a>. Bioinformatique, 34(11), 1962-1965.
-          </br><br/>
-          Si vous utilisez l'API, veuillez fournir une clé API NCBO BioPortal valide et accéder au service sur <a href="http://services.bioportal.lirmm.fr/ncbo_annotatorplus">http://services.bioportal.lirmm.fr/ncbo_annotatorplus </a></br>
-          Le texte soumis au NCBO Annotator+ doit être en anglais.
-      sample_text: Le mélanome est une tumeur maligne des mélanocytes qui se trouvent principalement dans la peau mais aussi dans l'intestin et l'œil.
-
-  search:
-    title: "Rechercher"
-    class_search: "Recherche de classe"
-    show_advanced_options: "Afficher les options avancées"
-    hide_advanced_options: "Masquer les options avancées"
-    view_search_documentation: "Voir la documentation de recherche"
-    include_in_search: "Inclure dans la recherche"
-    narrow_search_to: "Réduire la recherche à"
-    categories: "Catégories"
-    property_values: "Valeurs de propriété"
-    obsolete_classes: "Classes obsolètes"
-    ontology_views: "Vues d'ontologie"
-    exact_matches: " Correspondances Exactes"
-    classes_with_definitions: "Classes avec Définitions"
-    ontologies: "Ontologies"
-    index:
-      intro: Rechercher une classe dans plusieurs ontologies
-      search_keywords_placeholder: Entrez une classe, par ex. Mélanome
-      categories_placeholder: Commencez à taper pour sélectionner des catégories ou laissez vide pour tout utiliser
-      property_definition: Association nommée entre deux entités. Les exemples sont "définition" (une relation entre une classe et du texte) et "partie de" (une relation entre deux classes).
-      obsolete_definition: >
-        Une classe que les auteurs de l'ontologie ont signalée comme étant obsolète et qu'ils recommandent de ne pas utiliser. Ces cours
-        sont souvent laissés dans des ontologies (plutôt que de les supprimer entièrement) afin que les systèmes existants qui en dépendent continuent à fonctionner.
-
-  projects:
-    title: "Liste de projets"
-    project_description: "Description du projet"
-    description_text: "Texte de description"
-    view_projects_help: "Aide à la visualisation des projets"
-    create_new_project: Créer un nouveau projet
-
-    self: Projets
-    description: Description
-    contacts: Contacts
-    institutions: Institutions
-    ontologies: "Ontologies"
-    creator: "Utilisateur"
-    created: "Créé"
-    home_page: Page d'accueil
-    edit: Modifier
-    delete_admin_only: Supprimer (administrateur seulement)
-    delete_confirm: Êtes-vous sûr(e) ?
-
-    index:
-      intro: Parcourez une sélection de projets qui utilisent les ressources %{site}
-
-  landscape:
-    title: "%{site} Paysage"
-    intro: Visualiser les données récupérées à partir des ontologies stockées dans le portail
-    groups_and_categories: Groupes et catégories
-    ontologies_by: "Ontologies par %{type}"
-    ontologies_count_by_catalog: Nombre d'ontologies dans chaque catalogue de données
-    properties_use: Utilisation des propriétés
-    properties_usage_proportion: The proportion of properties usage among stored ontologies
-    ontologies_languages: Langues naturelles des ontologies
-    ontologies_licenses: Licences utilisées par les ontologies
-    ontology_tools: Outils les plus utilisés pour construire des ontologies
-
-    more_properties_charts: Plus de graphiques de propriétés
-    ontology_properties_pie_charts: Graphiques circulaires pour les propriétés utilisées dans les ontologies
-    owl_ontology_preflabel_uris: URIs de propriétés prefLabel utilisées pour les ontologies OWL
-    owl_ontology_synonym_uris: URIs de propriétés synonymes utilisées pour les ontologies OWL
-    owl_ontology_definition_uris: URIs de propriétés de définition utilisées pour les ontologies OWL
-    owl_ontology_author_uris: URIs de propriétés d'auteur utilisées pour les ontologies OWL
-
-    ontology_types: Types d'ontologie
-    ontology_formality_levels: Niveaux de formalité des ontologies
-    ontologies_formats: Format utilisé
-
-    ontologies_contributors: Contributeurs au développement d'ontologies
-
-    most_active_people: Les personnes les plus actives
-    most_mentioned_people: Les personnes les plus mentionnées en tant que contact, créateur, contributeur ou conservateur
-
-    most_active_organizations: Les organisations les plus actives
-    funding_endorsing_organizations: Les organisations qui financent et soutiennent le plus grand nombre d'ontologies
-
-    ontologies_activity_on: "Activité des ontologies sur %{site}"
-    most_active_people_as_reviewer: "Les personnes les plus actives en tant que relecteurs"
-    most_mentioned_people_as_reviewer: Personnes ayant publié des notes, des avis et des projets
-    most_active_ontologies: "Ontologies les plus actives"
-    ontologies_with_notes_reviews_projects: "Ontologies avec des notes, des critiques et des projets"
-
-    ontology_relations_network: "Réseau de relations ontologiques"
-    relations_between_stored_ontologies: "Relations entre les ontologies stockées sur le portail"
-
-    filter_network: "Filtrer le réseau"
-
-    ontology_fairness_evaluator: "Évaluateur de conformité FAIR des ontologies (O’FAIRe)"
-    average_metrics: "Métriques moyennes"
-
-    group: Groupe
-    category: Catégorie
-    size: Taille
-
-  home:
-    find_ontology: "Trouver une ontologie"
-    search_class: "Rechercher une classe"
-    browse_by_group: "Parcourir par groupe"
-    browse_ontologies: "Parcourir les ontologies"
-    comprehensive_repository: "le référentiel d'ontologies biomédicales le plus complet au monde"
-    advanced_search: "Recherche avancée"
-    ontology_visits: "Visites d'ontologie"
-    fair_scores: "Scores FAIR"
-    clear_selection: "Effacer la sélection"
-    latest_notes: "Dernières notes"
-    ontologies: "Ontologies"
-    classes: "Des classes"
-    individuals: "Personnes"
-    projects: "Projets"
-    users: "Utilisateurs"
-    no_recent_notes: "Aucune note récente n'a été soumise"
-
-    index:
-      find_ontology_placeholder: Commencez à taper le nom de l'ontologie, puis choisissez dans
-      query_placeholder: Entrez une classe, par exemple Melanoma
-      tagline: le référentiel d'ontologies biomédicales le plus complet au monde
-      title: Bienvenue à la %{organization}
-      welcome: Bienvenue à la %{site},
-    help:
-      welcome: Bienvenue à la le %{site} du Centre national d'ontologie biomédicale. %{site} est une application Web permettant d'accéder et de partager des ontologies biomédicales.
-      getting_started: >
-        %{site} permet aux utilisateurs de parcourir, charger, télécharger, rechercher, commenter et créer des mappages pour les ontologies.
-      browse: >
-        Les utilisateurs peuvent parcourir et explorer des ontologies individuelles en naviguant soit dans une structure arborescente, soit dans une vue graphique animée. Les utilisateurs peuvent également afficher les mappages et
-          métadonnées d'ontologie et téléchargement d'ontologies. De plus, les utilisateurs connectés peuvent soumettre une nouvelle ontologie à la bibliothèque.
-      rest_examples_html: affichez la documentation et des exemples de l'<a href="http://data.bioontology.org/documentation" target="_blank">%{site} API REST</a>.
-      announce_list_html: >
-        Pour recevoir des avis de nouvelles versions ou de pannes de site, veuillez vous abonner au
-        <a href="https://mailman.stanford.edu/mailman/listinfo/bioontology-support" target="_blank">liste de support bioontologie</a>.
-
-  recommender:
-    intro: Obtenez des recommandations pour les ontologies les plus pertinentes à partir d'un extrait d'un texte biomédical ou d'une liste de mots-clés
-    title: "recommandeur"
-    ontology_recommender: "Recommandeur d'ontologie"
-    ontology_recommendation_input: "Veuillez coller un paragraphe de texte ou quelques mots-clés pour calculer les recommandations d'ontologie."
-    weight_sum_greater_than_zero: "La somme des poids doit être supérieure à zéro"
-    weights_greater_than_zero: "Tous les poids doivent être supérieurs ou égaux à zéro"
-    valid_numeric_weights: "Tous les poids doivent être des valeurs numériques valides"
-    valid_integer_max_ontologies_per_set: "Le nombre maximum d'ontologies par ensemble doit être une valeur entière valide"
-    valid_max_ontologies_per_set_range: "Le nombre maximum d'ontologies par ensemble doit être un nombre entre 2 et 4"
-    recommendation_error: "Problème lors de la récupération des recommandations, veuillez réessayer"
-    no_recommendations: "Aucune recommandation trouvée"
-    no_sets_recommended: "Il n'y a pas d'ensembles d'ontologies recommandés pour l'entrée fournie. Veuillez essayer la sortie 'Ontologies'."
-    text_length_limit: "Veuillez utiliser moins de 500 mots. Si vous devez annoter de plus grands morceaux de texte, vous pouvez utiliser le service web de recommandation."
-
-  mappings:
-    title: "Correspondances"
-    upload_mappings: "Télécharger les correspondances"
-    mappings_bulk_load: "Chargement en masse des correspondances"
-    intro: "Parcourir les correspondances entre les classes de différentes ontologies"
-    no_mappings_available: "Aucune correspondance disponible"
-    loading_mappings: "Chargement des correspondances en cours..."
-    find_mappings: "Trouver les correspondances d'une classe / concept"
-    view_mappings_help: "View mappings help"
-    select_class: "Commencez à taper pour sélectionner une classe"
-    select_ontologies: "Commencez à taper pour sélectionner des ontologies ou laissez vide pour utiliser toutes les ontologies"
-    select_semantic_types: "Sélectionnez les types sémantiques UMLS"
-    select_semantic_types_help: "Commencez à taper pour sélectionner les types sémantiques UMLS ou laissez vide pour utiliser tous les types"
-    select_semantic_groups: "Sélectionnez les groupes sémantiques UMLS"
-    select_semantic_groups_help: "Commencez à taper pour sélectionner les groupes sémantiques UMLS ou laissez vide pour utiliser tous les groupes"
-    include_ancestors_up_to_level: "Inclure les ancêtres jusqu'au niveau"
-    include_score: "Inclure le score"
-
-  annotator:
-    title: "Annotateur"
-    get_annotator: "Obtenir les annotations"
-    filters:
-      match_longest_only: "Correspond le plus long uniquement"
-      match_partial_words: "Reconnaître des mots partiels"
-      include_mappings: "Inclure les mappages"
-      exclude_numbers: "Exclure des numéros"
-      exclude_synonyms: "Exclure les synonymes"
-      max_hierarchy_level: "Inclure les ancêtres jusqu'au niveau"
-      score: "Inclure le score"
-      score_help: "Annotations de score suivant la mesure NCBO 2009 précédente (ancienne) ou Annotations de score suivant la mesure C-Value (cvalue) ou Annotations de score suivant la mesure C-Value avec expansion de la hiérarchie (cvalueh)"
-      score_threshold: "Filtrer par seuil de score"
-      score_threshold_help: "Spécifier la valeur de score minimum pour les annotations"
-      confidence_threshold: "Seuil de confiance du filtre"
-      confidence_threshold_help: "Spécifiez la position minimale dans la distribution des scores (entre 1 et 100)"
-      recognizer de reconnaissance: "outil de reconnaissance d'entité"
-    start_typing_to_select: "Commencez à taper pour sélectionner %{type} ou laissez vide pour tout utiliser"
-    select: "Sélectionnez %{name}"
-    enter_or_paste_text: "Entrer ou coller le texte à annoter"
-    fast_context: "FastContext"
-    lemmatize: "Lemmatiser"
-    annotations_result: "Annotations"
-    results_filtered_by: "Les résultats sont filtrés par"
-
-    umls:
-      semantic_types: "Types sémantiques UMLS"
-      semantic_groups: "Groupes sémantiques UMLS"
-    index:
-      intro: Obtenez des annotations pour le texte biomédical avec des classes des ontologies
-      annotatorplus_html: <em>Consultez la version bêta d'<a href="%{annotatorplus_href}">AnnotatorPlus</a> ; une nouvelle version de l'Annotator avec un support supplémentaire pour la négation, et plus encore !</em>
-      fast_context:
-        tooltip: "Activer FastContext pour détecter : si un concept a été nié (affirmé, nié), qui a vécu le concept trouvé (patient, autre), quand le concept annoté s'est produit (récent, historique, hypothétique), et/ou si le concept annoté est incertain (certain, incertain)."
-      lemmatize:
-        tooltip: "Activez Lemmatize pour lemmatiser le texte soumis et utiliser un dictionnaire lemmatisé pour les annotations"
-      sample_text: Le mélanome est une tumeur maligne des mélanocytes qui se trouvent principalement dans la peau mais aussi dans l'intestin et l'œil.
-
-  ontology_details:
-    metadata:
-      details: "Détails"
-      acronym: "Acronym"
-      visibility: "Visibilité"
-      viewing_restriction: "Restriction de visualisation"
-      view_of_ontology: "Vue de l'ontologie"
-      description: "Description"
-      status: "Statut"
-      format: "Format"
-      contact: "Contact"
-      categories: "Catégories"
-      groups: "Groupes"
-      pull_url: "URL de pull"
-      submissions: "Soumissions"
-      links: "Liens"
-      add_submission: "Ajouter une soumission"
-      views_of: "Vues de"
-      create_new_view: "Créer une nouvelle vue"
-      no_views_of: "Aucune vue de %{name} disponible"
-      go_to_rest_api_json_entry: "Accéder à l'entrée JSON de l'API REST"
-      get_my_metadata_back: "Récupérer mes métadonnées"
-      n_triple: "N-Triple"
-      json_ld: "JSON-LD"
-      rdf_xml: "RDF/XML"
-      view_individual_metrics_definitions: "Voir les définitions de métriques individuelles"
-      metrics: "Métriques"
-      metrics_not_calculated_yet: "Nous n'avons pas encore calculé de métriques pour"
-      classes: "Classes"
-      individuals: "Individus"
-      properties: "Propriétés"
-      max_depth: "Profondeur maximale"
-      max_children: "Nombre maximum d'enfants"
-      avg_children: "Nombre moyen d'enfants"
-      single_child_classes: "Classes avec un seul enfant"
-      many_children_classes: "Classes avec plus de 25 enfants"
-      no_definition_classes: "Classes sans définition"
-      visits: "Visites"
-      download_as_csv: "Télécharger en CSV"
-      projects_using: "Projets utilisant"
-      no_projects_using: "Aucun projet n'utilise"
-      create_new_project: "Créer un nouveau projet"
-      additional_metadata: "Métadonnées supplémentaires"
-
-    concept: 
-      no_preferred_name_for_selected_language: "Pas de nom préféré pour la langue sélectionnée."
-      no_synonym_name_for_selected_language : "Aucun synonyme pour la langue sélectionnée."
-      no_definitions_for_selected_language : "Aucune définition pour la langue sélectionnée."
-      preferred_name: "Nom préféré"
-      id: "Identifiant"
-      synonyms: "Synonymes"
-      definitions: "Définitions"
-      obsolete: "Obsolète"
-      member_of: "Membre de"
-      in_schemes: "Dans les schémas"
-      type: "Type"
-      no_value_for_selected_language: "Pas de valeur pour la langue sélectionnée."
-
-
-
-  
-  layout:
-    header:
-      browse: "Parcourir"
-      search: "Rechercher"
-      mappings: "Mappings"
-      recommender: "Recommender"
-      annotator: "Annotateur"
-      ncbo_annotator_plus: "NCBO Annotator+"
-      projects: "Projets"
-      landscape: "Paysage"
-      login: "Se connecter"
-      account_setting: "Paramètres du compte"
-      submit_feedback: "Envoyer un commentaire"
-      help: "Aide"
-      release_notes: "Notes de version"
-      publications: "Publications"
-    footer:
-      products: "Produits"
-      copyright_html: Droit d'auteur &copie; 2005‑2022, Conseil d'administration de l'Université Leland Stanford Junior. Tous les droits sont réservés.
-      grant_html: >
-        <strong>%{site}</strong> est actuellement développé dans le cadre du <a href="http://www.d2kab.org">projet ANR D2KAB</a> (<a href="http:// www.agence-nationale-recherche.fr/Projet-ANR-18-CE23-0017">ANR-18-CE23-0017</a>). Il reçoit ou a également reçu le soutien du <a href="http://www.lirmm.fr/sifr">projet ANR SIFR</a> (<a href="https://anr.fr/Projet-ANR- 12-JS02-0010">ANR-12-JS02-0010</a>), Union Européenne <a href="http://www.lirmm.fr/sifr">Projet H2020-MSCA SIFRm</a> ( <a href="https://cordis.europa.eu/project/id/701771">N° 701771</a>), le <a href="https://www.lirmm.fr/numev/"> Labex NUMEV</a> (ANR-10-LABX-20), le <ahref="http://www.ibc-montpellier.fr/">projet IBC de Montpellier</a> (ANR-11-BINF0002) , l'<a href="https://www.agropolis-fondation.fr/The-LabEx-AGRO?lang=fr">Agro Labex</a> (ANR-10-LABX-0001) ainsi que de l'Université de Montpellier et du CNRS.
-    notices:
-      license_contact: >
-        Pour plus d'informations, envoyez un e-mail à <a href="mailto:support@ontoportal.org">support@ontoportal.org</a> ou
-          visitez <a href="https://ontoportal.org/licensing" target="_blank">https://ontoportal.org/licensing</a>.
-      license_obtain: >
-        Si vous êtes le propriétaire de cette installation OntoPortal, vous pouvez visiter
-          <a href="https://license.ontoportal.org" target="_blank">https://license.ontoportal.org</a> pour obtenir une licence.
-      license_expired: >
-        Nous sommes désolés, mais la licence pour cette installation d'OntoPortal a expiré. Si vous êtes le propriétaire de cette installation OntoPortal,
-         veuillez visiter <a href="https://license.ontoportal.org" target="_blank">https://license.ontoportal.org</a> pour renouveler votre licence.
-      license_trial:
-        one: Cette installation de l'appliance OntoPortal est une licence d'essai, qui expirera dans 1 jour.
-        other: Cette installation de l'appliance OntoPortal est une licence d'essai, qui expirera dans %{count} jours.
-
-  # Other
-
-  about: >
-    <div class='about p-2'>
-    <h2>Résumé</h2>
-    <p>
-    De nombreux vocabulaires et ontologies sont produits pour représenter et annoter les données agronomiques. Il est donc nécessaire de disposer d'une plateforme commune pour les identifier, les héberger et les utiliser dans les applications d'agro-informatique. Le projet AgroPortal vise à offrir un référentiel d'ontologies de référence pour l'agronomie, en réutilisant la technologie NCBO BioPortal. Les résultats scientifiques et l'expérience du domaine biomédical sont ainsi exploités et transposés dans le domaine de l'agronomie, comprenant les plantes, l'alimentation, l'environnement et éventuellement les sciences animales. Nous proposons un portail d'ontologies qui offre l'hébergement d'ontologies, la recherche, la versioning, la visualisation, le commentaire, la recommandation, permet l'annotation sémantique, ainsi que le stockage et l'exploitation d'alignements d'ontologies. Tout cela dans une infrastructure totalement conforme au web sémantique. Le projet AgroPortal accorde une attention particulière au respect des exigences de la communauté agronomique en termes de formats d'ontologies (par exemple, SKOS, dictionnaires de traits) ou de fonctionnalités prises en charge. Le projet AgroPortal est basé sur cinq cas d'utilisation agronomique qui participent à la conception et à l'orientation de la plateforme. AgroPortal offre déjà un référentiel de référence robuste et stable, d'une grande valeur pour le domaine de l'agronomie.
-    </p>
-    <h2>Use cases</h2>
-    <ul class="bulletlist m-3">
-    <li class="bulletlist"><a href="http://www.agrold.org">Projet IBC Rice Genomics & AgroLD</a> (P. Larmande): Data integration and knowledge management related to rice</li>
-    <li class="bulletlist"><a href="https://www.rd-alliance.org/groups/wheat-data-interoperability-wg.html">Groupe de travail RDA Wheat Data Interoperability</a> (E. Dzalé-Yeumo) : Cadre commun de publication des données blé</li>
-    <li class="bulletlist"><a href="http://lovinra.inra.fr">LovInra : Vocabulaires Ouverts Liés Inra</a> (S. Aubin) : Vocabulaires produits par des scientifiques de l'INRA</li>
-    <li class="bulletlist"><a href="http://www.cropontology.org">Projet Crop Ontology</a> (E. Arnaud) : Ontologies pour décrire le germoplasme et les caractères des cultures</li>
-    <li class="bulletlist"><a href="http://vest.agrisemantics.org">GODAN carte mondiale des normes de données agroalimentaires</a> (V. Pesce) : VEST/AgroPortal MAP of standards</li>
-    </ul>
-    <br>
-    <h2>Nouvelles fonctionnalités</h2>
-    <p>
-    See the <a href="https://github.com/agroportal/documentation/wiki/Release-notes">notes de version</a>
-    </p>
-    <br>
-    <h2>Les partenaires</h2>
-    <p>Le Centre National d'Ontologie Biomédicale (NCBO), l'Institut de Recherche pour le Développement (IRD), Research Data Alliance (RDA),
-     Bioversity International, Food & Agriculture Organization (FAO), Global Open Data for Agriculture & Nutrition (Godan Action), Institut National de la Recherche Agronomique (INRA)</p>
-    <h2>remerciements</h2>
-    <p>L'AgroPortail est en partie réalisé dans le cadre du projet d'Indexation Sémantique des Ressources Biomédicales Françaises (<a href="www.lirmm.fr/sifr">SIFR</a>)
-     qui ont reçu un financement du programme de recherche et d'innovation H2020 de l'UE dans le cadre de Marie Sklodowska-Curie (subvention 701771)
-     et l'Agence Nationale de la Recherche (bourse ANR-12-JS02-01001), le Labex NUMEV (bourse ANR-10-LABX-20),
-     l'Institut de Biologie Computationnelle de Montpellier (bourse ANR-11-BINF-0002) ainsi que par l'Université de Montpellier et le CNRS.
-     Nous remercions également le Centre National des Ontologies Biomédicales pour son aide et le temps passé avec nous dans le déploiement de l'AgroPortail.</p>
-    <h2>Équipe</h2>
-    Pour nous contacter: firstname.lastname@lirmm.fr
-    <ul class="bulletlist m-3">
-    <li class="bulletlist"><b>Clément Jonquet</b>,chercheur au LIRMM (Univ. de Montpellier, France), investigateur principal du projet AgroPortal</li>
-    <li class="bulletlist"><b>Anne Toulet</b>, chercheuse au LIRMM (Univ. de Montpellier, France)</li>
-    <li class="bulletlist"><b>Vincent Emonet</b>, ingénieur au LIRMM (Univ. de Montpellier, France)</li>
-    </ul>
-    </div>
-
   activerecord:
     errors:
       models:
@@ -425,34 +9,68 @@ fr:
               invalid_license_key: est une clé de licence invalide
               no_appliance_id_for_comparison: n'a pas pu être validé. Impossible de récupérer l'ID de l'appliance virtuelle.
               appliance_id_mismatch: est une non-concordance d'ID d'appliance
-
-  admin:
-    licenses:
-      create:
-        success: Licence renouvelée avec succès !
-
   date:
     formats:
       year_month_day_concise: "%Y-%m-%d" # 2017-03-01
       month_day_year: "%b %-d, %Y" # Mar 1, 2017
-      monthfull_day_year: "%B %-d, %Y" # March 1, 2017
-  
-  ontologies:
-    self: "Ontologies"
-    loading: Chargement des ontologies
-    intro: Parcourir la bibliothèque d'ontologies
-    please_wait: S'il vous plaît, attendez..
-    browse: Explorer
-    welcome_admin: Bienvenue admin
-    admin_help: Cette couleur indique les fonctionnalités réservées aux administrateurs
-    debug_info: Informations de débogage
-    submit_new_ontology: Soumettre une nouvelle ontologie
-    entry_type: Type d'entrée
-    uploaded_in_the_last: Téléchargé dans les derniers
+      monthfull_day_year: "%B %-d, %Y" # March 1, 201
 
+  acceptance: Acceptation
+  additional_parameters: 'Paramètres supplémentaires expliqués à '
+  admin:
+    licenses:
+      create:
+        success: Licence renouvelée avec succès !
+  all: Tout
+  annotator:
+    annotate_text_prompt: Saisissez ou collez le texte à annoter
+    annotations_result: Annotations
+    fast_context: FastContext
+    filters:
+      confidence_threshold: Seuil de confiance du filtre
+      confidence_threshold_help: Spécifiez la position minimale dans la distribution
+        des scores (entre 1 et 100)
+      exclude_numbers: Exclure des numéros
+      exclude_synonyms: Exclure les synonymes
+      include_mappings: Inclure les mappages
+      match_longest_only: Correspond le plus long uniquement
+      match_partial_words: Reconnaître des mots partiels
+      max_hierarchy_level: Inclure les ancêtres jusqu'au niveau
+      score: Inclure le score
+      score_help: Annotations de score suivant la mesure NCBO 2009 précédente (ancienne)
+        ou Annotations de score suivant la mesure C-Value (cvalue) ou Annotations
+        de score suivant la mesure C-Value avec expansion de la hiérarchie (cvalueh)
+      score_threshold: Filtrer par seuil de score
+      score_threshold_help: Spécifier la valeur de score minimum pour les annotations
+    get_annotator: Obtenir les annotations
+    index:
+      fast_context:
+        tooltip: 'Activer FastContext pour détecter : si un concept a été nié (affirmé,
+          nié), qui a vécu le concept trouvé (patient, autre), quand le concept annoté
+          s''est produit (récent, historique, hypothétique), et/ou si le concept annoté
+          est incertain (certain, incertain).'
+      intro: Obtenez des annotations pour le texte biomédical avec des classes des
+        ontologies
+      lemmatize:
+        tooltip: Activez Lemmatize pour lemmatiser le texte soumis et utiliser un
+          dictionnaire lemmatisé pour les annotations
+      sample_text: Le mélanome est une tumeur maligne des mélanocytes qui se trouvent
+        principalement dans la peau mais aussi dans l'intestin et l'œil.
+    lemmatize: Lemmatiser
+    results_filtered_by: Les résultats sont filtrés par
+    select: Sélectionnez %{name}
+    start_typing_to_select: Commencez à taper pour sélectionner %{type} ou laissez
+      vide pour tout utiliser
+    title: Annotateur
+    umls:
+      semantic_groups: Groupes sémantiques UMLS
+      semantic_types: Types sémantiques UMLS
+  certainty: Certitude
+  class: Classe
+  clear_selection: Effacer la sélection
   concepts:
     request_term:
-      new_term_instructions: >
+      new_term_instructions: |
         <p>Cette ontologie s'intègre à OntoloBridge, permettant aux utilisateurs de la communauté de suggérer des ajouts à l'ontologie publique. Remplissez le modèle ci-dessous pour soumettre une demande de terme directement au responsable de l'ontologie.</p>
           <blockquote>
             <p>Libellé du terme (obligatoire)<br>Nom du terme suggéré. Si un terme peut être décrit avec plusieurs synonymes, n'indiquez ici que le nom préféré.</p>
@@ -469,94 +87,316 @@ fr:
           <blockquote>
             <p>Justification (facultatif)<br>Fournissez ici toute information supplémentaire sur le terme demandé.</p>
           </blockquote>
+  context: Contexte
+  coverage: Couverture
+  experiencer: Experiencer
+  filter: Filtre
+  format_results: 'Formater les résultats en '
+  get_json_version: Get the json version
+  get_recommendations: Obtenir des recommandations
+  help: Aide
+  home:
+    agroportal_figures: "%{site} en chiffres:"
+    benefit1: Découvrez de nouvelles perspectives et connexions en explorant d'autres
+      ontologies dans le référentiel.
+    benefit2: Contribuez à la croissance et au développement de votre domaine en ajoutant
+      de nouveaux concepts et catégories.
+    benefit3: Utilisez le contrôle de version pour gérer les modifications apportées
+      à votre ontologie au fil du temps et collaborer avec d'autres utilisateurs.
+    benefit4: Obtenez des commentaires et des suggestions d'autres utilisateurs qui
+      peuvent examiner et commenter votre ontologie.
+    benefit5: Obtenez le score et les mesures FAIR pour votre ontologie.
+    fair_details: Voir les détails
+    fairness: Scores FAIR
+    get_annotations: Obtenir des annotations
+    get_recommendations: Obtenir des recommandations
+    index:
+      tagline: le référentiel d'ontologies biomédicales le plus complet au monde
+      title: Bienvenue à la %{organization}
+      welcome: Bienvenue à la %{site},
+    ontology_upload: Veux-tu télécharger une ontologie ?
+    ontology_upload_benefits: 'En téléchargeant votre ontologie sur %{site}, vous
+      pouvez :'
+    ontology_upload_button: Télécharger une ontologie
+    ontology_upload_desc: Télécharger une ontologie est un moyen de partager vos connaissances
+      du domaine avec les autres.
+    paste_text_prompt: Collez un paragraphe de texte ou quelques mots-clés..
+    recommender_annotator: Recommandateur et annotateur
+    supported_by: Soutenu par
+    twitter_news: Actualités twitter
+    with_collaboration: Avec la collaboration de
+  input: Entrée
+  insert_sample_text: Insérer un exemple de texte
+  keywords: Mots-clés
+  keywords_separated_by_commas: Mots-clés séparés par des virgules
+  knowledge_detail: Détail de la connaissance
+  landscape:
+    average_metrics: Métriques moyennes
+    category: Catégorie
+    filter_network: Filtrer le réseau
+    funding_endorsing_organizations: Les organisations qui financent et soutiennent
+      le plus grand nombre d'ontologies
+    group: Groupe
+    groups_and_categories: Groupes et catégories
+    intro: Visualiser les données récupérées à partir des ontologies stockées dans
+      le portail
+    more_properties_charts: Plus de graphiques de propriétés
+    most_active_ontologies: Ontologies les plus actives
+    most_active_organizations: Les organisations les plus actives
+    most_active_people: Les personnes les plus actives
+    most_active_people_as_reviewer: Les personnes les plus actives en tant que relecteurs
+    most_mentioned_people: Les personnes les plus mentionnées en tant que contact,
+      créateur, contributeur ou conservateur
+    most_mentioned_people_as_reviewer: Personnes ayant publié des notes, des avis
+      et des projets
+    ontologies_activity_on: Activité des ontologies sur %{site}
+    ontologies_by: Ontologies par %{type}
+    ontologies_contributors: Contributeurs au développement d'ontologies
+    ontologies_count_by_catalog: Nombre d'ontologies dans chaque catalogue de données
+    ontologies_formats: Format utilisé
+    ontologies_languages: Langues naturelles des ontologies
+    ontologies_licenses: Licences utilisées par les ontologies
+    ontologies_with_notes_reviews_projects: Ontologies avec des notes, des critiques
+      et des projets
+    ontology_fairness_evaluator: Évaluateur de conformité FAIR des ontologies (O’FAIRe)
+    ontology_formality_levels: Niveaux de formalité des ontologies
+    ontology_properties_pie_charts: Graphiques circulaires pour les propriétés utilisées
+      dans les ontologies
+    ontology_relations_network: Réseau de relations ontologiques
+    ontology_tools: Outils les plus utilisés pour construire des ontologies
+    owl_ontology_author_uris: URIs de propriétés d'auteur utilisées pour les ontologies
+      OWL
+    owl_ontology_definition_uris: URIs de propriétés de définition utilisées pour
+      les ontologies OWL
+    owl_ontology_preflabel_uris: URIs de propriétés prefLabel utilisées pour les ontologies
+      OWL
+    owl_ontology_synonym_uris: URIs de propriétés synonymes utilisées pour les ontologies
+      OWL
+    properties_usage_proportion: The proportion of properties usage among stored ontologies
+    properties_use: Utilisation des propriétés
+    relations_between_stored_ontologies: Relations entre les ontologies stockées sur
+      le portail
+    size: Taille
+    title: "%{site} Paysage"
+  layout:
+    header:
+      account_setting: Paramètres du compte
+      annotator: Annotateur
+      browse: Parcourir
+      documentation: Documentation
+      help: Aide
+      landscape: Paysage
+      login: Connexion
+      logout: Déconnecter
+      mappings: Mappings
+      publications: Publications
+      recommender: Recommender
+      release_notes: Notes de version
+      search_prompt: Rechercher dans %{portal_name} ...
+      submit_feedback: Envoyer un commentaire
+      support: assistance
+  login:
+    enter_email: Saisissez votre email
+    enter_password: Saisissez votre mot de passe
+    forgot_password: Mot de passe oublié ?
+    invalid_login: Erreurs sur le formulaire
+    no_account: Vous n'avez pas de compte ?
+    password: Mot de passe
+    register: S'inscrire
+    title: Connexion
+    username_or_email: Nom d'utilisateur ou Email
+  mappings:
+    find_mappings: Trouver les correspondances d'une classe / concept
+    intro: Parcourir les correspondances entre les classes de différentes ontologies
+    loading_mappings: Chargement des correspondances en cours...
+    mappings_bulk_load: Chargement en masse des correspondances
+    no_mappings_available: Aucune correspondance disponible
+    title: Correspondances
+    upload_mappings: Télécharger les correspondances
+  matched_class: Classe correspondante
+  matched_ontology: ontologie correspondante
+  max_ontologies_per_set: Nombre maximum d'ontologies par ensemble
+  nbco_annotatosplus:
+    annotations: Annotations
+    enter_paste_text_to_annotate: 'Entrez ou collez le texte à annoter :'
+    exclude_numbers: Exclure les nombres
+    exclude_synonyms: Exclure les synonymes
+    fast_context:
+      help: 'Activer FastContext pour détecter : si un concept a été nié (affirmé,
+        nié), qui a vécu le concept trouvé (patient, autre), quand le concept annoté
+        s''est produit (récent, historique, hypothétique), et/ou si le concept annoté
+        est incertain (certain, incertain).'
+      title: FastContext
+    filters:
+      additional_parameters_explained_at: 'Des paramètres supplémentaires sont expliqués
+        à la page :'
+      by:
+        certainty: Certitude
+        class: Classe
+        experiencer: Expérience
+        filter: Filtrer
+        match_context: Contexte
+        match_type: Type
+        matched_class: Classe associée
+        matched_ontology: Ontologie associée
+        negation: Négation
+        ontology: Ontologie
+        score: Score
+        temporality: Temporalité
+        title: Les résultats sont filtrés par
+        umls_sem_type: Type sémantique UMLS
+      confidence_threshold: Seuil de confiance du filtre
+      confidence_threshold_help: Spécifiez la position minimale dans la distribution
+        des scores (entre 1 et 100)
+      format_results_as: 'Formater les résultats en tant que :'
+      reproduce_results_using: Reproduire ces résultats en utilisant le
+      score_threshold: Filtrer par seuil de score
+      score_threshold_help: Spécifier la valeur de score minimum pour les annotations
+    include_ancestors_up_to_level: Inclure les ancêtres jusqu'au niveau
+    include_mappings: Inclure les correspondances
+    include_score: Inclure le score
+    index:
+      intro: |
+        Le NCBO Annotator+ est un proxy appelant le service Web NCBO Annotator sur le NCBO BioPortal.
+          <br/><br/>
+          Tchechmedjiev, A., Abdaoui, A., Emonet, V., Melzi, S., Jonnagaddala, J., & Jonquet, C. (2018). <a href="https://doi.org/10.1093/bioinformatics/bty009" target="_blank">Fonctionnalités améliorées pour annoter et indexer le texte clinique avec NCBO Annotator+</a>. Bioinformatique, 34(11), 1962-1965.
+          </br><br/>
+          Si vous utilisez l'API, veuillez fournir une clé API NCBO BioPortal valide et accéder au service sur <a href="http://services.bioportal.lirmm.fr/ncbo_annotatorplus">http://services.bioportal.lirmm.fr/ncbo_annotatorplus </a></br>
+          Le texte soumis au NCBO Annotator+ doit être en anglais.
+      sample_text: Le mélanome est une tumeur maligne des mélanocytes qui se trouvent
+        principalement dans la peau mais aussi dans l'intestin et l'œil.
+      title: NCBO Annotator +
+    insert_sample_text: Insérer un exemple de texte
+    match_longest_only: Correspondance la plus longue seulement
+    match_partial_words: Correspondance de mots partiels
+    recognizer: Reconnaissance d'entité
+    score_help: Annotations de score suivant la mesure NCBO 2009 précédente (ancienne)
+      ou Annotations de score suivant la mesure C-Value (cvalue) ou Annotations de
+      score suivant la mesure C-Value avec expansion de la hiérarchie (cvalueh)
+    select: Sélectionnez %{name}
+    select_ontologies: Commencez à taper pour sélectionner des ontologies ou laissez
+      vide pour utiliser toutes les ontologies
+    select_ontologies_list: Sélectionnez les ontologies
+    show_advanced_options: Afficher les options avancées
+    start_typing_to_select: Commencez à taper pour sélectionner %{type} ou laissez
+      vide pour tout utiliser
+    umls:
+      semantic_groups: Groupes sémantiques UMLS
+      semantic_types: Types sémantiques UMLS
+  negation: négation
+  none: aucune
+  ontologies:
+    ontology_search_prompt: 'Recherchez une ontologie ou un concept (Ex : Agrovoc...)'
+    self: Ontologies
+  ontology: Ontologie
+  ontology_details:
+    concept:
+      definitions: Définitions
+      id: Identifiant
+      in_schemes: Dans les schémas
+      member_of: Membre de
+      no_preferred_name_for_selected_language: Pas de nom préféré pour la langue sélectionnée.
+      obsolete: Obsolète
+      preferred_name: Nom préféré
+      synonyms: Synonymes
+      type: Type
+    metadata:
+      additional_metadata: Métadonnées supplémentaires
+  ontology_sets: Ensembles d'ontologies
+  output: Sortie
+  projects:
+    contacts: Contacts
+    create_new_project: Créer un nouveau projet
+    created: Créé
+    creator: Utilisateur
+    delete_admin_only: Supprimer (administrateur seulement)
+    delete_confirm: Êtes-vous sûr(e) ?
+    description: Description
+    description_text: Texte de description
+    edit: Modifier
+    home_page: Page d'accueil
+    index:
+      intro: Parcourez une sélection de projets qui utilisent les ressources %{site}
+    institutions: Institutions
+    ontologies: Ontologies
+    project_description: Description du projet
+    self: Projets
+    title: Liste de projets
+    view_projects_help: Aide à la visualisation des projets
+  recommender:
+    intro: Obtenez des recommandations pour les ontologies les plus pertinentes à
+      partir d'un extrait d'un texte biomédical ou d'une liste de mots-clés
+    no_recommendations: Aucune recommandation trouvée
+    no_sets_recommended: Il n'y a pas d'ensembles d'ontologies recommandés pour l'entrée
+      fournie. Veuillez essayer la sortie 'Ontologies'.
+    ontology_recommendation_input: Veuillez coller un paragraphe de texte ou quelques
+      mots-clés pour calculer les recommandations d'ontologie.
+    ontology_recommender: Recommandeur d'ontologie
+    paste_text_recommendations: Collez un paragraphe de texte ou quelques mots-clés
+      à utiliser pour calculer les recommandations d'ontologie
+    recommendation_error: Problème lors de la récupération des recommandations, veuillez
+      réessayer
+    text_length_limit: Veuillez utiliser moins de 500 mots. Si vous devez annoter
+      de plus grands morceaux de texte, vous pouvez utiliser le service web de recommandation.
+    title: recommandeur
+    valid_integer_max_ontologies_per_set: Le nombre maximum d'ontologies par ensemble
+      doit être une valeur entière valide
+    valid_max_ontologies_per_set_range: Le nombre maximum d'ontologies par ensemble
+      doit être un nombre entre 2 et 4
+    valid_numeric_weights: Tous les poids doivent être des valeurs numériques valides
+    weight_sum_greater_than_zero: La somme des poids doit être supérieure à zéro
+    weights_greater_than_zero: Tous les poids doivent être supérieurs ou égaux à zéro
+  register:
+    account_errors: 'Erreurs lors de la création de votre compte :'
+    confirm_password: Confirmer le mot de passe
+    create_account: Créer un nouveau compte
+    email: Email
+    first_name: Prénom
+    last_name: Nom
+    mailing_list: S'inscrire à la liste de diffusion d'AgroPortal
+    optional: "(Facultatif)"
+    password: Mot de passe
+    title: S'inscrire
+    username: Nom d'utilisateur
+  reproduce_results: 'Reproduisez ces résultats en utilisant le '
+  score: Score
+  search:
+    categories: Catégories
+    class_search: Recherche de classe
+    classes_with_definitions: Classes avec Définitions
+    hide_advanced_options: Masquer les options avancées
+    include_in_search: Inclure dans la recherche
+    index:
+      categories_placeholder: Commencez à taper pour sélectionner des catégories ou
+        laissez vide pour tout utiliser
+      obsolete_definition: 'Une classe que les auteurs de l''ontologie ont signalée
+        comme étant obsolète et qu''ils recommandent de ne pas utiliser. Ces cours
+        sont souvent laissés dans des ontologies (plutôt que de les supprimer entièrement)
+        afin que les systèmes existants qui en dépendent continuent à fonctionner.
 
-  # Generale
-  showing: Affichage
-  of: de
-  sort: Trier
-  popular: Populaire
-  name: Nom
-  classes_count: Nombre de classes
-  instances_concepts_count: Nombre d'instances/concepts
-  notes: Notes
-  upload_date: Date de téléchargement
-  release_date: Date de publication
-  fair_score: Score FAIR
-  search_rank: Classement de recherche
-  no_matches: Aucune correspondance !
-  uploaded: Téléchargé
-  view_of: Vue de
-  view: Vue
-  summary_only: Résumé seulement
-  groups: Groupes
-  categories: Catégories
-  admins: Administrateurs
-  status: Statut
-  no_submissions_available: Aucune soumission disponible
-  classes: classes
-
-  category: Catégorie
-  group: Groupe
-  format: Format
-  ontology_content: Contenu de l'ontologie
-  natural_language: Langage naturel
-  formality_levels: Niveaux de formalité
-  is_of_type: Est du type
-  missing_status: Statut manquant
-  types: Types
-  artifacts: Artéfacts
-  formats: Formats
-  selected_ontologies: Ontologies sélectionnées
-  all: "Tout"
-  none: "aucune"
-  keywords: "Mots-clés"
-  keywords_separated_by_commas: "Mots-clés séparés par des virgules"
-  see_details: "Voir les détails"
-  view_fair_scores_definitions: "View fair scores definitions"
-  get_json_version: "Get the json version"
-  select_ontologies: "Commencez à taper pour sélectionner des ontologies ou laissez vide pour toutes les utiliser"
-  clear_selection: "Effacer la sélection"
-  select_from_list: "Sélectionner dans la liste"
-  more: "Plus"
-  statistics: "Statistiques"
-  average: "Moyenne"
-  min: "Min"
-  max: "Max"
-  median: "Médiane"
-  slices: "Tranches"
-  help: "Aide"
-  or: "Ou"
-  show_advanced_options: "Afficher les options avancées"
-  insert_sample_text: "Insérer un exemple de texte"
-  class: "Classe"
-  filter: "Filtre"
-  ontology: "Ontologie"
-  type: "Type"
-  context: "Contexte"
-  umls_sem_type: "Type Sem UMLS"
-  matched_ontology: "ontologie correspondante"
-  matched_class: "Classe correspondante"
-  score: "Score"
-  negation: "négation"
-  experiencer: "Experiencer"
-  temporality: "Temporalité"
-  certainty: "Certitude"
-  format_results: "Formater les résultats en "
-  reproduce_results: "Reproduisez ces résultats en utilisant le "
-  additional_parameters: "Paramètres supplémentaires expliqués à "
-  input: "Entrée"
-  text: "Texte"
-  output: "Sortie"
-  ontology_sets: "Ensembles d'ontologies"
-  insert_sample_input: "Insérer une entrée d'exemple"
-  weights_configuration: "Configuration des poids"
-  coverage: "Couverture"
-  acceptance: "Acceptation"
-  knowledge_detail: "Détail de la connaissance"
-  specialization: "Spécialisation"
-  max_ontologies_per_set: "Nombre maximum d'ontologies par ensemble"
-  paste_input_text: "Collez un paragraphe de texte ou des mots-clés à utiliser dans le calcul des recommandations d'ontologie"
-  get_recommendations: "Obtenir des recommandations"
-  select_ontologies_list: "Sélectionnez les ontologies"
-
-  
+        '
+      property_definition: Association nommée entre deux entités. Les exemples sont
+        "définition" (une relation entre une classe et du texte) et "partie de" (une
+        relation entre deux classes).
+      search_keywords_placeholder: Entrez une classe, par ex. Mélanome
+    narrow_search_to: Réduire la recherche à
+    obsolete_classes: Classes obsolètes
+    ontologies: Ontologies
+    ontology_views: Vues d'ontologie
+    property_values: Valeurs de propriété
+    show_advanced_options: Afficher les options avancées
+    title: Rechercher
+    view_search_documentation: Voir la documentation de recherche
+  select_from_list: Sélectionner dans la liste
+  select_ontologies: Commencez à taper pour sélectionner des ontologies ou laissez
+    vide pour toutes les utiliser
+  select_ontologies_list: Sélectionnez les ontologies
+  show_advanced_options: Afficher les options avancées
+  specialization: Spécialisation
+  temporality: Temporalité
+  text: Texte
+  type: Type
+  umls_sem_type: Type Sem UMLS
+  view_fair_scores_definitions: View fair scores definitions
+  visits: Visites
+  weights_configuration: Configuration des poids

--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -1,0 +1,399 @@
+---
+it:
+  activaterecord:
+    errors:
+      models:
+        license:
+          attributes:
+            encrypted_key:
+              invalid_license_key: is an invalid license key
+              no_appliance_id_for_comparison: Could not be validated. Unable to retrieve virtual appliance ID.
+              appliance_id_mismatch: is an appliance id mismatch
+
+  date:
+    formats:
+      year_month_day_concise: "%Y-%m-%d" # 2017-03-01
+      month_day_year: "%b %-d, %Y" # Mar 1, 2017
+      monthfull_day_year: "%B %-d, %Y" # March 1, 2017
+
+  additional_parameters: Parametri aggiuntivi spiegati in
+  admin:
+    licenses:
+      create:
+        success: Licenza rinnovata con successo!
+  all: Tutti
+  annotator:
+    annotate_text_prompt: Inserire o incollare il testo da annotare
+    annotations_result: Annotazioni
+    fast_context: Contesto veloce
+    filters:
+      confidence_threshold: Soglia di confidenza del filtro
+      confidence_threshold_help: Specificare la posizione minima nella distribuzione
+        dei punteggi (tra 1 e 100)
+      exclude_numbers: Escludere i numeri
+      exclude_synonyms: Escludere sinonimi
+      include_mappings: Includere le mappature
+      match_longest_only: Solo la partita più lunga
+      match_partial_words: Riconoscere parole parziali
+      max_hierarchy_level: Includere gli antenati fino al livello
+      score: Includere il punteggio
+      score_help: Punteggio delle annotazioni secondo la precedente misura NCBO 2009
+        (old) o Punteggio delle annotazioni secondo la misura C-Value (cvalue) o Punteggio
+        delle annotazioni secondo la misura C-Value con espansione gerarchica (cvalueh)
+      score_threshold: Filtrare per soglia di punteggio
+      score_threshold_help: Specificare il valore minimo del punteggio per le annotazioni
+    get_annotator: Ottenere le annotazioni
+    index:
+      fast_context:
+        tooltip: 'Abilita FastContext a rilevare: se un concetto è stato negato (affermato,
+          negato), chi ha sperimentato il concetto trovato (paziente, altro), quando
+          si è verificato il concetto annotato (recente, storico, ipotetico), e/o
+          se il concetto annotato è incerto (certo, incerto).'
+      intro: Ottenere annotazioni per un testo biomedico con classi ontologiche
+      lemmatize:
+        tooltip: Abilita Lemmatize per lemmatizzare il testo inviato e utilizzare
+          un dizionario lemmatizzato per le annotazioni
+      sample_text: Il melanoma è un tumore maligno dei melanociti che si trova principalmente
+        nella pelle, ma anche nell'intestino e nell'occhio.
+    lemmatize: Lemmatizzare
+    results_filtered_by: I risultati sono filtrati da
+    select: Selezionare %{name}
+    start_typing_to_select: Iniziare a digitare per selezionare %{type} o lasciare
+      in bianco per utilizzare tutti i dati
+    title: Annotatore
+    umls:
+      semantic_groups: Gruppi semantici UMLS
+      semantic_types: Tipi semantici UMLS
+  certainty: Certezza
+  class: Classe
+  clear_selection: Azzeramento della selezione
+  concepts:
+    request_term:
+      new_term_instructions: |
+        <p>Questa ontologia si integra con OntoloBridge, permettendo agli utenti della comunità di suggerire aggiunte all'ontologia pubblica. Compilare il modello sottostante per inviare una richiesta di termine direttamente al gestore dell'ontologia.</p>
+          <blockquote>
+            <p>Etichetta del termine (obbligatorio)<br>Nome del termine suggerito. Se un termine può essere descritto con più di un sinonimo, inserire qui solo il nome preferito.</p>
+          </blockquote>
+          <blockquote>
+            <p>Descrizione del termine (obbligatorio)<br>Breve definizione, descrizione o uso del termine suggerito. In questa sezione si possono elencare i sinonimi di altri termini.</p>
+          </blockquote>
+          <blockquote>
+            <p>Superclasse (obbligatorio)<br>Il termine padre del termine suggerito. Il termine genitore deve essere una voce esistente nell'ontologia corrente. La superclasse può essere selezionata direttamente dall'albero delle classi del Bioportale.</p>
+          </blockquote>
+          <blockquote>
+            <p>Riferimenti (facoltativo)<br>Fornire prove dell'esistenza del termine richiesto, come ID Pubmed di articoli o link ad altre risorse che descrivono il termine.</p>
+          </blockquote>
+          <blockquote>
+            <p>Giustificazione (opzionale)<br>Fornisci qui qualsiasi informazione aggiuntiva sul termine richiesto.</p>
+          </blockquote>
+  context: Contesto
+  coverage: Copertura
+  filter: Filtro
+  format_results: Formatta i risultati come
+  get_json_version: Ottenere la versione json
+  get_recommendations: Raccomandazioni
+  help: Aiuto
+  home:
+    agroportal_figures: "%{site} in cifre:"
+    benefit1: Scoprite nuove intuizioni e connessioni esplorando le altre ontologie
+      presenti nel repository.
+    benefit2: Contribuite alla crescita e allo sviluppo del vostro dominio aggiungendo
+      nuovi concetti e categorie.
+    benefit3: Utilizzate il controllo di versione per gestire le modifiche alla vostra
+      ontologia nel tempo e collaborare con altri utenti.
+    benefit4: Ottenere feedback e suggerimenti da altri utenti che possono rivedere
+      e commentare la vostra ontologia.
+    benefit5: Ottenere il punteggio e le metriche FAIR per l'ontologia.
+    fair_details: Vedi dettagli
+    fairness: Punteggi FAIR
+    get_annotations: Ottenere le annotazioni
+    get_recommendations: Raccomandazioni
+    index:
+      tagline: La casa dei vocabolari e delle ontologie in agronomia e nei campi correlati.
+      title: Benvenuti alla %{organization}
+      welcome: Benvenuti al %{site},
+    ontology_upload: Volete caricare un'ontologia?
+    ontology_upload_benefits: 'Caricando la propria ontologia su %{site}, è possibile:'
+    ontology_upload_button: Caricare l'ontologia
+    ontology_upload_desc: Caricare un'ontologia è un modo per condividere la propria
+      conoscenza del dominio con altri.
+    paste_text_prompt: Incollare un paragrafo di testo o alcune parole chiave ...
+    recommender_annotator: Raccomandatore e annotatore
+    supported_by: Supportato da
+    twitter_news: Notizie su Twitter
+    with_collaboration: Con la collaborazione di
+  input: Ingresso
+  insert_sample_text: Inserire un testo di esempio
+  keywords: Parole chiave
+  keywords_separated_by_commas: Parole chiave separate da virgole
+  knowledge_detail: Dettaglio della conoscenza
+  landscape:
+    average_metrics: Metriche medie
+    category: Categoria
+    filter_network: Rete di filtraggio
+    funding_endorsing_organizations: Organizzazioni che finanziano e sostengono il
+      maggior numero di ontologie
+    group: Gruppo
+    groups_and_categories: Gruppi e categorie
+    intro: Visualizzare i dati recuperati dalle ontologie memorizzate nel portale
+    more_properties_charts: Altri grafici delle proprietà
+    most_active_ontologies: Le ontologie più attive
+    most_active_organizations: Le organizzazioni più attive
+    most_active_people: Le persone più attive
+    most_active_people_as_reviewer: Le persone più attive come recensori
+    most_mentioned_people: Le persone più citate come contatto, creatore, collaboratore
+      o curatore
+    most_mentioned_people_as_reviewer: Persone che hanno pubblicato note, recensioni
+      e progetti
+    ontologies_activity_on: Attività ontologica su %{site}
+    ontologies_by: Ontologie per %{type}
+    ontologies_contributors: Contribuenti allo sviluppo dell'ontologia
+    ontologies_count_by_catalog: Numero di ontologie in ogni catalogo di dati
+    ontologies_formats: Formato utilizzato
+    ontologies_languages: Linguaggi naturali delle ontologie
+    ontologies_licenses: Licenze utilizzate dalle ontologie
+    ontologies_with_notes_reviews_projects: Ontologie con note, recensioni e progetti
+    ontology_fairness_evaluator: Valutatore di ontologia FAIR (O'FAIRe)
+    ontology_formality_levels: Livelli di formalità delle ontologie
+    ontology_properties_pie_charts: Grafici a torta per le proprietà utilizzate nelle
+      ontologie
+    ontology_relations_network: Rete di relazioni ontologiche
+    ontology_tools: Strumenti più utilizzati per costruire ontologie
+    owl_ontology_author_uris: URI per le proprietà dell'autore utilizzate per le ontologie
+      OWL
+    owl_ontology_definition_uris: URI per le proprietà di definizione utilizzate per
+      le ontologie OWL
+    owl_ontology_preflabel_uris: URI per le proprietà prefLabel utilizzate per le
+      ontologie OWL
+    owl_ontology_synonym_uris: URI per le proprietà dei sinonimi utilizzati per le
+      ontologie OWL
+    properties_usage_proportion: La percentuale di utilizzo delle proprietà tra le
+      ontologie memorizzate
+    properties_use: Uso della proprietà
+    relations_between_stored_ontologies: Relazioni tra le ontologie memorizzate nel
+      portale
+    size: Dimensione
+    title: "%{site} Paesaggio"
+  layout:
+    header:
+      account_setting: Impostazioni dell'account
+      annotator: Annotatore
+      browse: Sfogliare
+      documentation: Documentazione
+      help: Aiuto
+      landscape: Paesaggio
+      login: Accesso
+      logout: logout
+      mappings: Mappature
+      publications: Pubblicazioni
+      release_notes: Note di rilascio
+      search_prompt: Cerca in %{portal_name} ...
+      submit_feedback: Invia un feedback
+      support: supporto
+  login:
+    enter_email: Inserisci il tuo indirizzo e-mail
+    enter_password: Inserire la password
+    forgot_password: Hai dimenticato la password?
+    invalid_login: Errori nel modulo
+    no_account: Non avete un account?
+    password: Password
+    register: Registro
+    title: Accesso
+    username_or_email: Nome utente o e-mail
+  mappings:
+    find_mappings: Trovare le mappature di una classe/concetto
+    intro: Sfogliare le mappature tra classi di diverse ontologie
+    loading_mappings: Caricamento delle mappature...
+    mappings_bulk_load: Mappatura del carico massivo
+    no_mappings_available: Nessuna mappatura disponibile
+    title: Corrispondenze
+    upload_mappings: Caricare le mappature
+  matched_class: Classe abbinata
+  matched_ontology: ontologia abbinata
+  max_ontologies_per_set: Numero massimo di ontologie per set
+  nbco_annotatosplus:
+    annotations: Annotazioni
+    enter_paste_text_to_annotate: 'Inserire o incollare il testo da annotare:'
+    exclude_numbers: Escludere i numeri
+    exclude_synonyms: Escludere sinonimi
+    fast_context:
+      help: 'Attivare FastContext per rilevare: se un concetto è stato negato (affermato,
+        negato), chi ha sperimentato il concetto trovato (paziente, altro), quando
+        si è verificato il concetto annotato (recente, storico, ipotetico), e/o se
+        il concetto annotato è incerto (certo, incerto).'
+      title: Contesto veloce
+    filters:
+      additional_parameters_explained_at: 'Ulteriori parametri sono spiegati nella
+        pagina:'
+      by:
+        certainty: Certezza
+        class: Classe
+        experiencer: Esperto
+        filter: Filtro
+        match_context: Contesto
+        match_type: Tipo
+        matched_class: Classe associata
+        matched_ontology: Ontologia associata
+        negation: Negazione
+        ontology: Ontologia
+        score: Punteggio
+        temporality: Temporalità
+        title: I risultati sono filtrati da
+        umls_sem_type: Tipo semantico UMLS
+      confidence_threshold: Soglia di fiducia del filtro
+      confidence_threshold_help: Specificare la posizione minima nella distribuzione
+        dei punteggi (tra 1 e 100)
+      format_results_as: 'Formattare i risultati come:'
+      reproduce_results_using: Riprodurre questi risultati utilizzando il metodo
+      score_threshold: Filtrare per soglia di punteggio
+      score_threshold_help: Specificare il valore minimo del punteggio per le annotazioni
+    include_ancestors_up_to_level: Includere gli antenati fino al livello
+    include_mappings: Includere le mappature
+    include_score: Includere il punteggio
+    index:
+      intro: |
+        NCBO Annotator+ è un proxy che chiama il servizio web NCBO Annotator sul BioPortale NCBO.
+           <br/><br/>
+           Tchechmedjiev, A., Abdaoui, A., Emonet, V., Melzi, S., Jonnagaddala, J., & Jonquet, C. (2018). <a href="https://doi.org/10.1093/bioinformatics/bty009" target="_blank">Funzioni migliorate per l'annotazione e l'indicizzazione di testi clinici con NCBO Annotator+</a>. Bioinformatica, 34(11), 1962-1965.
+           </br><br/>
+           Se si utilizza l'API, fornire una chiave API NCBO BioPortal valida e accedere al servizio all'indirizzo <a href="http://services.bioportal.lirmm.fr/ncbo_annotatorplus">http://services.bioportal.lirmm. en/ncbo_annotatorplus </a></br>
+           Il testo inviato a NCBO Annotator+ deve essere in inglese.
+      sample_text: Il melanoma è un tumore maligno dei melanociti che si trova principalmente
+        nella pelle, ma anche nell'intestino e nell'occhio.
+      title: Annotatore NCBO +
+    insert_sample_text: Inserire un testo di esempio
+    match_longest_only: Solo la partita più lunga
+    match_partial_words: Abbinare parole parziali
+    recognizer: Riconoscimento dell'entità
+    score_help: Punteggio delle annotazioni secondo la precedente misura NCBO 2009
+      (old) o Punteggio delle annotazioni secondo la misura C-Value (cvalue) o Punteggio
+      delle annotazioni secondo la misura C-Value con espansione gerarchica (cvalueh)
+    select: Selezionare %{name}
+    select_ontologies: Iniziare a digitare per selezionare le ontologie o lasciare
+      vuoto per utilizzare tutte le ontologie
+    select_ontologies_list: Selezionare le ontologie
+    show_advanced_options: Mostra le opzioni avanzate
+    start_typing_to_select: Iniziare a digitare per selezionare %{type} o lasciare
+      vuoto per usare tutti
+    umls:
+      semantic_groups: Gruppi semantici UMLS
+      semantic_types: Tipi semantici UMLS
+  negation: negazione
+  none: nessuno
+  ontologies:
+    ontology_search_prompt: 'Ricerca di un''ontologia o di un concetto (es.: Agrovoc
+      ...)'
+    self: Ontologie
+  ontology: Ontologia
+  ontology_details:
+    concept:
+      definitions: Definizioni
+      id: ID
+      in_schemes: In Schemi
+      member_of: Membro di
+      no_preferred_name_for_selected_language: Nessun nome preferito per la lingua
+        selezionata.
+      obsolete: Obsoleto
+      preferred_name: Nome preferito
+      synonyms: Sinonimi
+      type: Tipo
+    metadata:
+      additional_metadata: Metadati aggiuntivi
+  ontology_sets: Insiemi di ontologie
+  output: Uscita
+  projects:
+    contacts: Contatti
+    create_new_project: Creare un nuovo progetto
+    created: Creato
+    creator: Utente
+    delete_admin_only: Elimina (solo per l'amministratore)
+    delete_confirm: Sei sicuro?
+    description: Descrizione
+    description_text: Descrizione Testo
+    edit: Modifica
+    home_page: Pagina iniziale
+    index:
+      intro: Sfoglia una selezione di progetti che utilizzano risorse %{site}
+    institutions: Istituzioni
+    ontologies: Ontologie
+    project_description: Descrizione del progetto
+    self: Progetti
+    title: Elenco dei progetti
+    view_projects_help: Visualizza i progetti Aiuto
+  recommender:
+    intro: Ottenere raccomandazioni per le ontologie più rilevanti da un estratto
+      di un testo biomedico o da un elenco di parole chiave
+    no_recommendations: Nessuna raccomandazione trovata
+    no_sets_recommended: Non ci sono set di ontologie consigliati per l'input fornito.
+      Provare con l'output "Ontologie".
+    ontology_recommendation_input: Incollare un paragrafo di testo o alcune parole
+      chiave per calcolare le raccomandazioni dell'ontologia.
+    ontology_recommender: Raccomandatore di ontologia
+    paste_text_recommendations: Incollare un paragrafo di testo o alcune parole chiave
+      da utilizzare per calcolare le raccomandazioni dell'ontologia
+    recommendation_error: Problema nel recupero delle raccomandazioni, provare di
+      nuovo
+    text_length_limit: Si prega di utilizzare meno di 500 parole. Se avete bisogno
+      di annotare testi più lunghi, potete utilizzare il servizio web di raccomandazione.
+    title: raccomandatore
+    valid_integer_max_ontologies_per_set: Il numero massimo di ontologie per set deve
+      essere un valore intero valido
+    valid_max_ontologies_per_set_range: Il numero massimo di ontologie per set deve
+      essere un numero compreso tra 2 e 4
+    valid_numeric_weights: Tutti i pesi devono essere valori numerici validi
+    weight_sum_greater_than_zero: La somma dei pesi deve essere maggiore di zero
+    weights_greater_than_zero: Tutti i pesi devono essere maggiori o uguali a zero
+  register:
+    account_errors: 'Errori nella creazione dell''account:'
+    confirm_password: Confermare la password
+    create_account: Creare un nuovo account
+    email: Email
+    first_name: Nome
+    last_name: Cognome
+    mailing_list: Registrarsi alla mailing list di AgroPortal
+    optional: "(Opzionale)"
+    password: Password
+    title: Registro
+    username: Nome utente
+  reproduce_results: Riprodurre questi risultati utilizzando il metodo
+  score: Punteggio
+  search:
+    categories: Categorie
+    class_search: Ricerca di classe
+    classes_with_definitions: Classi con definizioni
+    hide_advanced_options: Nascondere le opzioni avanzate
+    include_in_search: Includere nella ricerca
+    index:
+      categories_placeholder: Iniziare a digitare per selezionare le categorie o lasciare
+        vuoto per utilizzare tutte le categorie
+      obsolete_definition: 'Una classe che gli autori dell''ontologia hanno segnalato
+        come obsoleta e che raccomandano di non usare. Spesso queste classi vengono
+        lasciate nelle ontologie (invece di essere eliminate del tutto) in modo che
+        i sistemi esistenti che dipendono da esse continuino a funzionare"
+
+        '
+      property_definition: Un'associazione nominativa tra due entità. Esempi sono
+        "definizione" (una relazione tra una classe e un testo) e "parte di" (una
+        relazione tra due classi).
+      search_keywords_placeholder: Inserire una classe, ad es. Melanoma
+    narrow_search_to: Restringere la ricerca a
+    obsolete_classes: Classi obsolete
+    ontologies: Ontologie
+    ontology_views: Viste ontologiche
+    property_values: Valori della proprietà
+    show_advanced_options: Mostra opzioni avanzate
+    title: Ricerca
+    view_search_documentation: Visualizza la documentazione della ricerca
+  select_from_list: Selezionare dall'elenco
+  select_ontologies: Iniziare a digitare per selezionare le ontologie o lasciare vuoto
+    per utilizzarle tutte
+  select_ontologies_list: Selezionare le ontologie
+  show_advanced_options: Mostra le opzioni avanzate
+  specialization: Specializzazione
+  temporality: Temporalità
+  text: Testo
+  type: Tipo
+  umls_sem_type: Tipo UMLS Sem
+  view_fair_scores_definitions: Visualizza le definizioni dei punteggi equi
+  visits: Visite
+  weights_configuration: Configurazione dei pesi


### PR DESCRIPTION
### Context 
this PR includes #326, fixes some page's internationalization and adds for the homepage the Italian and german translation

### Changes

* Add '`i18n-tasks`' and '`deepl-rb`' gems to fix and translate missing locales (https://github.com/ontoportal-lirmm/bioportal_web_ui/commit/0e74ba387bbe1f91830b94b4f00dc84ebc9fbc8d)
* Add italian and german locales (https://github.com/ontoportal-lirmm/bioportal_web_ui/commit/94991377c0b9e71f187af6ab2ef2c169782d707e)
* Fix som of the internalization of this pages: home, annotator, login, recommender and user form and show (https://github.com/ontoportal-lirmm/bioportal_web_ui/commit/01837352ad1c255d417010180552d22b413b55fa)