### PR TITLE
Fix: hide turbo frame error message when context changed

### DIFF
--- a/app/assets/stylesheets/components/alert.scss
+++ b/app/assets/stylesheets/components/alert.scss
@@ -24,7 +24,7 @@
 .alert-message{
     font-size: 16px;
     margin: 0 10px;
-    text-align: center;
+    width: 100%;
 }
 
 

--- a/app/javascript/component_controllers/index.js
+++ b/app/javascript/component_controllers/index.js
@@ -17,6 +17,7 @@ import Tabs_container_component_controller
 import alert_component_controller from "../../components/display/alert_component/alert_component_controller";
 import Progress_pages_component_controller
     from "../../components/layout/progress_pages_component/progress_pages_component_controller";
+import Reveal_component_controller from "../../components/layout/reveal_component/reveal_component_controller";
 
 
 application.register("turbo-modal", TurboModalController)
@@ -28,3 +29,4 @@ application.register("tabs-container", Tabs_container_component_controller)
 application.register("circle-progress-bar", CircleProgressBarComponentController)
 application.register("alert-component", alert_component_controller)
 application.register("progress-pages", Progress_pages_component_controller)
+application.register("reveal-component", Reveal_component_controller)

--- a/app/javascript/controllers/turbo_frame_error_controller.js
+++ b/app/javascript/controllers/turbo_frame_error_controller.js
@@ -34,18 +34,13 @@ export default class extends Turbo_frame_controller {
     Array.from(styles).forEach(e => el.removeChild(e))
 
     let body = el.querySelector('h1')
-    let div = document.createElement('div')
-    div.className ="text-center"
-    div.innerHTML = (body ? body.innerText : el.innerHTML)
-    this.errorMessageTarget.firstElementChild.appendChild(div)
+    this.errorMessageTarget.firstElementChild.querySelector('.alert-message').innerHTML =  (body ? body.innerText : el.innerHTML)
     $(this.errorMessageTarget).show()
   }
 
   #hideError(){
-    let child =this.errorMessageTarget.firstElementChild
     let count = this.errorMessageTarget.firstElementChild.childElementCount
-    if(count === 2) {
-      child.removeChild(child.lastElementChild)
+    if(count !== 0) {
       $(this.errorMessageTarget).hide()
     }
   }


### PR DESCRIPTION
### Changes
* Remove text-center by default on the alert messages 
* Make alert message text take full-width by default 
* Hide turbo frame error message when context changed (https://github.com/ontoportal-lirmm/bioportal_web_ui/pull/369/commits/963289f6cec3052ddf4b357b67a46e9a506a5f69)