### PR TITLE
Fix: ensure the omniauth_provider_info is get when put a string argument

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -38,7 +38,7 @@ module ApplicationHelper
   end
 
   def omniauth_token_provider(strategy)
-    omniauth_provider_info(strategy).keys.first
+    omniauth_provider_info(strategy.to_sym).keys.first
   end
 
   def isOwner?(id)


### PR DESCRIPTION
Fix using login using Google.
### Changes
* ensure the omniauth_provider_info is get when put a string argument (https://github.com/ontoportal-lirmm/bioportal_web_ui/pull/372/commits/064e01c26546b1d1dc9bf125de6ca4b677004c3b)