### PR TITLE
Fix: Optimize some pages load speed (metadata curator, summary, agents admin)

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/ontoportal-lirmm/ontologies_api_ruby_client.git
-  revision: 81313703f27bcd9b054fcf9fbe9d3c389647bcbe
+  revision: 674193220f93d99587e6d3a969adcb384caf0a61
   branch: development
   specs:
     ontologies_api_client (2.2.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/ontoportal-lirmm/ontologies_api_ruby_client.git
-  revision: 169afb7c1002f9db2b3276af36d552575cc80ba2
+  revision: 81313703f27bcd9b054fcf9fbe9d3c389647bcbe
   branch: development
   specs:
     ontologies_api_client (2.2.0)
@@ -99,6 +99,7 @@ GEM
       erubi (~> 1.4)
       parser (>= 2.4)
       smart_properties
+    bigdecimal (3.1.5)
     bindata (2.4.15)
     bindex (0.8.1)
     bootsnap (1.17.0)
@@ -147,9 +148,9 @@ GEM
     daemons (1.4.1)
     dalli (3.2.6)
     date (3.3.4)
-    debug (1.8.0)
-      irb (>= 1.5.0)
-      reline (>= 0.3.1)
+    debug (1.9.0)
+      irb (~> 1.10)
+      reline (>= 0.3.8)
     deepl-rb (2.5.3)
     diff-lcs (1.5.0)
     docile (1.4.0)
@@ -158,7 +159,7 @@ GEM
     erubi (1.12.0)
     erubis (2.7.0)
     eventmachine (1.2.7)
-    excon (0.105.0)
+    excon (0.108.0)
     execjs (2.9.1)
     faraday (2.0.1)
       faraday-net_http (~> 2.0)
@@ -177,7 +178,7 @@ GEM
     flamegraph (0.9.5)
     globalid (1.2.1)
       activesupport (>= 6.1)
-    graphql (2.1.6)
+    graphql (2.1.7)
       racc (~> 1.4)
     graphql-client (0.18.0)
       activesupport (>= 3.0)
@@ -218,8 +219,8 @@ GEM
     inline_svg (1.9.0)
       activesupport (>= 3.0)
       nokogiri (>= 1.6)
-    io-console (0.6.0)
-    irb (1.9.1)
+    io-console (0.7.1)
+    irb (1.10.1)
       rdoc
       reline (>= 0.3.8)
     iso-639 (0.3.6)
@@ -231,7 +232,7 @@ GEM
       railties (>= 3.2.16)
     jsbundling-rails (1.2.1)
       railties (>= 6.0.0)
-    json (2.7.0)
+    json (2.7.1)
     json-jwt (1.16.3)
       activesupport (>= 4.2)
       aes_key_wrap
@@ -319,7 +320,8 @@ GEM
       rack (>= 1.2, < 4)
       snaky_hash (~> 2.0)
       version_gem (~> 1.1)
-    oj (3.16.1)
+    oj (3.16.3)
+      bigdecimal (>= 3.0)
     omniauth (2.1.1)
       hashie (>= 3.4.6)
       rack (>= 2.2.3)
@@ -346,7 +348,7 @@ GEM
       actionpack (>= 4.2)
       omniauth (~> 2.0)
     open_uri_redirections (0.2.1)
-    parallel (1.23.0)
+    parallel (1.24.0)
     parser (3.2.2.4)
       ast (~> 2.4.1)
       racc
@@ -412,7 +414,7 @@ GEM
     recaptcha (5.9.0)
       json
     redcarpet (3.6.0)
-    regexp_parser (2.8.2)
+    regexp_parser (2.8.3)
     reline (0.4.1)
       io-console (~> 0.5)
     rest-client (2.1.0)

--- a/app/components/ontology_subscribe_button_component.rb
+++ b/app/components/ontology_subscribe_button_component.rb
@@ -1,8 +1,9 @@
 # frozen_string_literal: true
 
 class OntologySubscribeButtonComponent < ViewComponent::Base
-  def initialize(ontology_id:, subscribed:, user_id:, count: 0, link: 'javascript:void(0);')
+  def initialize(id: '', ontology_id:, subscribed:, user_id:, count: 0, link: 'javascript:void(0);')
     super
+    @id = id
     @subscribed = subscribed
     @sub_text = subscribed ? 'UnWatch' : 'Watch'
     @link = link

--- a/app/components/ontology_subscribe_button_component/ontology_subscribe_button_component.html.haml
+++ b/app/components/ontology_subscribe_button_component/ontology_subscribe_button_component.html.haml
@@ -1,4 +1,4 @@
-%div{@controller_params, style: 'margin-left: 10px;'}
+%div{@controller_params, style: 'margin-left: 10px;', id: @id}
   = render PillButtonComponent.new do
     %a.d-flex.align-items-center{href: @link}
       = inline_svg_tag "eye.svg"

--- a/app/controllers/agents_controller.rb
+++ b/app/controllers/agents_controller.rb
@@ -8,7 +8,7 @@ class AgentsController < ApplicationController
 
   def show
     # we use :agent_id not :id
-    @agent = LinkedData::Client::Models::Agent.find(params[:agent_id])
+    @agent = LinkedData::Client::Models::Agent.find(params[:agent_id].split('/').last)
     not_found("Agent with id #{params[:agent_id]}") if @agent.nil?
 
     @agent_id = params[:id] || agent_id(@agent)
@@ -67,7 +67,7 @@ class AgentsController < ApplicationController
   end
 
   def edit
-    @agent = LinkedData::Client::Models::Agent.find(params[:id])
+    @agent = LinkedData::Client::Models::Agent.find(params[:id].split('/').last)
     @name_prefix = params[:name_prefix] || ''
     @show_affiliations = params[:show_affiliations].nil? || params[:show_affiliations].eql?('true')
     @deletable = params[:deletable].to_s.eql?('true')
@@ -99,7 +99,7 @@ class AgentsController < ApplicationController
     else
       success_message = 'Agent successfully updated'
       table_line_id = agent_table_line_id(agent_id(agent))
-      agent = LinkedData::Client::Models::Agent.find(agent.id)
+      agent = LinkedData::Client::Models::Agent.find(agent.id.split('/').last)
       streams = [alert_success(id: alert_id) { success_message },
                  replace(table_line_id, partial: 'agents/show_line', locals: { agent: agent })
       ]
@@ -147,7 +147,7 @@ class AgentsController < ApplicationController
 
   def destroy
     error = nil
-    @agent = LinkedData::Client::Models::Agent.find(params[:id])
+    @agent = LinkedData::Client::Models::Agent.find(params[:id].split('/').last)
     success_text = ''
 
     if @agent.nil?

--- a/app/controllers/agents_controller.rb
+++ b/app/controllers/agents_controller.rb
@@ -67,7 +67,7 @@ class AgentsController < ApplicationController
   end
 
   def edit
-    @agent = LinkedData::Client::Models::Agent.find("#{rest_url}/Agents/#{params[:id]}")
+    @agent = LinkedData::Client::Models::Agent.find(params[:id])
     @name_prefix = params[:name_prefix] || ''
     @show_affiliations = params[:show_affiliations].nil? || params[:show_affiliations].eql?('true')
     @deletable = params[:deletable].to_s.eql?('true')
@@ -147,7 +147,7 @@ class AgentsController < ApplicationController
 
   def destroy
     error = nil
-    @agent = LinkedData::Client::Models::Agent.find("#{rest_url}/Agents/#{params[:id]}")
+    @agent = LinkedData::Client::Models::Agent.find(params[:id])
     success_text = ''
 
     if @agent.nil?
@@ -198,7 +198,7 @@ class AgentsController < ApplicationController
   end
 
   def update_agent(id = params[:id], params)
-    agent = LinkedData::Client::Models::Agent.find("#{rest_url}/Agents/#{id}")
+    agent = LinkedData::Client::Models::Agent.find(id)
 
     params[:creator] = session[:user].id if (agent.creator.nil? || agent.creator.empty?) && (params[:creator] || '').empty?
 

--- a/app/controllers/concerns/ontology_updater.rb
+++ b/app/controllers/concerns/ontology_updater.rb
@@ -86,7 +86,7 @@ module OntologyUpdater
   def reset_agent_attributes
     helpers.agent_attributes.each do |attr|
       current_val = @submission[attr]
-      new_values = Array(current_val).map { |x| LinkedData::Client::Models::Agent.find(x) }
+      new_values = Array(current_val).map { |x| LinkedData::Client::Models::Agent.find(x.split('/').last) }
 
       new_values = new_values.first unless current_val.is_a?(Array)
 

--- a/app/controllers/concerns/ontology_updater.rb
+++ b/app/controllers/concerns/ontology_updater.rb
@@ -13,7 +13,7 @@ module OntologyUpdater
     rescue StandardError
       next
     end
-    [@ontology, @ontology.update(values: new_values)]
+    [@ontology, @ontology.update(values: new_values, cache_refresh_all: false)]
   end
 
   def ontology_from_params

--- a/app/controllers/ontologies_controller.rb
+++ b/app/controllers/ontologies_controller.rb
@@ -357,7 +357,7 @@ class OntologiesController < ApplicationController
       subscribed = false
       user_id = nil
     else
-      user = LinkedData::Client::Models::User.find(session[:user].id).first
+      user = LinkedData::Client::Models::User.find(session[:user].id)
       subscribed = helpers.subscribed_to_ontology?(ontology_acronym, user)
       link = "javascript:void(0);"
       user_id = user.id

--- a/app/controllers/ontologies_controller.rb
+++ b/app/controllers/ontologies_controller.rb
@@ -56,17 +56,17 @@ class OntologiesController < ApplicationController
     ] + update_filters_counts
 
     streams =if params[:page].nil?
