### PR TITLE
Fix: Harmonize API and UI urls in Search, Annotator and Recommender pages

### DIFF
--- a/app/controllers/annotator_controller.rb
+++ b/app/controllers/annotator_controller.rb
@@ -37,9 +37,9 @@ class AnnotatorController < ApplicationController
     if params[:text] && !params[:text].empty?
       api_params = {
         text: params[:text],
-        ontologies: list_to_string(params[:ontologies_list]),
-        sementic_types: list_to_string(params[:semantic_types_list]),
-        semantic_groups: list_to_string(params[:semantic_groups_list]),
+        ontologies: params[:ontologies],
+        semantic_types: params[:semantic_types],
+        semantic_groups: params[:semantic_groups],
         whole_word_only: params[:whole_word_only],
         longest_only: params[:longest_only],
         expand_mappings: params[:expand_mappings],
@@ -191,8 +191,8 @@ class AnnotatorController < ApplicationController
   end
 
   def empty_advanced_options
-    params[:semantic_types_list].nil? &&
-      params[:semantic_groups_list].nil? &&
+    params[:semantic_types].nil? &&
+      params[:semantic_groups].nil? &&
       params[:class_hierarchy_max_level] == 'None' &&
       (params[:score].nil? || params[:score] == 'none') &&
       params[:score_threshold] == '0' &&

--- a/app/controllers/recommender_controller.rb
+++ b/app/controllers/recommender_controller.rb
@@ -16,7 +16,6 @@ class RecommenderController < ApplicationController
       @not_valid_max_num_set = (params[:max_elements_set] < '2') || (params[:max_elements_set] > '4')
     end
     unless params[:input].nil?  ||  params[:input].empty? || @not_valid_max_num_set
-      params[:ontologies] = params[:ontologies_list]&.join(',') || ''
       recommendations = LinkedData::Client::HTTP.post(RECOMMENDER_URI, params)
       @advanced_options_open = !recommender_params_empty?
       @results = []
@@ -52,6 +51,6 @@ class RecommenderController < ApplicationController
   end
 
   def recommender_params_empty?
-    (params[:wc].eql?('0.55') && params[:wa].eql?('0.15') && params[:wd].eql?('0.15') && params[:ws].eql?('0.15') && params[:max_elements_set].eql?('3') && params[:ontologies_list].nil?)
+    (params[:wc].eql?('0.55') && params[:wa].eql?('0.15') && params[:wd].eql?('0.15') && params[:ws].eql?('0.15') && params[:max_elements_set].eql?('3') && params[:ontologies].nil?)
   end
 end

--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -15,7 +15,6 @@ class SearchController < ApplicationController
     return if @search_query.empty?
 
     params[:pagesize] = "150"
-    params[:ontologies] = params[:ontologies_list]&.join(",")
     results = LinkedData::Client::Models::Class.search(@search_query, params).collection
 
     @advanced_options_open = !search_params_empty?

--- a/app/javascript/controllers/form_url_controller.js
+++ b/app/javascript/controllers/form_url_controller.js
@@ -2,40 +2,30 @@ import { Controller } from "@hotwired/stimulus"
 
 
 export default class extends Controller {
-    static targets = ['form']
-    static values = {
-        options: Array
-    }
-    
+ 
     submit(event){
         event.preventDefault();
-        let selectedOptions, hiddenInput, optionString
-        for(let i=0; i<this.optionsValue.length; i++){
-            selectedOptions = event.currentTarget.querySelector(`select[name="${this.optionsValue[i]}[]"]`).selectedOptions;
-            if(selectedOptions.length>0){
-                optionString = this.#array_to_string(selectedOptions)
-                hiddenInput = this.#create_hidden_input_element(optionString, this.optionsValue[i])
+        let selectedOptions, hiddenInput, optionString, selectElem
+        let  allSelects = this.element.querySelectorAll('select[name$="[]"]');
+        for (const select of allSelects) {
+            const selectElem = select.name.substring(0, select.name.indexOf('['));
+            const selectedOptions = select.selectedOptions;
+            if (selectedOptions.length > 0) {
+                const optionString = Array.from(selectedOptions, option => option.value).join(",");
+                const hiddenInput = this.#create_hidden_input_element(optionString, selectElem);
                 event.currentTarget.appendChild(hiddenInput);
-                this.#remove_html_element(event.currentTarget.querySelector(`select[name="${this.optionsValue[i]}[]"]`))
+                select.remove();
             }
         }
+        
         event.currentTarget.submit();
     }
-    #array_to_string(selectedOptions){
-        let optionString = "";
-        for (const option of selectedOptions) {
-            optionString += option.value + ",";
-        }
-        return optionString.slice(0, -1);
-    }
+
     #create_hidden_input_element(optionString, name){
         let hiddenInput = document.createElement('input');
         hiddenInput.type = 'hidden';
         hiddenInput.name = name;
         hiddenInput.value = optionString;
         return hiddenInput
-    }
-    #remove_html_element(element){
-        return element.remove();
     }
 }

