### PR TITLE
Fix: Allow special characters in annotator's text input

### DIFF
--- a/app/controllers/annotator_controller.rb
+++ b/app/controllers/annotator_controller.rb
@@ -36,7 +36,7 @@ class AnnotatorController < ApplicationController
     @annotator_ontologies = LinkedData::Client::Models::Ontology.all
     if params[:text] && !params[:text].empty?
       api_params = {
-        text: params[:text],
+        text: escape(params[:text]),
         ontologies: params[:ontologies],
         semantic_types: params[:semantic_types],
         semantic_groups: params[:semantic_groups],
@@ -203,7 +203,7 @@ class AnnotatorController < ApplicationController
   
 
   def json_link(url, optional_params)
-    base_url = "#{url}?text=#{params[:text]}&"
+    base_url = "#{url}?"
     filtered_params = optional_params.reject { |_, value| value.nil? }
     optional_params_str = filtered_params.map { |param, value| "#{param}=#{value}" }.join("&")
     return base_url + optional_params_str + "&apikey=#{$API_KEY}"


### PR DESCRIPTION
### Issue
When we use special characters in the annotator's text input like "%", it throws an error.

### Done in this PR
We encode the input text before doing the api fetch.

### Screenshot
![Capture d’écran du 2024-03-26 13-41-23](https://github.com/ontoportal-lirmm/bioportal_web_ui/assets/61744974/08957f4e-484b-4d58-91be-8110bd8d6f82)

