### PR TITLE
Fix: Add slider component to recommender page 

### DIFF
--- a/app/assets/stylesheets/components/index.scss
+++ b/app/assets/stylesheets/components/index.scss
@@ -30,3 +30,4 @@
 @import "radio";
 @import "progress_bar";
 @import "search_result";
+@import "range_slider";

--- a/app/assets/stylesheets/components/range_slider.scss
+++ b/app/assets/stylesheets/components/range_slider.scss
@@ -1,0 +1,59 @@
+.range-slider{
+    position: relative;
+    width: 100%;
+
+}
+.range-slider input{
+    -webkit-appearance: none;
+    -moz-appearance: none;
+    appearance: none;
+    background-color: #dbdbdb;
+    width: 100%;
+    position: absolute;
+    cursor: pointer;
+    height: 7px;
+    top: 4px;
+    border-radius: 5px;
+}
+.range-slider input::-webkit-slider-thumb{
+    -webkit-appearance: none;
+    width: 40px;
+    height: 40px;
+    cursor: pointer;
+    position: relative;
+    z-index: 3;
+}
+
+.range-slider .selector{
+    position: absolute;
+    z-index: 2;
+    left: 52%;
+}
+.range-slider .selector .select-button{
+    height: 15px;
+    width: 15px;
+    border-radius: 50%;
+    position: absolute;
+    background-color: var(--primary-color);
+}
+.range-slider .select-range{
+    width: 53%;
+    position: absolute;
+    z-index: 1;
+    background-color: gray;
+    border-radius: 3px 0 0 3px;
+    height: 7px;
+    top: 4px;
+    background-color: var(--primary-color);
+}
+
+.range-slider-container .selection{
+    background: var(--primary-color);
+    border-radius: 3px;
+    display: inline-block;
+    margin-bottom: 5px;
+    color: white;
+    padding: 1px 8px;
+}
+
+

--- a/app/assets/stylesheets/recommender.scss
+++ b/app/assets/stylesheets/recommender.scss
@@ -44,7 +44,6 @@
     outline: none;
     padding: 20px;
     width: 630px;
-    resize: none;
     border: none;
     margin-right: 30px;
 }

--- a/app/assets/stylesheets/recommender.scss
+++ b/app/assets/stylesheets/recommender.scss
@@ -137,7 +137,7 @@
     margin-left: 20px;
 }
 
-.recommender-advanced-options .maxsets{
+.recommender-advanced-options .ontologies{
     margin-right: 20px;
 }
 .recommender-advanced-options .hidebutton{

--- a/app/assets/stylesheets/recommender.scss
+++ b/app/assets/stylesheets/recommender.scss
@@ -178,7 +178,14 @@
     font-weight: 600;
     text-decoration: underline !important;
 }
-.cite-us-button{
-    display: inline-block;
+
+.recommender-bottom-actions{
     margin-top: 20px;
+    display: flex;
+}
+.recommender-bottom-actions div{
+    display: inline-block;
+}
+.recommender-bottom-actions div + div{
+    margin-left: 20px;
 }

--- a/app/components/input/range_slider_component.rb
+++ b/app/components/input/range_slider_component.rb
@@ -1,0 +1,13 @@
+
+
+class Input::RangeSliderComponent < ViewComponent::Base
+    def initialize(name: nil, label: nil ,value: '50', min: '0', max: '100', step: '1')
+        @name = name
+        @label = label
+        @value = value
+        @min = min
+        @max = max
+        @step = step
+    end
+
+end

--- a/app/components/input/range_slider_component/range_slider_component.html.haml
+++ b/app/components/input/range_slider_component/range_slider_component.html.haml
@@ -1,0 +1,12 @@
+.range-slider-container{'data-controller': 'range-slider'}
+    - if @label
+        .text-input-label
+            = @label
+
+    .selection{'data-range-slider-target': 'selection'}
+        50
+    .range-slider
+        %input{type: "range", min: @min, max: @max, step: @step, value: @value, 'data-action': 'input->range-slider#handleInput', 'data-range-slider-target': 'input', name: @name}
+        .selector{'data-range-slider-target': 'selector'}
+            .select-button
+        .select-range{'data-range-slider-target': 'range'}

--- a/app/components/input/range_slider_component/range_slider_component_controller.js
+++ b/app/components/input/range_slider_component/range_slider_component_controller.js
@@ -1,0 +1,19 @@
+import {Controller} from "@hotwired/stimulus";
+
+export default class extends Controller {
+    static targets = ['selector', 'range', 'selection', 'input']
+    connect(){
+        this.#updateSelector()
+    }
+
+    handleInput(){
+        this.#updateSelector()
+    }
+
+    #updateSelector(){
+        let pourcentage = (this.inputTarget.value / this.inputTarget.max) * 100
+        this.selectorTarget.style.left = (pourcentage*0.95)+"%"
+        this.rangeTarget.style.width = (pourcentage*0+pourcentage)+"%"
+        this.selectionTarget.innerHTML = this.inputTarget.value
+    }
+}

--- a/app/controllers/recommender_controller.rb
+++ b/app/controllers/recommender_controller.rb
@@ -11,8 +11,11 @@ class RecommenderController < ApplicationController
                               t('recommender.results_table.detail_score'), t('recommender.results_table.specialization_score'),
                               t('recommender.results_table.annotations')
                             ]
