### PR TITLE
Fix: Make usernames case insensitive

### DIFF
--- a/app/controllers/login_controller.rb
+++ b/app/controllers/login_controller.rb
@@ -16,6 +16,7 @@ class LoginController < ApplicationController
 
   # logs in a user
   def create
+    params[:user][:username] = params[:user][:username].downcase
     if is_email(params[:user][:username])
       username = LinkedData::Client::Models::User.find_by_email(params[:user][:username]).first.username
     else

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -202,6 +202,7 @@ class UsersController < ApplicationController
   def user_params
     params[:user]["orcidId"] = extract_id_from_url(params[:user]["orcidId"], 'orcid.org')
     params[:user]["githubId"] = extract_id_from_url(params[:user]["githubId"], 'github.com')
+    params[:user][:username] = params[:user][:username].downcase
     p = params.require(:user).permit(:firstName, :lastName, :username, :orcidId, :githubId, :email, :email_confirmation, :password,
                                      :password_confirmation, :register_mail_list, :admin)
     p.to_h


### PR DESCRIPTION
### Problem:
Our system currently operates with case-sensitive usernames, creating a disparity between usernames like "bilelkihal" and "Bilelkihal." This poses an issue as the conventional norm on the web is for usernames to be case-insensitive.

### Done in this PR:
- Make usernames case-insensitive in the register and edit account.
- Make usernames case-insensitive in the login.