### PR TITLE
Fix: adding new submission action and add a system for it 

### DIFF
--- a/.github/workflows/tests-real-data-stageportal.yml
+++ b/.github/workflows/tests-real-data-stageportal.yml
@@ -8,7 +8,7 @@ name: "Run remote API (stageportal) tests CI"
 
 on:
   push:
-  pull_request_target:
+  pull_request:
     types: [ opened, reopened ]
 env:
   API_URL: https://data.stageportal.lirmm.fr/ # or ${{ secrets.API_URL }}

--- a/.github/workflows/tests-real-data-testportal.yml
+++ b/.github/workflows/tests-real-data-testportal.yml
@@ -8,7 +8,7 @@ name: "Run remote API (testportal) tests CI"
 
 on:
   push:
-  pull_request_target:
+  pull_request:
     types: [ opened, reopened ]
 env:
   API_URL: https://data.testportal.lirmm.fr/ # or ${{ secrets.API_URL }}

--- a/.github/workflows/tests-system.yml
+++ b/.github/workflows/tests-system.yml
@@ -8,7 +8,7 @@ name: "Run system tests CI"
 
 on:
   push:
-  pull_request_target:
+  pull_request:
     types: [ opened, reopened ]
 env:
   API_URL: http://localhost:9393

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,7 +8,7 @@ name: "Run local API tests CI"
 
 on:
   push:
-  pull_request_target:
+  pull_request:
     types: [ opened, reopened ]
 env:
   API_URL: http://localhost:9393

--- a/app/components/chip_button_component/chip_button_component.html.haml
+++ b/app/components/chip_button_component/chip_button_component.html.haml
@@ -1,6 +1,9 @@
 - if @type == "static"
   %span.chip_button_container{@html_options}
     = @text || content
+- elsif !content
+  %a.chip_button_container_clickable{@html_options}
+    = @text
 - else
   %span.chip_button_container_clickable{@html_options}
-    = @text || content
+    = content

--- a/app/controllers/concerns/submission_filter.rb
+++ b/app/controllers/concerns/submission_filter.rb
@@ -32,6 +32,10 @@ module SubmissionFilter
       submissions = submissions.sort_by { |x| -x[:popularity] }
     elsif @selected_sort_by.eql?('fair')
       submissions = submissions.sort_by { |x| -x[:fairScore] }
+    elsif @selected_sort_by.eql?('notes')
+      submissions = submissions.sort_by { |x| -x[:note_count] }
+    elsif @selected_sort_by.eql?('projects')
+      submissions = submissions.sort_by { |x| -x[:project_count] }
     end
     submissions
   end
@@ -194,6 +198,8 @@ module SubmissionFilter
       ['Sort by release date', 'released'],
       ['Sort by FAIR score', 'fair'],
       ['Sort by popularity', 'visits'],
+      ['Sort by notes', 'notes'],
+      ['Sort by projects', 'projects'],
     ]
 
     init_filters(params)

--- a/app/controllers/concerns/submission_updater.rb
+++ b/app/controllers/concerns/submission_updater.rb
@@ -116,14 +116,9 @@ module SubmissionUpdater
     ]
 
     submission_metadata.each do |m|
-
       m_attr = m["attribute"].to_sym
-
-      attributes << if m["enforce"].include?("list")
-                      [{ m_attr => {} }, { m_attr => []}]
-                    else
-                      m_attr
-                    end
+      m_attr =  Array(m["enforce"]).include?("list") ? [{ m_attr => {} }, { m_attr => []}] : m_attr
+      attributes << m_attr
     end
     p = params.permit(attributes.uniq)
     p['pullLocation'] = '' if p['isRemote']&.eql?('3')

--- a/app/controllers/submissions_controller.rb
+++ b/app/controllers/submissions_controller.rb
@@ -45,7 +45,8 @@ class SubmissionsController < ApplicationController
         return
       end
     end
-    @submission = save_submission(new_submission_hash(@ontology))
+    @submission = @ontology.explore.latest_submission({ display: 'all' })
+    @submission = save_submission(new_submission_hash(@ontology, @submission))
 
     if response_error?(@submission)
       show_new_errors(@submission)

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -431,6 +431,21 @@ module ApplicationHelper
     output = "<span class='more_less_container'><span class='truncated_more'>#{truncate(text, :length => length, :omission => trailing_text)}" + more + "</span>"
   end
 