-    @advanced_options_open = false              
-    if params[:input] != nil   
+    @advanced_options_open = false 
+    if params[:max_elements_set]
+      @not_valid_max_num_set = (params[:max_elements_set] < '2') || (params[:max_elements_set] > '4')
+    end
+    unless params[:input].nil?  ||  params[:input].empty? || @not_valid_max_num_set
       params[:ontologies] = params[:ontologies_list]&.join(',') || ''
       recommendations = LinkedData::Client::HTTP.post(RECOMMENDER_URI, params)
       @advanced_options_open = !recommender_params_empty?

--- a/app/controllers/recommender_controller.rb
+++ b/app/controllers/recommender_controller.rb
@@ -20,6 +20,7 @@ class RecommenderController < ApplicationController
       recommendations = LinkedData::Client::HTTP.post(RECOMMENDER_URI, params)
       @advanced_options_open = !recommender_params_empty?
       @results = []
+      @json_link = "#{$REST_URL}/recommender?input=#{params[:input]}&apikey=#{$API_KEY}&ontologies=#{params[:ontologies]}&max_elements_set=#{params[:max_elements_set]}&input_type=#{params[:input_type]}&output_type=#{params[:output_type]}&wc=#{params[:wc]}&wa=#{params[:wa]}&wd=#{params[:wd]}&ws=#{params[:ws]}"
       recommendations.each do |recommendation|
         row = {
           ontologies: recommendation_ontologies(recommendation),

--- a/app/controllers/recommender_controller.rb
+++ b/app/controllers/recommender_controller.rb
@@ -34,45 +34,6 @@ class RecommenderController < ApplicationController
     end
   end
 
-  # def create
-  #   # Parse params (default values are set at the service level)
-  #   input = params[:input].strip.gsub("\r\n", " ").gsub("\n", " ")
-  #   start = Time.now
-  #   query = RECOMMENDER_URI
-  #   query += "?input=" + CGI.escape(input)
-  #   query += "&ontologies=" + CGI.escape(params[:ontologies].join(',')) unless params[:ontologies].nil?
-  #   query += "&input_type=" + params[:input_type] unless params[:input_type].nil?
-  #   query += "&output_type=" + params[:output_type] unless params[:output_type].nil?
-  #   query += "&max_elements_set=" + params[:max_elements_set] unless params[:output_type].nil?
-  #   query += "&wc=" + params[:wc].to_s unless params[:wc].nil?
-  #   query += "&ws=" + params[:ws].to_s unless params[:ws].nil?
-  #   query += "&wa=" + params[:wa].to_s unless params[:wa].nil?
-  #   query += "&wd=" + params[:wd].to_s unless params[:wd].nil?
-  #   recommendations = parse_json(query) # See application_controller.rb
-  #   LOG.add :debug, "Retrieved #{recommendations.length} recommendations: #{Time.now - start}s"
-  #   render :json => recommendations
-  # end
-
-  # NOTE: this call (POST) works at a local environment but not in staging
-  def create
-    start = Time.now
-    input = params[:input].strip.gsub("\r\n", " ").gsub("\n", " ")
-    # Default values are set at the service level)
-    form_data = Hash.new
-    form_data['input'] = input
-    form_data['ontologies'] = params[:ontologies].join(',') unless params[:ontologies].nil?
-    form_data['input_type'] = params[:input_type] unless params[:input_type].nil?
-    form_data['output_type'] = params[:output_type] unless params[:output_type].nil?
-    form_data['max_elements_set'] = params[:max_elements_set] unless params[:output_type].nil?
-    form_data['wc'] = params[:wc].to_s unless params[:wc].nil?
-    form_data['ws'] = params[:ws].to_s unless params[:ws].nil?
-    form_data['wa'] = params[:wa].to_s unless params[:wa].nil?
-    form_data['wd'] = params[:wd].to_s unless params[:wd].nil?
-    recommendations = LinkedData::Client::HTTP.post(RECOMMENDER_URI, form_data, raw: true)
-    LOG.add :debug, "Retrieved #{recommendations.length} recommendations: #{Time.now - start}s"
-    render json: recommendations
-  end
-
   def recommendation_ontologies(recommendation)
     recommendation.ontologies.map { |ont| { acronym: ont.acronym, link: ont.id } }
   end

--- a/app/javascript/component_controllers/index.js
+++ b/app/javascript/component_controllers/index.js
@@ -23,6 +23,7 @@ import Progress_pages_component_controller
 import Reveal_component_controller from '../../components/layout/reveal_component/reveal_component_controller'
 import Table_component_controller from '../../components/table_component/table_component_controller'
 import clipboard_component_controller from '../../components/clipboard_component/clipboard_component_controller'
+import range_slider_component_controller from '../../components/input/range_slider_component/range_slider_component_controller'
 
 application.register('turbo-modal', TurboModalController)
 application.register('file-input', FileInputLoaderController)
@@ -38,3 +39,4 @@ application.register('progress-pages', Progress_pages_component_controller)
 application.register('reveal-component', Reveal_component_controller)
 application.register('table-component', Table_component_controller)
 application.register('clipboard', clipboard_component_controller)
+application.register('range-slider', range_slider_component_controller)

--- a/app/javascript/controllers/recommender_controller.js
+++ b/app/javascript/controllers/recommender_controller.js
@@ -43,6 +43,17 @@ export default class extends Controller {
     recommandations_area.innerHTML = words.join(' ');
   }
 
+  handleInput(event){
+    var selectedInputChoice = document.querySelector('input[name="input_type"]:checked').value;
+    if (selectedInputChoice === "2"){
+      const textarea = event.currentTarget
+      const value = textarea.value;
+      const lastCharIsSpace = event.data === ' ';
+      const formattedValue = lastCharIsSpace ? value.trim() + ', ' : value;
+      textarea.value = formattedValue;
+    }
+  }
+
   #toggle(element){
     element.classList.toggle('d-none')
   }