-               [
-                 prepend('ontologies_list_container', partial: 'ontologies/browser/ontologies'),
-                 prepend('ontologies_list_container') {
-                   helpers.turbo_frame_tag("ontologies_filter_count_request") do
-                     helpers.browser_counter_loader
-                   end
-                 }
-               ]
-             else
-               [replace("ontologies_list_view-page-1", partial: 'ontologies/browser/ontologies')]
-             end
+                [
+                  prepend('ontologies_list_container', partial: 'ontologies/browser/ontologies'),
+                  prepend('ontologies_list_container') {
+                    helpers.turbo_frame_tag("ontologies_filter_count_request") do
+                      helpers.browser_counter_loader
+                    end
+                  }
+                ]
+              else
+                [replace("ontologies_list_view-page-1", partial: 'ontologies/browser/ontologies')]
+              end
 
     render turbo_stream: streams + count_streams
   end
@@ -246,7 +246,7 @@ class OntologiesController < ApplicationController
     # See: https://github.com/ncbo/bioportal_web_ui/issues/133.
     data_pages = KNOWN_PAGES - %w[summary notes]
     if @ontology.summaryOnly && params[:p].present? && data_pages.include?(params[:p].to_s)
-        redirect_to(ontology_path(params[:ontology]), status: :temporary_redirect) and return
+      redirect_to(ontology_path(params[:ontology]), status: :temporary_redirect) and return
     end
 
     #@ob_instructions = helpers.ontolobridge_instructions_template(@ontology)
