### PR TITLE
Feature: Add UI tests infrastructure and Github action 

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,51 @@
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+# This workflow will download a prebuilt Ruby version, install dependencies and run tests with Rake
+# For more information see: https://github.com/marketplace/actions/setup-ruby-jruby-and-truffleruby
+name: "Ruby on Rails CI"
+
+on:
+  push:
+  pull_request_target:
+    types: [ opened, reopened ]
+env:
+  API_URL: ${{ secrets.API_URL }}
+  API_KEY: ${{ secrets.API_KEY }}
+  BIOMIXER_URL: ${{ secrets.BIOMIXER_URL }}
+  FAIRNESS_URL: ${{ secrets.FAIRNESS_URL }}
+  ANNOTATOR_URL: ${{ secrets.ANNOTATOR_URL }}
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    services:
+      mysql:
+        image: mysql:latest
+        ports:
+          - "3306:3306"
+        env:
+          MYSQL_ROOT_PASSWORD: 'bp_user'
+      memcached:
+        image: memcached:1.6
+        ports:
+          - 11211:11211
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+      # Add or replace dependency steps here
+      - name: Install Ruby and gems
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 2.7.8
+          bundler-cache: true
+      # Add or replace database setup steps here
+      - name: set up config file
+        run: cp config/database.yml.sample config/database.yml
+      - name: Set up database schema
+        run: RAILS_ENV=test bin/rails db:setup
+      - name: Set up yarn
+        run: yarn install
+      # Add or replace test runners here
+      - name: Run tests
+        run: RAILS_ENV=test bin/rails test -v

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -90,7 +90,6 @@ GEM
     ast (2.4.2)
     autoprefixer-rails (10.4.15.0)
       execjs (~> 2)
-    base64 (0.1.1)
     bcrypt_pbkdf (1.1.0)
     better_html (2.0.2)
       actionview (>= 6.0)
@@ -345,7 +344,7 @@ GEM
     public_suffix (5.0.3)
     puma (5.6.7)
       nio4r (~> 2.0)
-    racc (1.7.1)
+    racc (1.7.3)
     rack (2.2.8)
     rack-accept (0.4.5)
       rack (>= 0.4)
@@ -399,7 +398,7 @@ GEM
     recaptcha (5.9.0)
       json
     redcarpet (3.6.0)
-    regexp_parser (2.8.1)
+    regexp_parser (2.8.2)
     reline (0.3.8)
       io-console (~> 0.5)
     rest-client (2.1.0)
@@ -426,8 +425,7 @@ GEM
       rspec-mocks (~> 3.12)
       rspec-support (~> 3.12)
     rspec-support (3.12.1)
-    rubocop (1.56.3)
-      base64 (~> 0.1.1)
+    rubocop (1.57.2)
       json (~> 2.3)
       language_server-protocol (>= 3.17.0)
       parallel (~> 1.10)
@@ -438,7 +436,7 @@ GEM
       rubocop-ast (>= 1.28.1, < 2.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 2.4.0, < 3.0)
-    rubocop-ast (1.29.0)
+    rubocop-ast (1.30.0)
       parser (>= 3.2.1.0)
     ruby-progressbar (1.13.0)
     ruby2_keywords (0.0.5)
@@ -536,6 +534,7 @@ GEM
 
 PLATFORMS
   x86_64-darwin-21
+  x86_64-darwin-23
   x86_64-linux
   x86_64-linux-musl
 
@@ -616,4 +615,4 @@ DEPENDENCIES
   will_paginate (~> 3.0)
 
 BUNDLED WITH
-   2.4.12
+   2.4.21

--- a/app/components/language_field_component.rb
+++ b/app/components/language_field_component.rb
@@ -8,12 +8,16 @@ class LanguageFieldComponent < ViewComponent::Base
   def initialize(value:, label: nil)
     super
     @value = value
-    @lang_code = ISO_639.find(value.split('/').last)&.alpha2 || nil
+    @lang_code = value&.is_a?(String) ? ISO_639.find(value.split('/').last)&.alpha2 : nil
     @label = label
   end
 
   def lang_code
     @lang_code = 'gb' if @lang_code.eql?('en')
     @lang_code