--- a/app/views/recommender/index.html.haml
+++ b/app/views/recommender/index.html.haml
@@ -43,10 +43,10 @@
                 .ontology-sets-choice
                   = render Input::RadioChipComponent.new(label: t('recommender.ontology_sets'), name: 'output_type', value: '2', checked: !check_output)
 
-            = show_advanced_options_button(text: t('show_advanced_options'), init: @advanced_options_open)
-            = hide_advanced_options_button(text: t('hide_advanced_options'), init: @advanced_options_open)
+            = show_advanced_options_button(text: t('show_advanced_options'), init: @advanced_options_open || @not_valid_max_num_set)
+            = hide_advanced_options_button(text: t('hide_advanced_options'), init: @advanced_options_open || @not_valid_max_num_set)
               
-        .recommender-advanced-options{'data-reveal-component-target': 'item', class: "#{@advanced_options_open ? '' : 'd-none'}"}
+        .recommender-advanced-options{'data-reveal-component-target': 'item', class: "#{@advanced_options_open || @not_valid_max_num_set ? '' : 'd-none'}"}
           .weights-configuration
             .title 
               = t('recommender.weights_configuration')
@@ -68,7 +68,7 @@
                 - get_ontologies_data
                 = render Input::SelectComponent.new(label: t('recommender.select_ontologies'), id: 'ontologies', name: 'ontologies_list[]', value: @onts_for_select, multiple: "multiple", selected: params[:ontologies_list])
               .maxsets.input.d-none{'data-recommender-target': 'maxset'}