--- a/app/javascript/controllers/form_url_controller.js
+++ b/app/javascript/controllers/form_url_controller.js
@@ -1,0 +1,41 @@
+import { Controller } from "@hotwired/stimulus"
+
+
+export default class extends Controller {
+    static targets = ['form']
+    static values = {
+        options: Array
+    }
+    
+    submit(event){
+        event.preventDefault();
+        let selectedOptions, hiddenInput, optionString
+        for(let i=0; i<this.optionsValue.length; i++){
+            selectedOptions = event.currentTarget.querySelector(`select[name="${this.optionsValue[i]}[]"]`).selectedOptions;
+            if(selectedOptions.length>0){
+                optionString = this.#array_to_string(selectedOptions)
+                hiddenInput = this.#create_hidden_input_element(optionString, this.optionsValue[i])
+                event.currentTarget.appendChild(hiddenInput);
+                this.#remove_html_element(event.currentTarget.querySelector(`select[name="${this.optionsValue[i]}[]"]`))
+            }
+        }
+        event.currentTarget.submit();
+    }
+    #array_to_string(selectedOptions){
+        let optionString = "";
+        for (const option of selectedOptions) {
+            optionString += option.value + ",";
+        }
+        return optionString.slice(0, -1);
+    }
+    #create_hidden_input_element(optionString, name){
+        let hiddenInput = document.createElement('input');
+        hiddenInput.type = 'hidden';
+        hiddenInput.name = name;
+        hiddenInput.value = optionString;
+        return hiddenInput
+    }
+    #remove_html_element(element){
+        return element.remove();
+    }
+}

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -96,3 +96,6 @@ application.register("sample-text", SampleTextController)
 
 import AnnotatorController from "./annotator_controller"
 application.register('annotator', AnnotatorController)
+
+import FormUrlController from "./form_url_controller"
+application.register('form-url', FormUrlController)

--- a/app/views/annotator/index.html.haml
+++ b/app/views/annotator/index.html.haml
@@ -1,13 +1,13 @@
 - @title= t('annotator.title')
 .annotator-page-container{'data-controller': 'annotator'}
-  .annotator-page-subcontainer
+  .annotator-page-subcontainer{'data-controller': 'form-url', 'data-form-url-options-value': ['ontologies', 'semantic_types', 'semantic_groups']}
     .annotator-page-title
       .text
         = @page_name
       .line
     .annotator-page-decription
       = t('annotator.description')
-    = form_tag(@form_url, method: :get, 'data-turbo': true, novalidate: true) do
+    = form_tag(@form_url, method: :get, 'data-turbo': true, novalidate: true, 'data-action': 'submit->form-url#submit') do
       .annotator-page-inputs{'data-controller': 'reveal-component'}
         .inputs
           %div
@@ -20,7 +20,7 @@
               = t('annotator.options')
             .select-ontologies
               - get_ontologies_data
-              = render Input::SelectComponent.new(label: t('recommender.select_ontologies'), id: 'ontologies', name: 'ontologies_list[]', value: @onts_for_select, multiple: "multiple", selected: params[:ontologies_list])
+              = render Input::SelectComponent.new(label: t('recommender.select_ontologies'), id: 'ontologies', name: 'ontologies[]', value: @onts_for_select, multiple: "multiple", selected: params[:ontologies]&.split(','))
             .prefrences
               .preftitle
                 = t('annotator.prefrences')