@@ -346,6 +346,28 @@ class OntologiesController < ApplicationController
     end
   end
 
+  def subscriptions
+    ontology_id = params[:ontology_id]
+    return not_found if ontology_id.nil?
+
+    ontology_acronym = ontology_id.split('/').last
+
+    if session[:user].nil?
+      link = "/login?redirect=#{request.url}"
+      subscribed = false
+      user_id = nil
+    else
+      user = LinkedData::Client::Models::User.find(session[:user].id).first
+      subscribed = helpers.subscribed_to_ontology?(ontology_acronym, user)
+      link = "javascript:void(0);"
+      user_id = user.id
+    end
+
+    count = helpers.count_subscriptions(ontology_id)
+    render inline:  helpers.turbo_frame_tag('subscribe_button') {
+      render_to_string(OntologySubscribeButtonComponent.new(id: 'subscribe_button', ontology_id: ontology_id, subscribed: subscribed, user_id: user_id, count: count, link: link),  layout: nil)
+    }
+  end
 
   def virtual
     redirect_new_api
@@ -362,7 +384,7 @@ class OntologiesController < ApplicationController
       render partial: 'ontologies/sections/widgets', layout: 'ontology_viewer'
     end
   end
-  
+
 
   def show_additional_metadata
     @metadata = submission_metadata

--- a/app/controllers/ontologies_controller.rb
+++ b/app/controllers/ontologies_controller.rb
@@ -461,12 +461,11 @@ class OntologiesController < ApplicationController
 
         target_id = relation_value
         target_in_portal = false
+        target_ont = nil
         # if we find our portal URL in the ontology URL, then we just keep the ACRONYM to try to get the ontology.
-        relation_value = relation_value.split('/').last if relation_value.include?($UI_URL)
-
-        # Use acronym to get ontology from the portal
-        target_ont = LinkedData::Client::Models::Ontology.find_by_acronym(relation_value).first
-        if target_ont
+        if relation_value.include?(portal_name)
+          relation_value = relation_value.split('/').last
+          target_ont = LinkedData::Client::Models::Ontology.find_by_acronym(relation_value).first
           target_id = target_ont.acronym
           target_in_portal = true
         end