+  end
+
+  def value
+    @value&.is_a?(String) ? @value.to_s.split('/').last : 'NO-LANG'
   end
 end

--- a/app/components/language_field_component/language_field_component.html.haml
+++ b/app/components/language_field_component/language_field_component.html.haml
@@ -5,4 +5,4 @@
       %div.ml-1
         = @label
 - else
-  = render ChipButtonComponent.new(text: @value ?  @value.split('/').last : 'NO-LANG')
+  = render ChipButtonComponent.new(text: value)

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -622,8 +622,9 @@ module ApplicationHelper
   def ontology_viewer_page_name(ontology_name, concept_label, page)
     ontology_name + " | " + main_language_label(concept_label) + " - #{page.capitalize}"
   end
-
-
+  def help_path(anchor: nil)
+    "#{Rails.configuration.settings.links[:help]}##{anchor}"
+  end
 
   def uri?(url)
     url =~ /\A#{URI::DEFAULT_PARSER.make_regexp(%w[http https])}\z/

--- a/config/bioportal_config_test.rb
+++ b/config/bioportal_config_test.rb
@@ -1,0 +1,172 @@
+# frozen_string_literal: true
+
+$SITE = 'Testportal'
+$UI_HOSTNAME = 'localhost'
+$UI_URL = "http://#{$UI_HOSTNAME}:3000"
+
+$API_KEY = ENV['API_KEY']
+$REST_URL = ENV['API_URL']
+$BIOMIXER_URL = ENV['BIOMIXER_URL']
+$ANNOTATOR_URL = $PROXY_URL = ENV['ANNOTATOR_URL']
+$FAIRNESS_URL = ENV['ANNOTATOR_URL']
+
+# config/initializers/omniauth_providers.rb
+$OMNIAUTH_PROVIDERS = {
+  github: {
+    client_id: 'id',
+    client_secret: 'secret',
+    icon: 'icons/github.svg'
+  },
+  google: {
+    strategy: :google_oauth2,
+    client_id: 'id',
+    client_secret: 'secret',
+    icon: 'icons/google.svg'
+  },
+  orcid: {
+    client_id: 'YOUR_ORCID_CLIENT_ID',
+    client_secret: 'YOUR_ORCID_CLIENT_SECRET',
+    icon: 'icons/orcid.svg'
+  },
+  keycloak: {
+    strategy: :keycloak_openid,
+    client_id: 'YOUR_KEYCLOAK_CLIENT_ID',
+    client_secret: 'YOUR_KEYCLOAK_CLIENT_SECRET',
+    client_options: { site: 'KEYCLOAK_SITE', realm: 'KEYCLOAK_REALM' },
+    name: 'keycloak',
+    icon: 'icons/keycloak.svg'
+  }
+}.freeze
+
+$INTERPORTAL_HASH = {}
+
+# If your BioPortal installation includes Fairness score set this to true
+$FAIRNESS_DISABLED = false
+
+# Pairing a name with an array of ontology virtual ids will allow you to filter ontologies based on a subdomain.
+# If your main UI is hosted at example.org and you add custom.example.org pointing to the same Rails installation
+# you could filter the ontologies visible at custom.example.org by adding this to the hash: "custom" => { :name => "Custom Slice", :ontologies => [1032, 1054, 1099] }
+# Any number of slices can be added. Groups are added automatically using the group acronym as the subdomain.
+$ENABLE_SLICES = true
+$ONTOLOGY_SLICES = {}
+
+# Cube metrics reporting
+$ENABLE_CUBE = false
+
+$NOT_DOWNLOADABLE = {}
+# Enable client request caching
+$CLIENT_REQUEST_CACHING = true
+
+# If you don't use Airbrake you can have exceptions emailed to the $ERROR_EMAIL address by setting this to 'true'
+$EMAIL_EXCEPTIONS = false
+
+# Announcements mailman mailing list REQUEST address, EX: list-request@lists.example.org
+# NOTE: You must use the REQUEST address for the mailing list. ONLY WORKS WITH MAILMAN LISTS.
+$ANNOUNCE_LIST ||= 'appliance-users-request@localhost'
+
+# Email addresses used for sending notifications (errors, feedback, support)
+$SUPPORT_EMAIL ||= 'support@localhost'
+$ADMIN_EMAIL ||= 'admin@localhost'
+$ERROR_EMAIL ||= 'errors@localhost'
+
+# Custom BioPortal logging
+require 'log'
+$REMOTE_LOGGING = false
+
+##
+# Custom Ontology Details
+# Custom details can be added on a per ontology basis using a key/value pair as columns of the details table
+#
+# Example:
+# $ADDITIONAL_ONTOLOGY_DETAILS = { 1000 => { "Additional Detail" => "Text to be shown in the right-hand column." } }
+##
+$ADDITIONAL_ONTOLOGY_DETAILS = {}
+
+# Site notice appears on all pages and remains closed indefinitely. Stored below as a hash with a unique key and a
+#  EX: $SITE_NOTICE = { :unique_key => 'Put your message here (can include <a href="/link">html</a> if you use
+$SITE_NOTICE = {}
+################################
+## AUTO-GENERATED DO NOT MODIFY
+#################################
+
+# Full string for site, EX: "NCBO BioPortal"
+$ORG_SITE = $ORG.nil? || $ORG.empty? ? $SITE : "#{$ORG} #{$SITE}"
+
+$HOME_PAGE_LOGOS = {
+  supported_by: [
+    {
+      img_src: 'logos/supports/numev.png',
+      url: 'http://www.lirmm.fr/numev',
+      target: '_blank'
+    },
+    {
+      img_src: 'logos/supports/anr.png',
+      url: 'https://anr.fr/en',
+      target: '_blank'
+    },
+    {
+      img_src: 'logos/supports/eu.png',
+      url: 'https://commission.europa.eu/research-and-innovation_en',
+      target: '_blank'
+    }
+  ],
+  with_the_collaboration_of: [
+    {
+      img_src: 'logos/collaboration/d2kab.png',
+      url: 'http://d2kab.mystrikingly.com',
+      target: '_blank'
+    },
+    {
+      img_src: 'logos/collaboration/lirmm.png',
+      url: 'http://www.lirmm.fr',
+      target: '_blank'
+    },
+    {
+      img_src: 'logos/collaboration/inrae.png',
+      url: 'https://www.inrae.fr/enm',
+      target: '_blank'
+    },
+    {
+      img_src: 'logos/collaboration/stanford.png',
+      url: 'https://www.stanford.edu',
+      target: '_blank'
+    }
+  ]
+}
+
+$FOOTER_LINKS = {
+  social: [
+    { logo: 'social/people.svg', link: 'https://github.com/orgs/agroportal/people' },
+    { logo: 'social/github.svg', link: 'https://github.com/agroportal' },
+    { logo: 'social/twitter.svg', link: 'https://twitter.com/lagroportal' }
+  ],
+  sections: {
+    products: {
+      ontoportal: 'https://ontoportal.org/',
+      release_notes: 'https://doc.jonquetlab.lirmm.fr/share/e6158eda-c109-4385-852c-51a42de9a412/doc/release-notes-btKjZk5tU2',
+      api: 'https://data.agroportal.lirmm.fr/',
+      sparql: 'https://sparql.agroportal.lirmm.fr/test/'
+    },
+    support: {
+      contact_us: 'https://agroportal.lirmm.fr/feedback',
+      wiki: 'https://www.bioontology.org/wiki/',
+      documentation: 'https://ontoportal.github.io/documentation/'
+    },
+    agreements: {
+      terms: '',
+      privacy_policy: '',
+      cite_us: '',
+      acknowledgments: ''
+    },
+    about: {
+      about_us: 'https://github.com/agroportal/project-management',
+      projects: 'https://d2kab.mystrikingly.com/',
+      team: 'https://github.com/orgs/agroportal/people'
+    }
+  }
+}
+
+$UI_THEME = :stageportal
+if File.exist?('config/bioportal_config_development_testportal.lirmm.fr.rb')
+  require_relative 'bioportal_config_development_testportal.lirmm.fr' # local credentials
+end