+  def chips_component(id: , name: , label: , value: , checked: false , tooltip: nil, &block)
+    content_tag(:div, data: { controller: 'tooltip' }, title: tooltip) do
+      check_input(id: id, name: name, value: value, label: label, checked: checked, &block)
+    end
+  end
+
+  def group_chip_component(id: nil, name: , object: , checked: , value: nil, title: nil, &block)
+    title ||= object["name"]
+    value ||= (object["value"] || object["acronym"] || object["id"])
+
+    chips_component(id: id || value, name: name, label: object["acronym"],
+                    checked: checked,
+                    value: value, tooltip: title, &block)
+  end
+  alias  :category_chip_component :group_chip_component
 
   def add_comment_button(parent_id, parent_type)
     if session[:user].nil?

--- a/app/helpers/inputs_helper.rb
+++ b/app/helpers/inputs_helper.rb
@@ -17,8 +17,12 @@ module InputsHelper
                                       data: data)
   end
 
-  def check_input(id:, name:, value:, label: '', checked: false)
-    render ChipsComponent.new(name: name, id: id, label: label, value: value, checked: checked)
+  def check_input(id:, name:, value:, label: '', checked: false, &block)
+    render ChipsComponent.new(name: name, id: id, label: label, value: value, checked: checked) do |c|
+      if block_given?
+        capture(c, &block)
+      end
+    end
   end
 
   def switch_input(id:, name:, label:, checked: false, value: '', boolean_switch: false, style: nil)

--- a/app/helpers/ontologies_helper.rb
+++ b/app/helpers/ontologies_helper.rb
@@ -538,7 +538,7 @@ module OntologiesHelper
                                     ['JsonLd', 'MOD/json-ld'],
                                     ['XML', 'MOD/rdf-xml']
                                   ]) do |format, label|
-          render ChipButtonComponent.new(type: 'clickable', 'data-action': "metadata-downloader#download#{format}") do
+          render ChipButtonComponent.new(type: 'clickable', 'data-action': "click->metadata-downloader#download#{format}") do
             concat content_tag(:span, label)
             concat content_tag(:span, inline_svg("summary/download.svg", width: '15px', height: '15px'))
           end
@@ -601,7 +601,7 @@ module OntologiesHelper
         empty_state_message("No projects using #{ontology_acronym}")
       else
         horizontal_list_container(projects) do |project|
-           render ChipButtonComponent.new(url: project_path(project.acronym), text: project.name, type: "clickable")
+          render ChipButtonComponent.new(url: project_path(project.acronym), text: project.name, type: "clickable")
         end
       end
     end

--- a/app/helpers/submission_inputs_helper.rb
+++ b/app/helpers/submission_inputs_helper.rb
@@ -173,7 +173,9 @@ module SubmissionInputsHelper
 
     render(Layout::RevealComponent.new(init_show: ontology.viewingRestriction&.eql?('private'), show_condition: 'private')) do |c|
       c.button do
-        select_input(label: "Visibility", name: "ontology[viewingRestriction]", values: %w[public private], selected: ontology.viewingRestriction)
+        select_input(label: "Visibility", name: "ontology[viewingRestriction]", required: true,
+                     values: %w[public private],
+                     selected: ontology.viewingRestriction)
       end
       content_tag(:div, class: 'upload-ontology-input-field-container') do
         select_input(label: "Add or remove accounts that are allowed to see this ontology in #{portal_name}.", name: "ontology[acl]", values: @user_select_list, selected: ontology.acl, multiple: true)

--- a/app/helpers/submission_inputs_helper.rb
+++ b/app/helpers/submission_inputs_helper.rb
@@ -132,7 +132,9 @@ module SubmissionInputsHelper
       content_tag(:div, class: 'upload-ontology-chips-container') do
         hidden_field_tag('ontology[hasDomain][]') +
           categories.map do |category|
-            check_input(name: "ontology[hasDomain][]", id: category[:acronym], label: category[:acronym], value: category[:id], checked: ontology.hasDomain&.any? { |x| x.eql?(category[:id]) })
+            category_chip_component(id: category[:acronym], name: "ontology[hasDomain][]",
+                                    object: category, value: category[:id],
+                                    checked: ontology.hasDomain&.any? { |x| x.eql?(category[:id]) })
           end.join.html_safe
       end
     end
@@ -159,7 +161,9 @@ module SubmissionInputsHelper
       content_tag(:div, class: 'upload-ontology-chips-container') do
         hidden_field_tag('ontology[group][]') +
           groups.map do |group|