-                = render Input::NumberComponent.new(label: t('recommender.max_ont_set'), name: "max_elements_set", value: params[:max_elements_set] || 3)
+                = render Input::NumberComponent.new(label: t('recommender.max_ont_set'), name: "max_elements_set", value: params[:max_elements_set] || 3, min: '2', max: '4', step: '1', error_message: "#{@not_valid_max_num_set ? 'Valid values are: 2, 3, 4' : ''}")
               .input{'data-recommender-target': 'empty'}
 
         .recommender-page-button#get_recommendations_button{class: is_input ?  "" : "d-none", 'data-recommender-target': 'button'}

--- a/app/views/recommender/index.html.haml
+++ b/app/views/recommender/index.html.haml
@@ -110,10 +110,18 @@
                 - r.td do
                   .recommender-result-highlighted{'data-action': 'change->recommender#handleHighlightedChange'}
                     = render Input::RadioChipComponent.new(label: result[:annotations].length.to_s+' annotations', name: 'highlighted_recommendation', value: result[:annotations], checked: result[:highlighted])
-
-        .cite-us-button
-          = render Buttons::RegularButtonComponent.new(id:'regular-button', value: "Cite", variant: "secondary", href: "https://doi.org/10.1186/s13326-017-0128-y", size: "slim", target: '_blank', state: "regular") do |btn|
-            - btn.icon_left do
-              = inline_svg_tag "icons/cite.svg"
+        .recommender-bottom-actions
+          .json-button
+            = render Buttons::RegularButtonComponent.new(id:'recommender_cite_json', value: "JSON", variant: "secondary", href: @json_link, size: "slim", target: '_blank', state: "regular") do |btn|
+              - btn.icon_left do
+                = inline_svg_tag "json.svg"
+          .cite-us-button
+            = render Buttons::RegularButtonComponent.new(id:'recommender_cite_us', value: "Cite", variant: "secondary", href: "https://doi.org/10.1186/s13326-017-0128-y", size: "slim", target: '_blank', state: "regular") do |btn|
+              - btn.icon_left do
+                = inline_svg_tag "icons/cite.svg"
+          .go-to-annotator
+            = render Buttons::RegularButtonComponent.new(id:'recommender_go_annotator', value: "Get results from annotator", variant: "secondary", href: "/annotator?text=#{params[:input]}&ontologies=#{params[:ontologies]}", size: "slim", target: '_blank', state: "regular") do |btn|
+              - btn.icon_right do
+                = inline_svg_tag "arrow-right-outlined.svg"
 
   

--- a/app/views/recommender/index.html.haml
+++ b/app/views/recommender/index.html.haml
@@ -63,11 +63,11 @@
             .title 
               = t('recommender.ontologies_configuration')
             .inputs-container
-              .maxsets.input.d-none{'data-recommender-target': 'maxset'}
-                = render Input::NumberComponent.new(label: t('recommender.max_ont_set'), name: "max_elements_set", value: params[:max_elements_set] || 3)
               .ontologies.input
                 - get_ontologies_data
                 = render Input::SelectComponent.new(label: t('recommender.select_ontologies'), id: 'ontologies', name: 'ontologies_list[]', value: @onts_for_select, multiple: "multiple", selected: params[:ontologies_list])
+              .maxsets.input.d-none{'data-recommender-target': 'maxset'}
+                = render Input::NumberComponent.new(label: t('recommender.max_ont_set'), name: "max_elements_set", value: params[:max_elements_set] || 3)
               .input{'data-recommender-target': 'empty'}
 
         .recommender-page-button#get_recommendations_button{class: is_input ?  "" : "d-none", 'data-recommender-target': 'button'}

--- a/app/views/recommender/index.html.haml
+++ b/app/views/recommender/index.html.haml
@@ -14,7 +14,7 @@
           %div
             - is_input = @results.nil? || @results.empty?
             .recommender-page-text-area{class: is_input ?  "" : "d-none", 'data-recommender-target': 'input', 'data-controller': 'sample-text'}
-              %textarea#recommender-text-area{rows: "4" , placeholder: t('recommender.hint'), name: "input", oninput: 'handleInput(event)',  maxlength: "500", 'data-sample-text-target': "input"}
+              %textarea#recommender-text-area{rows: "4" , placeholder: t('recommender.hint'), name: "input", oninput: 'handleInput(event)',  maxlength: "9678", 'data-sample-text-target': "input"}
                 = params[:input]
               = insert_sample_text_button(t('recommender.insert_sample_text'))
 

