### PR TITLE
Fix: update ontology summary and edit pages code to adapt the change in the backend metadata 

### DIFF
--- a/app/controllers/concerns/submission_filter.rb
+++ b/app/controllers/concerns/submission_filter.rb
@@ -22,12 +22,7 @@ module SubmissionFilter
     # @page = LinkedData::Client::Models::OntologySubmission.all(request_params)
     @page = OpenStruct.new(page: 1, next_page: nil)
     submissions = LinkedData::Client::Models::OntologySubmission.all(request_params)
-    analytics = LinkedData::Client::Analytics.all
-    @analytics = analytics.to_h.map do |key, ontology_analytics|
-      next if key.eql?(:links) || key.eql?(:context)
-
-      [key.to_s, ontology_analytics.to_h.values.map { |x| x&.values }.flatten.compact.sum]
-    end.compact.to_h
+    @analytics =  helpers.ontologies_analytics
 
     # get fair scores of all ontologies
     @fair_scores = fairness_service_enabled? ? get_fair_score('all') : nil

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -7,9 +7,9 @@ class HomeController < ApplicationController
   include FairScoreHelper
 
   def index
-    @analytics = LinkedData::Client::Analytics.last_month
+    @analytics =  helpers.ontologies_analytics
     # Calculate BioPortal summary statistics
-    @ont_count = @analytics.onts.size
+    @ont_count = @analytics.keys.size
     metrics = LinkedData::Client::Models::Metrics.all
     metrics = metrics.each_with_object(Hash.new(0)) do |h, sum|
       h.to_hash.slice(:classes, :properties, :individuals).each { |k, v| sum[k] += v }
@@ -32,9 +32,9 @@ class HomeController < ApplicationController
 
     @anal_ont_names = []
     @anal_ont_numbers = []
-    @analytics.onts[0..4].each do |visits|
-      @anal_ont_names << visits[:ont]
-      @anal_ont_numbers << visits[:views]
+    @analytics.sort_by{|ont, count| -count}[0..4].each do |ont, count|
+      @anal_ont_names << ont
+      @anal_ont_numbers << count
     end
 
   end

--- a/app/controllers/ontologies_controller.rb
+++ b/app/controllers/ontologies_controller.rb
@@ -318,11 +318,11 @@ class OntologiesController < ApplicationController
        relation]
     end
     @methodology_properties = properties_hash_values(category_attributes["methodology"])
-    @agents_properties = properties_hash_values(category_attributes["people"].without('wasGeneratedBy', 'wasInvalidatedBy') + [:hasCreator, :hasContributor, :translator, :publisher, :copyrightHolder])
-    @dates_properties = properties_hash_values(category_attributes["dates"] + [:creationDate, :modificationDate, :released])
-    @links_properties = properties_hash_values(category_attributes["links"].without('includedInDataCatalog') +[:wasGeneratedBy, :wasInvalidatedBy] )
-    @identifiers = properties_hash_values( [:URI, :versionIRI, :identifier])
-    @projects_properties = properties_hash_values(category_attributes["usage"].without('hasDomain') + [:audience, :includedInDataCatalog])
+    @agents_properties = properties_hash_values(category_attributes["persons and organizations"])
+    @dates_properties = properties_hash_values(category_attributes["dates"])
+    @links_properties = properties_hash_values(category_attributes["links"])
+    @identifiers = properties_hash_values([:URI, :versionIRI, :identifier])
+    @projects_properties = properties_hash_values(category_attributes["usage"])
     @ontology_icon_links = [%w[summary/download dataDump], %w[summary/homepage homepage], %w[summary/documentation documentation], %w[icons/github repository], %w[summary/sparql endpoint]]
     if request.xhr?
       render partial: 'ontologies/sections/metadata', layout: false

--- a/app/controllers/submissions_controller.rb
+++ b/app/controllers/submissions_controller.rb
@@ -71,9 +71,9 @@ class SubmissionsController < ApplicationController
     category_attributes = submission_metadata.group_by{|x| x['category']}.transform_values{|x| x.map{|attr| attr['attribute']} }
     category_attributes = category_attributes.reject{|key| ['no'].include?(key.to_s)}
     category_attributes['general'] << %w[acronym name groups administeredBy categories]
-    category_attributes['license'] << 'viewingRestriction'
+    category_attributes['licensing'] << 'viewingRestriction'
     category_attributes['relations'] << 'viewOf'
-    @categories_order = ['general', 'description', 'dates', 'license', 'people', 'links', 'images', 'community', 'usage' ,'relations', 'content','methodology', 'object description properties']
+    @categories_order = ['general', 'description', 'dates', 'licensing', 'persons and organizations', 'links', 'media', 'community', 'usage' ,'relations', 'content','methodology', 'object description properties']
     @category_attributes = category_attributes
   end
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -24,6 +24,14 @@ module ApplicationHelper
                        :cclicense => "http://creativecommons.org/licenses/"}
 
 
+  def ontologies_analytics
+    LinkedData::Client::Analytics.all.to_h.map do |key, ontology_analytics|
+      next if key.eql?(:links) || key.eql?(:context)
+
+      [key.to_s, ontology_analytics.to_h.values.map { |x| x&.values }.flatten.compact.sum]
+    end.compact.to_h
+  end
+
   def get_apikey
     unless session[:user].nil?
       return session[:user].apikey

--- a/app/views/submissions/edit.html.haml
+++ b/app/views/submissions/edit.html.haml
@@ -25,6 +25,10 @@
 
         %hr#edit-ontology-actions-devider
         .edit-ontology-actions
+          .cancel-button.mx-2{onClick: 'window.history.back();'}
+            = render Buttons::RegularButtonComponent.new(id:'cancel-button', value: "Cancel", variant: "secondary", size: "slim") do |btn|
+              - btn.icon_left do
+                - inline_svg_tag "x.svg", width: "20", height: "20"
           .reset-all-button#reset-all-button
             = render Buttons::RegularButtonComponent.new(id:'reset-all-fields', value: "Reset all fields", variant: "secondary", size: "slim") do |btn|
               - btn.icon_left do


### PR DESCRIPTION
This PR, follows this backend change https://github.com/ontoportal-lirmm/ontologies_linked_data/pull/108, updating ontology summary, and editing page code to adapt the renaming of the categories (people, images, and license) e19a6e50be51b0068726b576c1f59a043ef71887 .

In addition: 
* Added  "cancel" button to the submission edit form (https://github.com/ontoportal-lirmm/bioportal_web_ui/commit/0774326953fe5a0ea766ce83caa87f5a5fc57a67)
![image](https://github.com/ontoportal-lirmm/bioportal_web_ui/assets/29259906/d9874a80-fb65-49fb-9b2d-365369df7282)

* Fixed homepage analytics to use all the analytics not only the last_month as a temporary solution for https://github.com/agroportal/project-management/issues/439. (https://github.com/ontoportal-lirmm/bioportal_web_ui/commit/19b78d4c2268e80b39ed812ce3add197518ec7dd)
![image](https://github.com/ontoportal-lirmm/bioportal_web_ui/assets/29259906/5d824af1-6aa6-4a63-81bf-a3effa92f0be)