-            check_input(name: "ontology[group][]", id: group[:acronym], label: group[:acronym], value: group[:id], checked: ontology.group&.any? { |x| x.eql?(group[:id]) })
+            group_chip_component(name: "ontology[group][]", id: group[:acronym],
+                                 object: group, value: group[:id],
+                                 checked: ontology.group&.any? { |x| x.eql?(group[:id]) })
           end.join.html_safe
       end
     end

--- a/app/views/ontologies/browser/browse.html.haml
+++ b/app/views/ontologies/browser/browse.html.haml
@@ -60,17 +60,13 @@
                   .collapse{id: "browse-#{key}-filter", class: "#{values[2].positive? ? 'show': ''}"}
                     .browse-filter-checks-container
                       - values.first.each do |object|
-                        - title = (key.eql?(:categories) || key.eql?(:groups) ?  object["name"] : '')
-                        - value = (object["value"] || object["acronym"] || object["id"])
-                        %div{data: {controller: 'tooltip'}, title: title}
-                          = render ChipsComponent.new(id: value, name: key, value: value,
-                                    label:  object["acronym"].humanize,
-                                    checked: values[1]&.include?(object["id"])) do |c|
-                            - c.count do
-                              %span.badge.badge-light.ml-1
-                                = turbo_frame_tag "count_#{key}_#{object["id"]}", busy: true
-                                %span.show-if-loading
-                                  = render LoaderComponent.new(small:true)
+                        - title = (key.eql?(:categories) || key.eql?(:groups)) ? nil : ''
+                        = group_chip_component(name: key, object: object, checked: values[1]&.include?(object["id"]), title: title) do |c|
+                          - c.count do
+                            %span.badge.badge-light.ml-1
+                              = turbo_frame_tag "count_#{key}_#{object["id"]}", busy: true
+                              %span.show-if-loading
+                                = render LoaderComponent.new(small:true)
 
         .browse-second-row
           .browse-search-bar

--- a/app/views/ontologies/new.html.haml
+++ b/app/views/ontologies/new.html.haml
@@ -23,7 +23,7 @@
                   .upload-ontology-input-field-container
                     = attribute_input('description', long_text: true)
                   - if @is_update_ontology
-                    .upload-ontology-input-field-container
+                    .upload-ontology-input-field-container{id: "submissionnotes_from_group_input"}
                       = attribute_input("notes", label: 'Change notes')
                   .upload-ontology-field-container
                     = render Layout::RevealComponent.new(init_show: @submission.hasOntologyLanguage&.eql?('SKOS'), show_condition: 'SKOS') do |c|
@@ -40,6 +40,7 @@
                       - c.button do
                         = attribute_input("status")
                       .upload-ontology-field-container
+                        - @submission.valid = nil unless @submission.status&.eql?('retired')
                         = attribute_input("valid")
                   .upload-ontology-field-container
                     = render partial: 'ontologies/submission_location_form'
@@ -50,5 +51,5 @@
                       = attribute_input('modificationDate', label: 'Modification date', max_date: Date.today)
                     - else
                       = attribute_input('released',  label: 'Date of original creation',  max_date: Date.today)
-                  .upload-ontology-contact
+                  .upload-ontology-contact{id: "submissioncontact_from_group_input"}
                     = contact_input(show_help: false)

--- a/test/system/submission_flows_test.rb
+++ b/test/system/submission_flows_test.rb
@@ -33,48 +33,7 @@ class SubmissionFlowsTest < ApplicationSystemTestCase
 
     assert_selector ".Upload-ontology-title > div", text: 'Submit new ontology', wait: 10
 
-    within 'form#ontologyForm' do
-      # Page 1
-      fill_in 'ontology[name]', with: @new_ontology.name
-      fill_in 'ontology[acronym]', with: @new_ontology.acronym
-
-      tom_select 'ontology[viewingRestriction]', @new_ontology.viewingRestriction
-      tom_select 'ontology[administeredBy][]', @new_ontology.administeredBy
-
-      @new_ontology.hasDomain.each do |cat|
-        check cat.acronym, allow_label_click: true
-      end
-
-      @new_ontology.group.each do |group|
-        check group.acronym, allow_label_click: true
-      end
-
-      click_button 'Next'
-
-      # Page 2
-
-      fill_in 'submission[URI]', with: @new_submission.URI
-      fill_in 'submission[description]', with: @new_submission.description
-
-      tom_select 'submission[hasOntologyLanguage]', @new_submission.hasOntologyLanguage
-      tom_select 'submission[status]', @new_submission.status
-
-      choose 'submission[isRemote]', option: @new_submission.isRemote
-      fill_in 'submission[pullLocation]', with: @new_submission.pullLocation
-
-      click_button 'Next'
-
-      # Page 3
-      date_picker_fill_in 'submission[released]', @new_submission.released
-
-      @new_submission.contact.each do |contact|
-        all("[name^='submission[contact]'][name$='[name]']").last.set(contact["name"])
-        all("[name^='submission[contact]'][name$='[email]']").last.set(contact["email"])
-        find('.add-another-object', text: 'Add another contact').click
-      end
-
-      click_button 'Finish'
-    end
+    fill_ontology(@new_ontology, @new_submission)
 
     assert_selector 'h2', text: 'Ontology submitted successfully!'
     click_on current_url.gsub("/ontologies/success/#{@new_ontology.acronym}", '') + ontology_path(@new_ontology.acronym)