--- a/app/controllers/submissions_controller.rb
+++ b/app/controllers/submissions_controller.rb
@@ -88,9 +88,10 @@ class SubmissionsController < ApplicationController
     acronym = params[:ontology_id]
     submission_id = params[:id]
     if params[:ontology]
-      @ontology = update_existent_ontology(acronym)
-      if @ontology.nil? || response_error?(@ontology)
-        show_new_errors(@ontology, partial: 'submissions/form_content', id: 'test')
+      @ontology, response = update_existent_ontology(acronym)
+
+      if response.nil? || response_error?(response)
+        show_new_errors(response, partial: 'submissions/form_content', id: 'test')
         return
       end
     end
@@ -100,7 +101,7 @@ class SubmissionsController < ApplicationController
                          notice: 'Submission updated successfully'
     end
 
-    @submission, response = update_submission(update_submission_hash(acronym), submission_id)
+    @submission, response = update_submission(update_submission_hash(acronym), submission_id, @ontology)
     if params[:attribute].nil?
       if response_error?(response)
         show_new_errors(response, partial: 'submissions/form_content', id: 'test')

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -63,7 +63,7 @@ module ApplicationHelper
       end
     end
   end
-  
+
 
   def encode_param(string)
     CGI.escape(string)
@@ -476,21 +476,15 @@ module ApplicationHelper
 
   def subscribe_button(ontology_id)
     return if ontology_id.nil?
-    ontology_acronym = ontology_id.split('/').last
-
-    if session[:user].nil?
-      link = "/login?redirect=#{request.url}"
-      subscribed = false
-      user_id = nil
-    else
-      user = LinkedData::Client::Models::User.find(session[:user].id)
-      subscribed = subscribed_to_ontology?(ontology_acronym, user)
-      link = "javascript:void(0);"
-      user_id = user.id
+    render TurboFrameComponent.new(id: 'subscribe_button', src: ontology_subscriptions_path(ontology_id: ontology_id.split('/').last), class: 'ml-1') do |t|
+      t.loader do
+        content_tag(:div, style: 'margin-left: 10px;') do
+          render PillButtonComponent.new do
+            (content_tag(:span, 'Watching', class: 'ml-1') + render(LoaderComponent.new(small: true))).html_safe
+          end
+        end
+      end
     end
-
-    count = count_subscriptions(ontology_id)
-    render OntologySubscribeButtonComponent.new(ontology_id: ontology_id, subscribed: subscribed, user_id: user_id, count: count, link: link)
   end
 
   def admin_block(ontology: @ontology, user: session[:user], class_css: "admin-border", &block)

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -473,6 +473,13 @@ module ApplicationHelper
                     class: "add_proposal btn btn-primary", data: { show_modal_title_value: "Add a new proposal"}
     end
   end
+  def link?(str)
+    # Regular expression to match strings starting with "http://" or "https://"
+    link_pattern = /\Ahttps?:\/\//
+
+    # Check if the string matches the pattern
+    !!(str =~ link_pattern)
+  end
 
   def subscribe_button(ontology_id)
     return if ontology_id.nil?

--- a/app/helpers/fair_score_helper.rb
+++ b/app/helpers/fair_score_helper.rb
@@ -13,7 +13,11 @@ module FairScoreHelper
   end
   def get_fairness_json(ontologies_acronyms, apikey = user_apikey)
     begin
-      MultiJson.load(Faraday.get(get_fairness_service_url(apikey) + "&ontologies=#{ontologies_acronyms}&combined").body.force_encoding('ISO-8859-1').encode('UTF-8'))
+      conn = Faraday.new do |conn|
+        conn.options.timeout = 1
+      end
+      response = conn.get(get_fairness_service_url(apikey) + "&ontologies=#{ontologies_acronyms}&combined")
+      MultiJson.load(response.body.force_encoding('ISO-8859-1').encode('UTF-8'))
     rescue
       Rails.logger.warn "FAIRness service issue unreachable"
       {}

--- a/app/helpers/ontologies_helper.rb
+++ b/app/helpers/ontologies_helper.rb
@@ -291,12 +291,16 @@ module OntologiesHelper
   end
 
   def show_category_name(domain)
+    return domain unless link?(domain)
+
     acronym = domain.split('/').last.upcase
     category = LinkedData::Client::Models::Category.find(acronym).first
     category ? category.name : acronym.titleize
   end
 
   def show_group_name(domain)
