### PR TITLE
Fix: add current url in portals errors

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -793,8 +793,9 @@ class ApplicationController < ActionController::Base
   def internal_server_error(exception)
     current_user = session[:user] if defined?(session)
     request_ip = request.remote_ip if defined?(request)
-    
-    Notifier.error(exception, current_user, request_ip).deliver_now
+    current_url = request.original_url if defined?(request)
+  
+    Notifier.error(exception, current_user, request_ip, current_url).deliver_now
     render 'errors/internal_server_error', status: 500
   end
 end

--- a/app/mailers/notifier.rb
+++ b/app/mailers/notifier.rb
@@ -1,10 +1,11 @@
 class Notifier < ApplicationMailer
 
-  def error(error, current_user = nil, request_ip = nil)
+  def error(error, current_user = nil, request_ip = nil, current_url = nil)
     @error_message = error.message
     @backtrace = error.backtrace
     @current_user = current_user
     @request_ip = request_ip
+    @current_url = current_url
   
     mail(to: "#{$SUPPORT_EMAIL}", from: "#{$SUPPORT_EMAIL}",
         subject: "[#{$SITE}] Exception Mailer: #{@error_message}")

--- a/app/views/notifier/error.html.haml
+++ b/app/views/notifier/error.html.haml
@@ -20,6 +20,10 @@
             %p
                 %strong Request IP:
                 = @request_ip
+        - if @current_url
+            %p
+                %strong Current URL:
+                = @current_url
         %p
             %br/
             %strong Details:


### PR DESCRIPTION
## Context
 See: https://github.com/ontoportal-lirmm/bioportal_web_ui/issues/362
       https://github.com/ontoportal-lirmm/bioportal_web_ui/pull/385

## Changes
- [x] Add current url in the email of portals erros
![image](https://github.com/ontoportal-lirmm/bioportal_web_ui/assets/31127782/feca3f89-4a49-4ba5-82c7-5bda4478f7bd)