@@ -109,9 +68,6 @@ class SubmissionFlowsTest < ApplicationSystemTestCase
     @new_ontology.group.each do |group|
       assert_text group.name
     end
-
-
-
 
   end
 
@@ -336,6 +292,97 @@ class SubmissionFlowsTest < ApplicationSystemTestCase
 
   end
 
+  test "click on button add submission, create a new submission and go to it's summary page" do
+    submission_2 = fixtures(:submissions)[:submission2]
+    ontology_2 = fixtures(:ontologies)[:ontology2]
+    ontology_2[:administeredBy] = [@logged_user.username, @user_bob.username]
+    ontology_2[:hasDomain] = @categories.sample(3)
+    ontology_2[:group] = @groups.sample(2)
+    submission_2[:isRemote] = '1'
+
+    new_ontology1 = @new_ontology
+    existent_ontology = new_ontology1
+    existent_submission = @new_submission
+    existent_submission[:submissionStatus] = %w[ERROR_RDF UPLOADED]
+    create_ontology(existent_ontology, existent_submission)
+    visit ontology_path(existent_ontology.acronym)
+
+    # click add button
+    find("a.rounded-button[href=\"#{new_ontology_submission_path(existent_ontology.acronym)}\"]").click
+    sleep 1
+    # assert existent
+
+    assert_equal existent_ontology.name, find_field('ontology[name]').value
+    assert_equal existent_ontology.acronym, find_field('ontology[acronym]', disabled: true).value
+    # assert_equal existent_submission.administeredBy, find_field('ontology[administeredBy]').value
+    # assert_equal existent_submission.hasDomain, find_field('ontology[viewingRestriction]').value
+
+    click_button 'Next'
+
+    assert_equal existent_submission.URI, find_field('submission[URI]').value
+    assert_equal existent_submission.description, find_field('submission[description]').value
+    assert_equal existent_submission.hasOntologyLanguage, find_field('submission[hasOntologyLanguage]').value
+    assert_equal existent_submission.notes.sort, all('[name^="submission[notes]"]').map(&:value).sort
+    assert_equal existent_submission.pullLocation, find_field('submission[pullLocation]').value
+
+    click_button 'Next'
+
+    assert_equal Date.parse(existent_submission.modificationDate).to_s, find('[name="submission[modificationDate]"]', visible: false).value
+    assert_equal existent_submission.contact.map(&:values).flatten.sort, all('[name^="submission[contact]"]').map(&:value).sort
+
+    # fill new version metadata
+    click_button 'Back'
+    sleep 0.5
+    click_button 'Back'
+
+
+    fill_ontology(ontology_2, submission_2, add_submission: true)
+
+
+    assert_selector 'h2', text: 'Ontology submitted successfully!'
+    click_on current_url.gsub("/ontologies/success/#{existent_ontology.acronym}", '') + ontology_path(existent_ontology.acronym)
+
+    assert_text "#{ontology_2.name} (#{existent_ontology.acronym})"
+    assert_selector '.alert-message', text: "The ontology is processing."
+
+    ontology_2.hasDomain.each do |cat|
+      assert_text cat.name
+    end
+
+    refute_text 'Version IRI'
+    assert_text existent_submission.version, count: 1
+
+    assert_text submission_2.URI
+    assert_text submission_2.description
+    assert_text submission_2.pullLocation
+
+
+    # check
+    assert_selector '.fas.fa-key' if submission_2.status.eql?('private')
+
+    # check
+    assert_selector '.chip_button_container.chip_button_small', text: submission_2.hasOntologyLanguage
+
+    submission_2.contact.each do |contact|
+      assert_text contact["name"]
+      assert_text contact["email"]
+    end
+
+    open_dropdown "#community"
+
+    ontology_2.group.each do |group|
+      assert_text group.name
+    end
+
+
+    open_dropdown "#dates"
+    assert_date submission_2.modificationDate
+    assert_date existent_submission.released
+
+    refute_text 'Validity date'
+    refute_text 'Curation date'
+  end
+
   private
 
   def submission_general_edit_fill(ontology, submission, selected_categories:, selected_groups:)