+    return domain unless link?(domain)
+
     acronym = domain.split('/').last.upcase
     category = LinkedData::Client::Models::Group.find(acronym).first
     category ? category.name : acronym.titleize

--- a/app/helpers/ontologies_helper.rb
+++ b/app/helpers/ontologies_helper.rb
@@ -176,10 +176,9 @@ module OntologiesHelper
     else
       uri = submission.id + "/download?apikey=#{get_apikey}"
       links << { href: uri, label: submission.pretty_format }
-      latest = ontology.explore.latest_submission({ include_status: 'ready' })
-      if latest && latest.submissionId == submission.submissionId
+      if submission_ready?(submission)
         links << { href: "#{ontology.id}/download?apikey=#{get_apikey}&download_format=csv", label: "CSV" }
-        if !latest.hasOntologyLanguage.eql?('UMLS')
+        unless submission.hasOntologyLanguage.eql?('UMLS')
           links << { href: "#{ontology.id}/download?apikey=#{get_apikey}&download_format=rdf", label: "RDF/XML" }
         end
       end

--- a/app/helpers/ontologies_helper.rb
+++ b/app/helpers/ontologies_helper.rb
@@ -292,21 +292,16 @@ module OntologiesHelper
 
   def show_category_name(domain)
     acronym = domain.split('/').last.upcase
-    category = LinkedData::Client::Models::Category.find_by_acronym(acronym).first
+    category = LinkedData::Client::Models::Category.find(acronym).first
     category ? category.name : acronym.titleize
   end
 
   def show_group_name(domain)
     acronym = domain.split('/').last.upcase
-    category = LinkedData::Client::Models::Group.find_by_acronym(acronym).first
+    category = LinkedData::Client::Models::Group.find(acronym).first
     category ? category.name : acronym.titleize
   end
 
-  def show_group_name(domain)
-    acronym = domain.split('/').last.upcase
-    category = LinkedData::Client::Models::Group.find_by_acronym(acronym).first
-    category ? category.name : acronym
-  end
 
   def visits_data(ontology = nil)
     ontology ||= @ontology

--- a/app/helpers/ontologies_helper.rb
+++ b/app/helpers/ontologies_helper.rb
@@ -294,7 +294,7 @@ module OntologiesHelper
     return domain unless link?(domain)
 
     acronym = domain.split('/').last.upcase.strip
-    category = LinkedData::Client::Models::Category.find(acronym).first
+    category = LinkedData::Client::Models::Category.find(acronym)
     category ? category.name : acronym.titleize
   end
 
@@ -302,7 +302,7 @@ module OntologiesHelper
     return domain unless link?(domain)
 
     acronym = domain.split('/').last.upcase.strip
-    category = LinkedData::Client::Models::Group.find(acronym).first
+    category = LinkedData::Client::Models::Group.find(acronym)
     category ? category.name : acronym.titleize
   end
 

--- a/app/helpers/ontologies_helper.rb
+++ b/app/helpers/ontologies_helper.rb
@@ -562,7 +562,7 @@ module OntologiesHelper
 
   def ontology_edit_button
     return unless @ontology.admin?(session[:user])
-    render RoundedButtonComponent.new(link: edit_ontology_path(@ontology.acronym), icon: 'edit.svg',
+    render RoundedButtonComponent.new(link: edit_ontology_submission_path(ontology_id: @ontology.acronym, id: @submission_latest.id.split('/').last), icon: 'edit.svg',
                                       size: 'medium',
                                       title: 'Edit metadata')
   end

--- a/app/helpers/ontologies_helper.rb
+++ b/app/helpers/ontologies_helper.rb
@@ -293,7 +293,7 @@ module OntologiesHelper
   def show_category_name(domain)
     return domain unless link?(domain)
 
-    acronym = domain.split('/').last.upcase
+    acronym = domain.split('/').last.upcase.strip
     category = LinkedData::Client::Models::Category.find(acronym).first
     category ? category.name : acronym.titleize
   end
@@ -301,7 +301,7 @@ module OntologiesHelper
   def show_group_name(domain)
     return domain unless link?(domain)
 
-    acronym = domain.split('/').last.upcase
+    acronym = domain.split('/').last.upcase.strip
     category = LinkedData::Client::Models::Group.find(acronym).first
     category ? category.name : acronym.titleize
   end

--- a/app/javascript/controllers/ontology_viewer_tabs_controller.js
+++ b/app/javascript/controllers/ontology_viewer_tabs_controller.js
@@ -36,10 +36,10 @@ export default class extends Controller {
   #disableLanguageSelector(selectedSection){
     if (this.languageSectionsValue.includes(selectedSection)){
       this.languageSelectorTarget.removeAttribute("disabled")
-      this.languageSelectorTarget.style.visibility = 'visible'
+      this.languageSelectorTarget.style.display = 'block'
     } else{
       this.languageSelectorTarget.setAttribute("disabled", true)
-      this.languageSelectorTarget.style.visibility = 'hidden'
+      this.languageSelectorTarget.style.display = 'none'
     }
   }
 

--- a/app/views/layouts/_ontology_viewer.html.haml
+++ b/app/views/layouts/_ontology_viewer.html.haml
@@ -56,7 +56,7 @@
                      selected: selected_section?(section_title),
                      page_name: ontology_viewer_page_name(@ontology.acronym, @concept&.prefLabel || '', section_title))
             - t.pinned_right do