--- a/app/views/recommender/index.html.haml
+++ b/app/views/recommender/index.html.haml
@@ -14,7 +14,7 @@
           %div
             - is_input = @results.nil? || @results.empty?
             .recommender-page-text-area{class: is_input ?  "" : "d-none", 'data-recommender-target': 'input', 'data-controller': 'sample-text'}
-              %textarea#recommender-text-area{rows: "4" , placeholder: t('recommender.hint'), name: "input", oninput: 'handleInput(event)',  maxlength: "9678", 'data-sample-text-target': "input"}
+              %textarea#recommender-text-area{rows: "4" , placeholder: t('recommender.hint'), name: "input", 'data-action': "input->recommender#handleInput",  maxlength: "9678", 'data-sample-text-target': "input"}
                 = params[:input]
               = insert_sample_text_button(t('recommender.insert_sample_text'))
 
@@ -51,14 +51,15 @@
             .title 
               = t('recommender.weights_configuration')
             .inputs-container
+              -#binding.pry
               .ninput
-                = render Input::NumberComponent.new(label: t('recommender.converage'), name: "wc", value: params[:wc] || 0.55, min: '0', max: '1', step: '0.01')
+                = render Input::RangeSliderComponent.new(label: t('recommender.converage'), name: "wc", value: params[:wc] || 0.55, min: '0', max: '1', step: '0.01')
               .ninput
-                = render Input::NumberComponent.new(label: t('recommender.acceptance'), name: "wa", value: params[:wa] || 0.15, min: '0', max: '1', step: '0.01')
+                = render Input::RangeSliderComponent.new(label: t('recommender.acceptance'), name: "wa", value: params[:wa] || 0.15, min: '0', max: '1', step: '0.01')
               .ninput
-                = render Input::NumberComponent.new(label: t('recommender.knowledge_detail'), name: "wd", value: params[:wd] || 0.15, min: '0', max: '1', step: '0.01')
+                = render Input::RangeSliderComponent.new(label: t('recommender.knowledge_detail'), name: "wd", value: params[:wd] || 0.15, min: '0', max: '1', step: '0.01')
               .ninput
-                = render Input::NumberComponent.new(label: t('recommender.specialization'), name: "ws", value: params[:ws] || 0.15, min: '0', max: '1', step: '0.01')
+                = render Input::RangeSliderComponent.new(label: t('recommender.specialization'), name: "ws", value: params[:ws] || 0.15, min: '0', max: '1', step: '0.01')
           .ontologies-configuration
             .title 
               = t('recommender.ontologies_configuration')
@@ -114,17 +115,5 @@
           = render Buttons::RegularButtonComponent.new(id:'regular-button', value: "Cite", variant: "secondary", href: "https://doi.org/10.1186/s13326-017-0128-y", size: "slim", target: '_blank', state: "regular") do |btn|
             - btn.icon_left do
               = inline_svg_tag "icons/cite.svg"
-
-:javascript
-  function handleInput(event) {
-    var selectedInputChoice = document.querySelector('input[name="input_type"]:checked').value;
-    if (selectedInputChoice === "2"){
-      const textarea = document.getElementById('recommender-text-area');
-      const value = textarea.value;
-      const lastCharIsSpace = event.data === ' ';
-      const formattedValue = lastCharIsSpace ? value.trim() + ', ' : value;
-      textarea.value = formattedValue;
-    }
-  }
 
   


### PR DESCRIPTION
### Done in this PR:

- [x] Clean recommender controller from unused code.
- [x]  Maximize the limite of the input text length in recommender page (976 char)
- [x]  Make range slider component
- [x] Add 'JSON' and 'Get results from annotator' buttons
- [ ] Keywords by using line breaks instead of commas.
- [ ] Mouse hover to explain keywords

**Screenshots**
![image](https://github.com/ontoportal-lirmm/bioportal_web_ui/assets/61744974/36d28130-6d22-4e3c-a1df-a776d29a952c)
![image](https://github.com/ontoportal-lirmm/bioportal_web_ui/assets/61744974/f5dad683-d03f-4190-bf36-dcfd284e728f)