@@ -426,11 +473,10 @@ class SubmissionFlowsTest < ApplicationSystemTestCase
 
   def submission_agent_edit_fill(submission)
     # TODO use list_inputs
-    submission.contact.each do |contact|
-      all("[name^='submission[contact]'][name$='[name]']").last.set(contact["name"])
-      all("[name^='submission[contact]'][name$='[email]']").last.set(contact["email"])
-      find('.add-another-object', text: 'Add another contact').click
-    end
+    wait_for_text "Contact"
+
+    list_inputs "#submissioncontact_from_group_input", "submission[contact]", submission.contact
+
 
     agent1 = fixtures(:agents)[:agent1]
     agent2 = fixtures(:agents)[:agent2]
@@ -558,5 +604,48 @@ class SubmissionFlowsTest < ApplicationSystemTestCase
   def open_dropdown(target)
     find(".dropdown-container .dropdown-title-bar[data-target=\"#{target}\"]").click
     sleep 1
+  end
+
+  def fill_ontology(new_ontology, new_submission, add_submission: false)
+    within 'form#ontologyForm' do
+      # Page 1
+      fill_in 'ontology[name]', with: new_ontology.name
+      fill_in 'ontology[acronym]', with: new_ontology.acronym unless add_submission
+
+      tom_select 'ontology[viewingRestriction]', new_ontology.viewingRestriction
+      tom_select 'ontology[administeredBy][]', new_ontology.administeredBy
+
+      list_checks new_ontology.hasDomain.map(&:acronym), @categories.map(&:acronym)
+      list_checks new_ontology.group.map(&:acronym), @groups.map(&:acronym)
+
+
+      click_button 'Next'
+
+      # Page 2
+      fill_in 'submission[URI]', with: new_submission.URI
+      fill_in 'submission[description]', with: new_submission.description
+
+      if add_submission
+        list_inputs "#submissionnotes_from_group_input", "submission[notes]", new_submission.notes
+      end
+      tom_select 'submission[hasOntologyLanguage]', new_submission.hasOntologyLanguage
+      tom_select 'submission[status]', new_submission.status
+
+      choose 'submission[isRemote]', option: new_submission.isRemote
+      fill_in 'submission[pullLocation]', with: new_submission.pullLocation
+
+      click_button 'Next'
+
+      # Page 3
+      if add_submission
+       date_picker_fill_in 'submission[modificationDate]', new_submission.modificationDate
+      else
+       date_picker_fill_in 'submission[released]', new_submission.released
+      end
+
+      list_inputs "#submissioncontact_from_group_input", "submission[contact]", new_submission.contact
+
+      click_button 'Finish'
+    end
   end
 end


### PR DESCRIPTION
### Changes
* Add sort by notes and projects to browse page (https://github.com/ontoportal-lirmm/bioportal_web_ui/pull/403/commits/85d8592e455dc49860422203e6e24ff4c6ddf658)
<img width="447" alt="image" src="https://github.com/ontoportal-lirmm/bioportal_web_ui/assets/29259906/3e139db7-e0e5-4f64-bcde-7ccad695bcd2">

* Fix chips button component to be clickable again (https://github.com/ontoportal-lirmm/bioportal_web_ui/pull/403/commits/936c165823e4b034165c89161366590444ee44d7)

* Make the visibility property in the ontology form required (https://github.com/ontoportal-lirmm/bioportal_web_ui/pull/403/commits/86428d38bf70ca12aefc3581e159a21d100bec3d)

* Extract and reuse group chip component from browse page to ontology form (https://github.com/ontoportal-lirmm/bioportal_web_ui/pull/403/commits/1f0f36c1889567b3bc69dc042e9fe69f4f3b29e7)
<img width="447" alt="image" src="https://github.com/ontoportal-lirmm/bioportal_web_ui/assets/29259906/a42ee936-ca50-4570-9ffd-7d0360b230aa">

* Add the new submission to an ontology flow test (https://github.com/ontoportal-lirmm/bioportal_web_ui/pull/403/commits/8a0132c4d40c998714d1d94908e051f49be3baf9)
* Prevent the add new submission form to copy all the old submission vals](https://github.com/ontoportal-lirmm/bioportal_web_ui/pull/403/commits/e4d45887e3b8afa7cd11ef1a15b6ed8942383a87)