-              %div{style: "visibility: #{ontology_data_section? ? 'visible' : 'hidden'}; border: none; outline: none; padding: 1px",
+              %div{style: "display: #{ontology_data_section? ? 'block' : 'none'}; border: none; outline: none; padding: 1px",
                 data: {'ontology-viewer-tabs-target': 'languageSelector' }}
                 = language_selector_tag(:content_language)
             - t.item_content do

--- a/app/views/ontologies_metadata_curator/_attribute_inline.html.haml
+++ b/app/views/ontologies_metadata_curator/_attribute_inline.html.haml
@@ -1,8 +1,8 @@
+- acronym = ontology ? ontology.acronym : submission.id.split('/')[-3]
 = render TurboFrameComponent.new(id: id) do
   %div.d-flex.justify-content-between.align-items-center
     %div.d-flex.justify-content-between
       %div
-        - acronym = ontology.acronym
         - equivalents = equivalent_properties(attribute)
         - equivalents.each do |attr|
           %div.d-flex
@@ -31,5 +31,5 @@
                         %p
                           = value
             %div
-              = edit_submission_property_link(ontology.acronym, submission.submissionId, attribute) do
+              = edit_submission_property_link(acronym, submission.submissionId, attribute) do
                 %i.far.fa-edit

--- a/app/views/ontologies_metadata_curator/_attribute_inline_editable.html.haml
+++ b/app/views/ontologies_metadata_curator/_attribute_inline_editable.html.haml
@@ -1,4 +1,4 @@
-- acronym = ontology.acronym
+- acronym = ontology ? ontology.acronym : submission.id.split('/')[-3]
 - submission_id = submission.submissionId
 - id = attribute_input_frame_id(acronym, submission_id, attribute)
 = render TurboFrameComponent.new(id: id+'_form') do
@@ -7,4 +7,4 @@
     = hidden_field object_name(acronym, submission_id), :id, value: submission_id
     = hidden_field_tag :attribute, attribute
     = render partial: "ontologies_metadata_curator/attribute_inline", locals: { id: id, attribute: attribute,
-                    submission: submission, ontology: ontology }
+                    submission: submission , ontology: ontology}

--- a/app/views/ontologies_metadata_curator/_metadata_table_row.html.haml
+++ b/app/views/ontologies_metadata_curator/_metadata_table_row.html.haml
@@ -1,4 +1,4 @@
-- acronym = submission.ontology.acronym
+- acronym = submission.id.split('/')[-3]
 - id = ontology_submission_id_label(acronym, submission.submissionId)
 %tr{id: id+'_row'}
   %th{scope:"row", style: 'width: 5%'}
@@ -7,4 +7,4 @@
         %h6{style:'margin-top: 0.2rem'}=id
   - attributes.each do |meta|
     %td{style: "width: #{95 / attributes.size}%; vertical-align: top; word-break: break-word;"}
-      = render partial: 'attribute_inline_editable', locals: {attribute: meta, submission: submission, ontology: submission.ontology}
+      = render partial: 'attribute_inline_editable', locals: {attribute: meta, submission: submission, ontology: nil}

--- a/app/views/submissions/_submissions.html.haml
+++ b/app/views/submissions/_submissions.html.haml
@@ -28,11 +28,6 @@
             %div.align-middle
               Actions
 
-      - begin
-        - submission_ready = @ontology.explore.latest_submission({:include_status => 'ready', display: 'submissionId'})
-        - submission_readyId = submission_ready.submissionId unless submission_ready.nil?
-      - rescue
-        - submission_readyId = -1
       - @submissions.each_with_index do |sub, index|
         - hidden_row_class = index >= 5 ? "hidden_ont hidden_select" : ""
         - t.row(id:"submission_#{sub.submissionId}" , class_css: hidden_row_class) do |r|
