### PR TITLE
Fix: display of content sections in summary page by adding option to disable text truncate 

### DIFF
--- a/app/components/field_container_component.rb
+++ b/app/components/field_container_component.rb
@@ -3,7 +3,7 @@
 class FieldContainerComponent < ViewComponent::Base
 
   renders_one :label
-  def initialize(label: nil, value: nil)
+  def initialize(label: nil, value: nil, truncate: false)
     super
     @label = label
     @value = value

--- a/app/components/layout/horizontal_list_component.rb
+++ b/app/components/layout/horizontal_list_component.rb
@@ -3,13 +3,17 @@
 class Layout::HorizontalListComponent < ViewComponent::Base
   renders_many :elements
 
+  def initialize(truncate: true)
+    @truncate = truncate ? 'text-truncate' : ''
+  end
+
   def call
     return if elements.empty?
 
     content_tag(:div, class: 'd-flex flex-wrap align-items-center') do
       out = ''
       elements.each do |element|
-        out = out +  content_tag(:div, element, class: 'mr-1 mb-1 text-truncate')
+        out = out +  content_tag(:div, element, class: "mr-1 mb-1 #{@truncate}")
       end
       raw out
     end

--- a/app/components/link_field_component/link_field_component.html.haml
+++ b/app/components/link_field_component/link_field_component.html.haml
@@ -1,7 +1,7 @@
 - if internal_link?
   = render ChipButtonComponent.new(type: "clickable") do
     = link_tag
-- elsif @value.to_s =~ /\A#{URI::regexp(%w[http https])}\z/
+- elsif link?(@value.to_s)
   = render ChipButtonComponent.new(type: "clickable") do
     = link_tag
 - else

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -81,7 +81,7 @@ module ApplicationHelper
       end
     end
   end
-  
+
 
 
   def encode_param(string)
@@ -138,7 +138,7 @@ module ApplicationHelper
     end
   end
 
- 
+
 
   def help_icon(link, html_attribs = {})
     html_attribs["title"] ||= "Help"
@@ -330,7 +330,7 @@ module ApplicationHelper
   def link?(str)
     # Regular expression to match strings starting with "http://" or "https://"
     link_pattern = /\Ahttps?:\/\//
-
+    str = str&.strip
     # Check if the string matches the pattern
     !!(str =~ link_pattern)
   end
@@ -496,7 +496,7 @@ module ApplicationHelper
     else
       link_to(link,'', {data: data[:data], class: 'btn btn-sm btn-light', target: '_blank'})
     end
-     
+
 
   end
 
@@ -620,7 +620,7 @@ module ApplicationHelper
       content_tag(:div, text, class: 'text')
     end
   end
-  
+
   def insert_sample_text_button(text)
     content_tag(:div, class:'insert-sample-text-button') do
       content_tag(:div, class: 'button', 'data-action': 'click->sample-text#annotator_recommender', 'data-sample-text': t("sample_text")) do
@@ -632,7 +632,7 @@ module ApplicationHelper
 
   def empty_state(text)
     content_tag(:div, class:'browse-empty-illustration') do
-      inline_svg_tag('empty-box.svg') + 
+      inline_svg_tag('empty-box.svg') +
       content_tag(:p, text)
     end
   end

--- a/app/helpers/components_helper.rb
+++ b/app/helpers/components_helper.rb
@@ -71,15 +71,15 @@ module ComponentsHelper
     content_tag(:p, message.html_safe, class: 'font-italic field-description_text')
   end
 
-  def properties_list_component(c, properties, &block)
+  def properties_list_component(c, properties, truncate: true, &block)
     properties.each do |k, value|
       values, label = value
       c.row do
         content = if block_given?
                     capture(values, &block)
                   else
-                    if link?(Array(values).first)
-                      horizontal_list_container(values) { |v| link?(v) ? render(LinkFieldComponent.new(value: v)) : v }
+                    if Array(values).any?{|v| link?(v)}
+                      horizontal_list_container(values, truncate: truncate) { |v| link?(v) ? render(LinkFieldComponent.new(value: v)) : v }
                     else
                       Array(values).join(', ')
                     end
@@ -90,10 +90,10 @@ module ComponentsHelper
 
   end
 
-  def horizontal_list_container(values, &block)
+  def horizontal_list_container(values, truncate: true, &block)
     return if Array(values).empty?
 
-    render Layout::HorizontalListComponent.new do |l|
+    render Layout::HorizontalListComponent.new(truncate: truncate) do |l|
       Array(values).each do |v|
         l.element do
           capture(v, &block)

--- a/app/helpers/ontologies_helper.rb
+++ b/app/helpers/ontologies_helper.rb
@@ -190,9 +190,7 @@ module OntologiesHelper
     links
   end
 
-  def link?(string)
-    string.to_s.start_with?('http://') || string.to_s.start_with?('https://')
-  end
+
 
   def mappings_link(ontology, count)
     return '0' if ontology.summaryOnly || count.nil? || count.zero?
@@ -544,7 +542,7 @@ module OntologiesHelper
       if url.include?(rest_hostname)
         url = url['?'] ? "#{url}&apikey=#{get_apikey}" : "#{url}?apikey=#{get_apikey}"
       end
-      
+
       content_tag(:span, data: {controller:"tooltip" } , title:  title) do
         link_to(inline_svg("#{icon}.svg", width: "32", height: '32'),
                 url, link_options)
@@ -681,4 +679,3 @@ module OntologiesHelper
     Array(submission&.naturalLanguage).map { |natural_language| natural_language["iso639"] && natural_language.split('/').last }.compact
   end
 end
-

--- a/app/views/ontologies/sections/_metadata.html.haml
+++ b/app/views/ontologies/sections/_metadata.html.haml
@@ -36,7 +36,7 @@
         }
       = properties_dropdown('methodology',t("ontologies.sections.methodology_and_provenance"), t("ontologies.sections.info_tooltip_properties_dropdown"), @methodology_properties)
       = properties_dropdown('community',t("ontologies.sections.community"), t("ontologies.sections.info_tooltip_properties_dropdown"), nil ) do |c|
-        - properties_list_component(c, @community_properties)
+        - properties_list_component(c, @community_properties, truncate: false)
         - unless Array(@ontology.group).empty?
           - c.row do
             = render FieldContainerComponent.new(label: t("ontologies.sections.label_groups")) do


### PR DESCRIPTION
## Context
 See: https://github.com/ontoportal-lirmm/bioportal_web_ui/issues/485
## Changes
- [x] Fix the display of content ( url and text) in Community section
![image](https://github.com/ontoportal-lirmm/bioportal_web_ui/assets/31127782/cbdf87fa-6522-42ad-83d5-a9a77e22a38b)

