### PR TITLE
Fix: Make select component displays all options

### DIFF
--- a/app/components/select_input_component/select_input_component_controller.js
+++ b/app/components/select_input_component/select_input_component_controller.js
@@ -29,6 +29,8 @@ export default class SelectInput extends Controller {
         }
       }
     }
+    
+    myOptions['maxOptions'] = Infinity
 
     if(!this.searchableValue){
       myOptions['controlInput'] = null


### PR DESCRIPTION
### Problem:
The current implementation of our select input component presents a limitation when dealing with a large number of options. The component only displays a limited set of choices, necessitating users to start typing the name of a specific option when it's not displayed.

### Done in this PR:
I made the select input component displays all available options, regardless of their quantity.

### Screenshot:
![image](https://github.com/ontoportal-lirmm/bioportal_web_ui/assets/61744974/7d6c207f-7846-4131-a8c7-c0e6e367448e)