@@ -35,8 +35,8 @@
                 
         .more-advanced-options{'data-reveal-component-target': 'item', class: "#{@advanced_options_open ? '' : 'd-none'}"}
           .filters_line
-            = render Input::SelectComponent.new(label: t('annotator.select_umls_sementic_types'), id: 'umls_semantic_types', name: 'semantic_types_list[]', value: @semantic_types_for_select, multiple: true, selected: params[:semantic_types_list])
-            = render Input::SelectComponent.new(label: t('annotator.select_umls_sementic_groupes'), id: 'umls_semantic_groups', name: 'semantic_groups_list[]', value: @semantic_groups_for_select, multiple: true, selected: params[:semantic_groups_list])
+            = render Input::SelectComponent.new(label: t('annotator.select_umls_sementic_types'), id: 'umls_semantic_types', name: 'semantic_types[]', value: @semantic_types_for_select, multiple: true, selected: params[:semantic_types]&.split(','))
+            = render Input::SelectComponent.new(label: t('annotator.select_umls_sementic_groupes'), id: 'umls_semantic_groups', name: 'semantic_groups[]', value: @semantic_groups_for_select, multiple: true, selected: params[:semantic_groups]&.split(','))
             = render Input::SelectComponent.new(label: t('annotator.include_ancentors'), id: 'ancestors_level', name: 'class_hierarchy_max_level', value: @ancestors_levels, selected: params[:class_hierarchy_max_level])
           .filters_line
             - include_score_helper = 'Score annotations following previous NCBO 2009 measure (old) or Score annotations following C-Value measure (cvalue) or Score annotations following C-Value measure with hierarchy expansion (cvalueh).'

--- a/app/views/annotator/index.html.haml
+++ b/app/views/annotator/index.html.haml
@@ -1,13 +1,13 @@
 - @title= t('annotator.title')
 .annotator-page-container{'data-controller': 'annotator'}
-  .annotator-page-subcontainer{'data-controller': 'form-url', 'data-form-url-options-value': ['ontologies', 'semantic_types', 'semantic_groups']}
+  .annotator-page-subcontainer
     .annotator-page-title
       .text
         = @page_name
       .line
     .annotator-page-decription
       = t('annotator.description')
-    = form_tag(@form_url, method: :get, 'data-turbo': true, novalidate: true, 'data-action': 'submit->form-url#submit') do
+    = form_tag(@form_url, method: :get, 'data-turbo': true, novalidate: true,'data-controller': 'form-url', 'data-action': 'submit->form-url#submit') do
       .annotator-page-inputs{'data-controller': 'reveal-component'}
         .inputs
           %div

--- a/app/views/recommender/index.html.haml
+++ b/app/views/recommender/index.html.haml
@@ -1,6 +1,6 @@
 - @title = t('recommender.title')
 .recommender-page-container{'data-controller': 'recommender'}
-  .recommender-page-subcontainer{'data-controller': 'form-url', 'data-form-url-options-value': ['ontologies']}
+  .recommender-page-subcontainer
     .recommender-page-title
       .text
         = t('recommender.title')
@@ -8,7 +8,7 @@
     .recommender-page-decription
       = t('recommender.intro')
 
-    = form_tag('/recommender', method: :get, 'data-turbo': true, novalidate: true, 'data-action': 'submit->form-url#submit') do
+    = form_tag('/recommender', method: :get, 'data-turbo': true, novalidate: true, 'data-action': 'submit->form-url#submit', 'data-controller': 'form-url') do
       .recommender-page-inputs{'data-controller': 'reveal-component'}
         .inputs 
           %div

--- a/app/views/recommender/index.html.haml
+++ b/app/views/recommender/index.html.haml
@@ -1,6 +1,6 @@
 - @title = t('recommender.title')
 .recommender-page-container{'data-controller': 'recommender'}
-  .recommender-page-subcontainer
+  .recommender-page-subcontainer{'data-controller': 'form-url', 'data-form-url-options-value': ['ontologies']}
     .recommender-page-title
       .text
         = t('recommender.title')
@@ -8,7 +8,7 @@
     .recommender-page-decription
       = t('recommender.intro')
 
