### PR TITLE
Fix: landscape page raising error for groups does not have a description

### DIFF
--- a/app/controllers/landscape_controller.rb
+++ b/app/controllers/landscape_controller.rb
@@ -542,7 +542,7 @@ class LandscapeController < ApplicationController
       groups_info_hash[group.acronym][:name] = group.name
       groups_info_hash[group.acronym][:description] = []
       # Slice the description in 6 words string to avoid too long sentence in the bar chart tooltip in js
-      group.description.split(" ").each_slice(6) {|slice| groups_info_hash[group.acronym][:description].push(slice.join(" ")) }
+      group.description.split(" ").each_slice(6) {|slice| groups_info_hash[group.acronym][:description].push(slice.join(" ")) } if group.description
     end
 
     domains_info_hash = {}
@@ -552,7 +552,7 @@ class LandscapeController < ApplicationController
       domains_info_hash[domain.acronym][:name] = domain.name
       domains_info_hash[domain.acronym][:description] = []
       # Slice the description in 6 words string to avoid too long sentence in the bar chart tooltip in js
-      domain.description.split(" ").each_slice(6) {|slice| domains_info_hash[domain.acronym][:description].push(slice.join(" ")) }
+      domain.description.split(" ").each_slice(6) {|slice| domains_info_hash[domain.acronym][:description].push(slice.join(" ")) } if domain.description
     end
 
     @landscape_data = {


### PR DESCRIPTION
The landscape fails, if one of the groups or categories does not have a description.  
This PR adds security to check the existence of the description before using it.