--- a/config/database.yml.sample
+++ b/config/database.yml.sample
@@ -12,10 +12,9 @@
 default: &default
   adapter: mysql2
   encoding: utf8mb4
-  pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
   username: root
   password: bp_user
-  host: db
+  host: 127.0.0.1
 
 development:
   <<: *default

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -1,4 +1,6 @@
-require "active_support/core_ext/integer/time"
+# frozen_string_literal: true
+
+require 'active_support/core_ext/integer/time'
 
 # The test environment is used exclusively to run your application's
 # test suite. You never need to work with it otherwise. Remember that
@@ -14,18 +16,18 @@ Rails.application.configure do
   # Eager loading loads your whole application. When running a single test locally,
   # this probably isn't necessary. It's a good idea to do in a continuous integration
   # system, or in some way before deploying your code.
-  config.eager_load = ENV["CI"].present?
+  config.eager_load = ENV['CI'].present?
 
   # Configure public file server for tests with Cache-Control for performance.
   config.public_file_server.enabled = true
   config.public_file_server.headers = {
-    "Cache-Control" => "public, max-age=#{1.hour.to_i}"
+    'Cache-Control' => "public, max-age=#{1.hour.to_i}"
   }
 
   # Show full error reports and disable caching.
   config.consider_all_requests_local       = true
   config.action_controller.perform_caching = false
