### PR TITLE
Fix: Ontology views in upload ontology

### DIFF
--- a/app/helpers/submission_inputs_helper.rb
+++ b/app/helpers/submission_inputs_helper.rb
@@ -239,14 +239,13 @@ module SubmissionInputsHelper
   def ontology_view_of_input(ontology = @ontology)
     render Layout::RevealComponent.new(selected: !ontology.view?, toggle: true) do |c|
       c.button do
-        content_tag(:span, class: 'd-flex') do
+        content_tag(:span, class: 'd-flex mb-2') do
           switch_input(id: 'ontology_isView', name: 'ontology[isView]', label: 'Is this ontology a view of another ontology?', checked: ontology.view?, style: 'font-size: 14px;')
         end
-
-        c.container do
-          content_tag(:div) do
-            render partial: "shared/ontology_picker_single", locals: { placeholder: "", field_name: "viewOf", selected: ontology.viewOf }
-          end
+      end
+      c.container do
+        content_tag(:div) do
+          render partial: "shared/ontology_picker_single", locals: { placeholder: "", field_name: "viewOf", selected: ontology.viewOf }
         end
       end
     end


### PR DESCRIPTION
### Done in this PR:
Fixed an issue in the ontology_view_of_input function where a missing closure resulted in the disappearance of ontology view of from the upload ontology form.

### Screenshot:
![image](https://github.com/ontoportal-lirmm/bioportal_web_ui/assets/61744974/2d5bd19a-3dcd-437d-a705-448d92efa72e)
