### PR TITLE
Fix: upload/edit submission forms issues

### DIFF
--- a/app/assets/stylesheets/upload_ontology.scss
+++ b/app/assets/stylesheets/upload_ontology.scss
@@ -21,20 +21,6 @@
     flex-direction: column;
 }
 
-.Upload-ontology-title {
-    font-size: 18px;
-    display: flex;
-    font-weight: bold;
-    flex-direction: column;
-    align-items: center;
-}
-
-.Upload-ontology-title hr {
-    border: 1px solid var(--primary-color);
-    width: 93px;
-    margin: 0;
-}
-
 .upload-ontology-progress {
     display: flex;
     align-items: center;

--- a/app/views/ontologies/new.html.haml
+++ b/app/views/ontologies/new.html.haml
@@ -7,10 +7,14 @@
         = error_message_alert
         .upload-ontology-card
           .upload-ontology-center
-            .Upload-ontology-title
+            .d-flex.justify-content-between
+              %a{:href => "javascript:javascript:history.go(-1)"}
+                %img.lost-password-arrowback{:src => "#{asset_path("arrow-back.svg")}"}
+              .register-title-container
+                %h2.register-title
+                  = @is_update_ontology ? "Add new submisison for ontology #{@ontology.acronym}" : "Submit new ontology" 
+                %hr#register-title-line/
               %div
-                = @is_update_ontology ? "Add new submisison for ontology #{@ontology.acronym}" : "Submit new ontology"
-              %hr
             .upload-ontology-progress
               = render Layout::ProgressPagesComponent.new(pages_title: ['Details', 'General information', 'Dates and contacts']) do |c|
                 - c.page do

--- a/app/views/ontologies/new.html.haml
+++ b/app/views/ontologies/new.html.haml
@@ -10,7 +10,7 @@
             .d-flex.justify-content-between
               %a{:href => "javascript:javascript:history.go(-1)"}
                 %img.lost-password-arrowback{:src => "#{asset_path("arrow-back.svg")}"}
-              .register-title-container
+              .register-title-container.Upload-ontology-title
                 %h2.register-title
                   = @is_update_ontology ? "Add new submisison for ontology #{@ontology.acronym}" : "Submit new ontology" 
                 %hr#register-title-line/

--- a/app/views/ontologies/new.html.haml
+++ b/app/views/ontologies/new.html.haml
@@ -10,7 +10,7 @@
             .d-flex.justify-content-between
               %a{:href => "javascript:javascript:history.go(-1)"}
                 %img.lost-password-arrowback{:src => "#{asset_path("arrow-back.svg")}"}
-              .register-title-container.Upload-ontology-title
+              .register-title-container
                 %h2.register-title
                   = @is_update_ontology ? "Add new submisison for ontology #{@ontology.acronym}" : "Submit new ontology" 
                 %hr#register-title-line/

--- a/app/views/submissions/_form_content.html.haml
+++ b/app/views/submissions/_form_content.html.haml
@@ -1,7 +1,7 @@
 - unless @errors.nil?
   = turbo_frame_tag 'test', target: '_top' do
     = error_message_alert
-    = form_for :submission, url: ontology_submission_path(params["ontology_id"], params["id"]), html: { id: "ontology_submission_form", method: :put, multipart: true, 'data-turbo': true} do
+    = form_for :submission, url: ontology_submission_path(params["ontology_id"], params["id"]), html: { id: "ontology_submission_form", method: :put, multipart: true, 'data-turbo': true, novalidate: 'true'} do
       = render_submission_inputs('')
       %hr#edit-ontology-actions-devider
       .edit-ontology-actions

--- a/app/views/submissions/edit.html.haml
+++ b/app/views/submissions/edit.html.haml
@@ -2,7 +2,7 @@
 .center
   .edit-ontology-container
     = turbo_frame_tag("test") do
-      = form_for :submission, url: ontology_submission_path(@ontology.acronym, params["id"]), html: { id: "ontology_submission_form", method: :put, multipart: true, 'data-turbo': true, 'data-turbo-frame': '_top'} do
+      = form_for :submission, url: ontology_submission_path(@ontology.acronym, params["id"]), html: { id: "ontology_submission_form", method: :put, multipart: true, 'data-turbo': true, 'data-turbo-frame': '_top', novalidate: 'true'} do
         .edit-ontology-title
           %div Edit ontology
           %hr

--- a/test/system/submission_flows_test.rb
+++ b/test/system/submission_flows_test.rb
@@ -31,7 +31,7 @@ class SubmissionFlowsTest < ApplicationSystemTestCase
   test "create a new ontology and go to it's summary page" do
     visit new_ontology_url
 
-    assert_selector ".Upload-ontology-title > div", text: 'Submit new ontology', wait: 10
+    assert_text 'Submit new ontology', wait: 10
 
     within 'form#ontologyForm' do
       # Page 1


### PR DESCRIPTION
Done in this PR:
- I added a button to exit the upload ontology form
![Capture d'écran 2023-12-05 154304](https://github.com/ontoportal-lirmm/bioportal_web_ui/assets/61744974/62e23704-1ec7-4f84-91a3-36b6bf8f37ab)

- I fixed the infinit button loading problem in edit submission form when typing a wrong URL/URI (caused by the automatique validation of the field by the native HTML5)


