### PR TITLE
Fix: Auto fill ontology viw of input when we click the '+' button in summary page

### DIFF
--- a/app/components/layout/reveal_component.rb
+++ b/app/components/layout/reveal_component.rb
@@ -6,7 +6,7 @@ class Layout::RevealComponent < ViewComponent::Base
 
   def initialize(selected: nil, possible_values: [], hidden_class: 'd-none', toggle: false)
     @hidden_class = hidden_class
-    @possible_values = possible_values
+    @possible_values = toggle && possible_values.empty? ? [true] : possible_values
     @selected = selected
     @toggle = toggle
   end

--- a/app/controllers/ontologies_controller.rb
+++ b/app/controllers/ontologies_controller.rb
@@ -156,6 +156,7 @@ class OntologiesController < ApplicationController
 
   def new
     @ontology = LinkedData::Client::Models::Ontology.new
+    @ontology.viewOf = params.dig(:ontology, :viewOf)
     @submission = LinkedData::Client::Models::OntologySubmission.new
     @submission.hasOntologyLanguage = 'OWL'
     @ontologies = LinkedData::Client::Models::Ontology.all(include: 'acronym', include_views: true, display_links: false, display_context: false)

--- a/app/helpers/submission_inputs_helper.rb
+++ b/app/helpers/submission_inputs_helper.rb
@@ -237,17 +237,15 @@ module SubmissionInputsHelper
   end
 
   def ontology_view_of_input(ontology = @ontology)
-    is_view_open = !params[:ontology]&.[](:viewOf).nil?
-    pre_selected_ontology = params[:ontology]&.[](:viewOf)
-    render Layout::RevealComponent.new(selected: is_view_open, toggle: true, possible_values: is_view_open ? [is_view_open] : []) do |c|
+    render Layout::RevealComponent.new(selected: ontology.view?, toggle: true) do |c|
       c.button do
         content_tag(:span, class: 'd-flex mb-2') do
-          switch_input(id: 'ontology_isView', name: 'ontology[isView]', label: 'Is this ontology a view of another ontology?', checked: is_view_open, style: 'font-size: 14px;')
+          switch_input(id: 'ontology_isView', name: 'ontology[isView]', label: 'Is this ontology a view of another ontology?', checked: ontology.view?, style: 'font-size: 14px;')
         end
       end
       c.container do
         content_tag(:div) do
-          render partial: "shared/ontology_picker_single", locals: { placeholder: "", field_name: "viewOf", selected: pre_selected_ontology}
+          render partial: "shared/ontology_picker_single", locals: { placeholder: "", field_name: "viewOf", selected: ontology.viewOf}
         end
       end
     end

--- a/app/helpers/submission_inputs_helper.rb
+++ b/app/helpers/submission_inputs_helper.rb
@@ -237,16 +237,17 @@ module SubmissionInputsHelper
   end
 
   def ontology_view_of_input(ontology = @ontology)
-    render Layout::RevealComponent.new(selected: !ontology.view?, toggle: true) do |c|
+    is_view_open = !params[:ontology]&.[](:viewOf).nil?
+    pre_selected_ontology = params[:ontology]&.[](:viewOf)
+    render Layout::RevealComponent.new(selected: is_view_open, toggle: true, possible_values: is_view_open ? [is_view_open] : []) do |c|
       c.button do
-        content_tag(:span, class: 'd-flex') do
-          switch_input(id: 'ontology_isView', name: 'ontology[isView]', label: 'Is this ontology a view of another ontology?', checked: ontology.view?, style: 'font-size: 14px;')
+        content_tag(:span, class: 'd-flex mb-2') do
+          switch_input(id: 'ontology_isView', name: 'ontology[isView]', label: 'Is this ontology a view of another ontology?', checked: is_view_open, style: 'font-size: 14px;')
         end
-
-        c.container do
-          content_tag(:div) do
-            render partial: "shared/ontology_picker_single", locals: { placeholder: "", field_name: "viewOf", selected: ontology.viewOf }
-          end
+      end
+      c.container do
+        content_tag(:div) do
+          render partial: "shared/ontology_picker_single", locals: { placeholder: "", field_name: "viewOf", selected: pre_selected_ontology}
         end
       end
     end


### PR DESCRIPTION
### Done in this PR:
Auto fill ontology view of input when we click the '+' button in summary page, see the demo for a better understanding.
### Demo

[Capture vidéo du 22-02-2024 17:59:02.webm](https://github.com/ontoportal-lirmm/bioportal_web_ui/assets/61744974/aebf6766-16a8-4012-bccd-bf82bee167c1)