-  config.cache_store = :null_store
+  config.cache_store = ActiveSupport::Cache::MemCacheStore.new('localhost:11211', namespace: 'BioPortal')
 
   # Raise exceptions instead of rendering exception templates.
   config.action_dispatch.show_exceptions = false

--- a/test/controllers/application_controller_test.rb
+++ b/test/controllers/application_controller_test.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class ApplicationControllerTest < ActionDispatch::IntegrationTest
+  test 'should show home page' do
+    get ''
+    assert_response :success
+  end
+
+  test 'should show projects page' do
+    get '/projects'
+    assert_response :success
+  end
+
+  test 'should show annotator page' do
+    get '/annotator'
+    assert_response :success
+  end
+
+  test 'should show recommender page' do
+    get '/recommender'
+    assert_response :success
+  end
+
+  test 'should show mapping page' do
+    get '/mappings'
+    assert_response :success
+  end
+
+  test 'should show feedback page' do
+    get '/feedback'
+    assert_response :success
+  end
+end

--- a/test/controllers/landscape_controller_test.rb
+++ b/test/controllers/landscape_controller_test.rb
@@ -1,9 +1,11 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class LandscapeControllerTest < ActionController::TestCase
-  test "should get index" do
+  test 'should get index' do
+    skip('take too much time')
     get :index
     assert_response :success
   end
-
 end

--- a/test/controllers/ontologies_controller_test.rb
+++ b/test/controllers/ontologies_controller_test.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class OntologiesControllerTest < ActionDispatch::IntegrationTest
+  ONTOLOGIES = LinkedData::Client::Models::Ontology.all(include: 'acronym')
+  PAGES = %w[summary classes properties notes mappings schemes collections widgets].freeze
+
+  test 'should return all the ontologies' do
+    get ontologies_path
+    assert_response :success
+  end
+
+  ONTOLOGIES.sample(5).flat_map { |ont| PAGES.map { |page| [ont, page] } }.each do |ont, page|
+    test "should get page #{page} of #{ont.acronym} ontology" do
+      path = "#{ontologies_path}/#{ont.acronym}?p=#{page}"
+      get path
+      assert_response :success, "GET #{path} returned #{response.status}"
+    end
+  end
+end


### PR DESCRIPTION
### Changes

* add GitHub CI tests (https://github.com/ontoportal-lirmm/bioportal_web_ui/pull/377/commits/69b2a21a0687842e17aac4ecf9293a4db8b7e603)
* Add the following tests (https://github.com/ontoportal-lirmm/bioportal_web_ui/pull/377/commits/4f38aff7598efb6555deaaeeff67e4c28177f147):
   *  Check that these pages: home, projects, annotator, recommender, mappings ontologies, and feedback, are accessible.
   * Take a sample of 5 ontologies,  and check for each of their pages: summary, classes, notes, widgets, instances, schemes, collection, and properties; they are accessible.