-    = form_tag('/recommender', method: :get, 'data-turbo': true, novalidate: true) do
+    = form_tag('/recommender', method: :get, 'data-turbo': true, novalidate: true, 'data-action': 'submit->form-url#submit') do
       .recommender-page-inputs{'data-controller': 'reveal-component'}
         .inputs 
           %div
@@ -66,7 +66,7 @@
             .inputs-container
               .ontologies.input
                 - get_ontologies_data
-                = render Input::SelectComponent.new(label: t('recommender.select_ontologies'), id: 'ontologies', name: 'ontologies_list[]', value: @onts_for_select, multiple: "multiple", selected: params[:ontologies_list])
+                = render Input::SelectComponent.new(label: t('recommender.select_ontologies'), id: 'ontologies', name: 'ontologies[]', value: @onts_for_select, multiple: "multiple", selected: params[:ontologies]&.split(','))
               .maxsets.input.d-none{'data-recommender-target': 'maxset'}
                 = render Input::NumberComponent.new(label: t('recommender.max_ont_set'), name: "max_elements_set", value: params[:max_elements_set] || 3, min: '2', max: '4', step: '1', error_message: "#{@not_valid_max_num_set ? 'Valid values are: 2, 3, 4' : ''}")
               .input{'data-recommender-target': 'empty'}

--- a/app/views/search/index.html.haml
+++ b/app/views/search/index.html.haml
@@ -1,6 +1,6 @@
-.search-page-container 
+.search-page-container{'data-controller': 'form-url', 'data-form-url-options-value': ['ontologies']}
   .search-page-subcontainer{'data-controller': 'reveal-component'}
-    = form_tag(search_path, method: :get, 'data-turbo': true) do
+    = form_tag(search_path, method: :get, 'data-turbo': true, 'data-action': 'submit->form-url#submit') do
       .search-page-input-container{'data-controller': 'reveal'}
         .search-page-input
           %input{type:"text", placeholder: t('search.search_place_holder'), name: "q", value: @search_query}
@@ -23,7 +23,7 @@
                 = t("search.advanced_options.ontologies")
               .field
                 - get_ontologies_data
-                = render Input::SelectComponent.new(id: 'search-ontologies', name: 'ontologies_list[]', value: @onts_for_select, multiple: "multiple", selected:  params[:ontologies_list])
+                = render Input::SelectComponent.new(id: 'search-ontologies', name: 'ontologies[]', value: @onts_for_select, multiple: "multiple", selected:  params[:ontologies]&.split(','))
           
           .right 
             .filter-container

--- a/app/views/search/index.html.haml
+++ b/app/views/search/index.html.haml
@@ -1,6 +1,6 @@
-.search-page-container{'data-controller': 'form-url', 'data-form-url-options-value': ['ontologies']}
+.search-page-container
   .search-page-subcontainer{'data-controller': 'reveal-component'}
-    = form_tag(search_path, method: :get, 'data-turbo': true, 'data-action': 'submit->form-url#submit') do
+    = form_tag(search_path, method: :get,data:{turbo: true, controller: 'form-url', action: 'submit->form-url#submit'}) do
       .search-page-input-container{'data-controller': 'reveal'}
         .search-page-input
           %input{type:"text", placeholder: t('search.search_place_holder'), name: "q", value: @search_query}


### PR DESCRIPTION
### Context
Current URLs of the search, Annotator and Recommender services, show the lists of params in this way:
![image](https://github.com/ontoportal-lirmm/bioportal_web_ui/assets/61744974/559a1ae1-43eb-4e18-a9ce-97b03c66fcd3)

But the api url shows:
![image](https://github.com/ontoportal-lirmm/bioportal_web_ui/assets/61744974/67645639-b51e-4e3f-9c28-f894bcc3d7c3)

### Done in this PR:
I made API and UI urls harmonized for the search, recommender and annotator pages.

[Capture vidéo du 12-03-2024 12:42:50.webm](https://github.com/ontoportal-lirmm/bioportal_web_ui/assets/61744974/4f5ff14f-e9d5-4f11-8480-bf88d6e3f13c)

### PS: 
"%2C" is a URL-encoded representation of the comma "," done by default by the browser to ensure that the special character is transmitted correctly.