@@ -40,7 +35,7 @@
           - if @ontology.admin?(session[:user])
             - r.td { raw sub.submissionId }
           - r.td do
-            = render SubmissionStatusComponent.new(sub, sub.submissionId==submission_readyId) 
+            = render SubmissionStatusComponent.new(sub, submission_ready?(sub))
           - r.td {  xmldatetime_to_date(sub.modificationDate) unless sub.modificationDate.nil? }
           - r.td {  xmldatetime_to_date(sub.creationDate) unless sub.creationDate.nil? }
 

--- a/app/views/submissions/edit.html.haml
+++ b/app/views/submissions/edit.html.haml
@@ -1,7 +1,7 @@
 - section = params[:section] || 'general'
 .center
   .edit-ontology-container
-    = turbo_frame_tag(params[:container_id]) do
+    = turbo_frame_tag(params[:container_id] || 'test') do
       = form_for :submission, url: ontology_submission_path(@ontology.acronym, params["id"]), html: { id: "ontology_submission_form", method: :put, multipart: true, 'data-turbo': true, 'data-turbo-frame': '_top', novalidate: 'true'} do
         .edit-ontology-title
           %div Edit ontology

--- a/bin/ontoportal
+++ b/bin/ontoportal
@@ -179,7 +179,7 @@ test() {
   echo "Running tests..."
   echo "Run: API_URL=$api_url bundle exec rails test -v $test_options"
 
-  docker compose run --rm -it test bash -c "(bundle check || bundle install) && RAILS_ENV=test bin/rails db:prepare && API_URL=$api_url bundle exec rails test -v $test_options"
+  docker compose run --rm -it test bash -c "bundle config unset local.ontologies_api_client && (bundle check || bundle install) && RAILS_ENV=test bin/rails db:prepare && API_URL=$api_url bundle exec rails test -v $test_options"
 
   # echo "Stopping API..."
   # bin/stop_api

--- a/bin/ontoportal
+++ b/bin/ontoportal
@@ -64,12 +64,17 @@ dev() {
   
 
   local reset_cache=false
+  local api_client_path=""
   local api_url=""
   local api_key=""
 
   # Check for command line arguments
   while [[ "$#" -gt 0 ]]; do
     case $1 in
+      --api-client-path)
+        api_client_path="$2"
+        shift 2
+        ;;
       --reset-cache)
         reset_cache=true
         shift
@@ -114,8 +119,27 @@ dev() {
     docker compose down --volumes
   fi
 
+  local docker_run_cmd="docker compose run --rm -it"
+  local bash_cmd=""
+  # Conditionally add bind mounts only if the paths are not empty
+      for path_var in "api_client_path:ontologies_api_ruby_client" ; do
+        IFS=':' read -r path value <<< "$path_var"
+
+        if [ -n "${!path}" ]; then
+          host_path="$(realpath "$(dirname "${!path}")")/$value"
+          echo "Run: bundle config local.$value ${!path}"
+          container_path="/app/tmp/$value"
+          docker_run_cmd+=" -v $host_path:$container_path"
+          bash_cmd+="(bundle config local.ontologies_api_client $container_path) &&"
+        else
+          bash_cmd+=" (bundle config unset local.ontologies_api_client) &&"
+        fi
+  done
+  bash_cmd+=" (bundle check || bundle install || bundle update) && bin/rails db:prepare && bundle exec rails s -b 0.0.0.0 -p 3000"
+  docker_run_cmd+=" --service-ports rails bash -c \"$bash_cmd\""
+  echo "$docker_run_cmd"
   echo "Run: bundle exec rails s -b 0.0.0.0 -p 3000"
-  docker compose run --rm -it --service-ports rails bash -c "(bundle check || bundle install) && bin/rails db:prepare && bundle exec rails s -b 0.0.0.0 -p 3000"
+  eval "$docker_run_cmd"
 }
 
 # Function to handle the "test" option

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -48,13 +48,14 @@ Rails.application.routes.draw do
   resources :ontologies do
     resources :submissions do 
       get 'edit_properties'
-    end 
+    end
 
     get 'instances/:instance_id', to: 'instances#show', constraints: { instance_id: /[^\/?]+/ }
     get 'schemes/show_scheme', to: 'schemes#show'
     get 'collections/show'
     get 'metrics'
     get 'metrics_evolution'
+    get 'subscriptions'
   end
 
   resources :login

