### PR TITLE
Feature: make home bubbles clickable

### DIFF
--- a/app/assets/stylesheets/home.scss
+++ b/app/assets/stylesheets/home.scss
@@ -66,7 +66,7 @@ i.fa.fa-caret-square-o-down {
   
 }
 
-.home-bubble h5{
+.home-bubble .h5{
   color: white;
   font-size: 18px;
   margin: 0;

--- a/app/views/home/index.html.haml
+++ b/app/views/home/index.html.haml
@@ -20,22 +20,22 @@
     .home-random-bubbles
       %img{:src => asset_path("home-random-bubbles.svg")}/
     .home-bubble.home-bubble-one
-      %h5
+      %a.h5{href:"/ontologies/#{@anal_ont_names[0]}", style: "color: white !important"}
         = @anal_ont_names[0]
       %p 
         = @anal_ont_numbers[0].to_s + " " + t('visits')
     .home-bubble.home-bubble-two
-      %h5
+      %a.h5{href:"/ontologies/#{@anal_ont_names[1]}", style: "color: white !important"}
         = @anal_ont_names[1]
       %p 
         = @anal_ont_numbers[1].to_s + " " + t('visits')
     .home-bubble.home-bubble-three
-      %h5
+      %a.h5{href:"/ontologies/#{@anal_ont_names[2]}", style: "color: white !important"}
         = @anal_ont_names[2]
       %p 
         = @anal_ont_numbers[2].to_s + " " + t('visits')
     %a.home-bubble.home-bubble-four{:href => "/visits"}
-      %h5 ...
+      .h5 ...
 
   .home-header-title-container
     .home-header-title


### PR DESCRIPTION
### Context:
I took on the perspective of a regular user. Upon landing on the home page, the ontology bubbles immediately caught my attention.
AGROVOC is the most visited ontology showed in the biggest bubble, I wanted to see more details about it so I clicked on it, but I found that it's not clickable.
So I had to manually copy the name of it and initiate a separate search.

### Done in this PR:
- I made the home page bubbles clickable.

### Demo
[Capture vidéo du 23-02-2024 12:13:18.webm](https://github.com/ontoportal-lirmm/bioportal_web_ui/assets/61744974/2f772632-e738-4489-b364-5f4ec0d7d1a8)



