### PR TITLE
Feature: Add view badge to the summary header section 

### DIFF
--- a/app/assets/stylesheets/components/chip_button.scss
+++ b/app/assets/stylesheets/components/chip_button.scss
@@ -23,6 +23,5 @@
   color: var(--primary-color);
   font-weight: 500;
   font-size: 15px;
-  cursor: grab;
   display: inline;
 }

--- a/app/assets/stylesheets/ontology_details_header.scss
+++ b/app/assets/stylesheets/ontology_details_header.scss
@@ -58,6 +58,7 @@
     align-items: center;
     font-size: 14px;
     color: #888888;
+    margin-top: 12px;
 }
 .ontology-details-last-update img{
     margin-right: 10px;

--- a/app/views/layouts/ontology_viewer/_header.html.haml
+++ b/app/views/layouts/ontology_viewer/_header.html.haml
@@ -5,6 +5,10 @@
 .ontology-details-header-container
   .ontology-details-path
     %a{href: "/ontologies"} ontologies
+    - if @ontology.viewOf
+      %img{src: asset_path("arrow-right-outlined.svg")}/
+      %div
+        = @ontology.viewOf.split('/').last
     %img{src: asset_path("arrow-right-outlined.svg")}/
     %div
       = @ontology.acronym
@@ -15,6 +19,8 @@
           = @ontology.name
           %span{data: { controller: 'tooltip'}, title: ontology_alternative_names}
             = "("+ @ontology.acronym+")"
+          - if @ontology.viewOf
+            = render ChipButtonComponent.new(class: 'chip_button_small mr-1', text: 'view', type: 'clickable', clickable: false)
           - if @ontology.private?
             = render ChipButtonComponent.new(class: 'chip_button_small mr-1') do
               = private_ontology_icon(@ontology.private?)

--- a/app/views/ontologies/sections/metadata/_ontology_description_section.html.haml
+++ b/app/views/ontologies/sections/metadata/_ontology_description_section.html.haml
@@ -2,21 +2,24 @@
   - c.header(text: t("ontologies.sections.metadata.general_information"))
   = render Layout::ListComponent.new do |l|
     - l.row do
-      .d-flex.align-items-center
-        %div
-          - if @submission_latest&.abstract.blank?
-            .creation_text
-              = render TextAreaFieldComponent.new(value: @submission_latest&.description)
-          - else
+      %div
+        - if @submission_latest&.abstract.blank?
+          .creation_text.d-flex.align-items-center
+            = render TextAreaFieldComponent.new(value: @submission_latest&.description)
+            - unless @submission_latest&.logo.nil? || !link?(@submission_latest&.logo)
+              = image_tag(@submission_latest&.logo, class: 'description_img ml-2', width: '145px')
+        - else
+          .d-flex.align-items-center
             = render FieldContainerComponent.new(label: t("ontologies.sections.metadata.abstract")) do
               .creation_text
                 = render TextAreaFieldComponent.new(value: @submission_latest&.abstract)
-            = render FieldContainerComponent.new(label: t("ontologies.sections.metadata.description")) do
-              .creation_text
-                = render TextAreaFieldComponent.new(value: @submission_latest&.description)
+            - unless @submission_latest&.logo.nil? || !link?(@submission_latest&.logo)
+              = image_tag(@submission_latest&.logo, class: 'description_img ml-2', width: '145px')
+          = render FieldContainerComponent.new(label: t("ontologies.sections.metadata.description")) do
+            .creation_text
+              = render TextAreaFieldComponent.new(value: @submission_latest&.description)
 
-        - unless @submission_latest&.logo.nil? || !link?(@submission_latest&.logo)
-          = image_tag(@submission_latest&.logo, class: 'description_img', width: '145px')
+        
 
 
     - l.row do


### PR DESCRIPTION
### Done in this PR:
- Distinguish view by adding the view tag beside the name and add the reference ontology in the navigation.

![Capture d’écran du 2024-03-06 15-46-58](https://github.com/ontoportal-lirmm/bioportal_web_ui/assets/61744974/30916498-d8ab-444c-847e-2e962a0bda1b)
- Fix ontology image position issue 

![Capture d’écran du 2024-03-06 16-13-25](https://github.com/ontoportal-lirmm/bioportal_web_ui/assets/61744974/c3056eed-9eaa-4929-bf07-40b60ce3098f)


### Left to do:
- Limits heights of different sections and add a see more button if needed (like for categories and subjects)