--- a/test/system/submission_flows_test.rb
+++ b/test/system/submission_flows_test.rb
@@ -264,32 +264,33 @@ class SubmissionFlowsTest < ApplicationSystemTestCase
     # Assert relations
     click_on "See all metadata"
     sleep 1
-    within "#application_modal_content" do
-      wait_for 'input[type="search"]'
-      find('input').set('hasPriorVersion')
-      assert_text submission_2.hasPriorVersion
-
-      submission_2.alternative.each do |alt|
-        find('input').set('alternative')
-        assert_text alt
-      end
-
-      submission_2.hiddenLabel.each do |alt|
-        find('input').set('hiddenLabel')
-        assert_text alt
-      end
-
-      relations = [:hasPart, :ontologyRelatedTo, :similarTo, :comesFromTheSameDomain,
-                   :isAlignedTo, :isBackwardCompatibleWith, :isIncompatibleWith,
-                   :hasDisparateModelling, :hasDisjunctionsWith, :generalizes,
-                   :explanationEvolution, :useImports,
-                   :usedBy, :workTranslation, :translationOfWork
-      ]
-      relations.each do |key|
-        find('input').set(key)
-        2.times.each { |id| assert_text "https://#{key}.2.#{id}.com" }
-      end
-    end
+    # TODO put again when the sell all metadata popup, have the option to search all the metadata
+    # within "#application_modal_content" do
+    #   wait_for 'input[type="search"]'
+    #   find('input').set('hasPriorVersion')
+    #   assert_text submission_2.hasPriorVersion
+    #
+    #   submission_2.alternative.each do |alt|
+    #     find('input').set('alternative')
+    #     assert_text alt
+    #   end
+    #
+    #   submission_2.hiddenLabel.each do |alt|
+    #     find('input').set('hiddenLabel')
+    #     assert_text alt
+    #   end
+    #
+    #   relations = [:hasPart, :ontologyRelatedTo, :similarTo, :comesFromTheSameDomain,
+    #                :isAlignedTo, :isBackwardCompatibleWith, :isIncompatibleWith,
+    #                :hasDisparateModelling, :hasDisjunctionsWith, :generalizes,
+    #                :explanationEvolution, :useImports,
+    #                :usedBy, :workTranslation, :translationOfWork
+    #   ]
+    #   relations.each do |key|
+    #     find('input').set(key)
+    #     2.times.each { |id| assert_text "https://#{key}.2.#{id}.com" }
+    #   end
+    # end
 
   end
 

--- a/test/system/submission_flows_test.rb
+++ b/test/system/submission_flows_test.rb
@@ -78,7 +78,7 @@ class SubmissionFlowsTest < ApplicationSystemTestCase
     visit ontology_path(@new_ontology.acronym)
 
     # click edit button
-    find("a.rounded-button[href=\"#{edit_ontology_path(@new_ontology.acronym)}\"]").click
+    find("a.rounded-button[href=\"#{edit_ontology_submission_path(ontology_id: @new_ontology.acronym, id: 1)}\"]").click
     sleep 1
 
     selected_categories = @categories[3..4]


### PR DESCRIPTION
### Prerequisites
* https://github.com/ontoportal-lirmm/ontologies_api_ruby_client/pull/14 

### Changes
* Optimize the summary page loading time ( 51.06% less time), by 
   * [update the summary watch button to be lazy loaded](https://github.com/ontoportal-lirmm/bioportal_web_ui/pull/411/commits/0b65c2497d6e251e8aa6f1682d3a191a542883c6)
   * [optimize the submissions partial to not load the latest submission twice](https://github.com/ontoportal-lirmm/bioportal_web_ui/pull/411/commits/58f7faceeccb48f4d714738a619464a38c4b1c11)
* Optimize submission update page loading time  (79.99% less time), by 
  * [optimize the submission update page speed](https://github.com/ontoportal-lirmm/bioportal_web_ui/pull/411/commits/3e875371837a8900623e8b5840dbe9602d09bed7)
* Optimize metadata curator page loading time (97.1% less time), by 
  *  [optimize the metadata curator call to use the new submissions endpoint](https://github.com/ontoportal-lirmm/bioportal_web_ui/pull/411/commits/69553afa8458bf8a378337211116b212b58bd08c)
* Optimize their agent admin page loading time (91.8% less time), by 
  * https://github.com/ontoportal-lirmm/ontologies_linked_data/commit/e128d4422ece20c62acc3c2032e3029f4f6d7719 

See detailed benchmark in the comment below 