### PR TITLE
Feature: Add OntoPortal tools age

### DIFF
--- a/app/assets/stylesheets/application.css.scss.erb
+++ b/app/assets/stylesheets/application.css.scss.erb
@@ -56,13 +56,14 @@
 @import "ontology_details_header";
 @import "ontology_viewer";
 @import "browse";
-@import "tools";
 @import "agent_tooltip";
+@import "content_finder";
+@import "tools";
+
 /* Bootstrap and Font Awesome */
 @import "bootstrap";
 @import "bootstrap_overrides";
-@import "agent_tooltip";
-@import "content_finder";
+
 
 <% if (ui_theme = $UI_THEME.to_s.parameterize).present? && File.exists?(Rails.root.join('app', 'assets', 'stylesheets', 'themes', ui_theme)) %>
   @import "themes/<%= ui_theme %>/main";

--- a/app/assets/stylesheets/application.css.scss.erb
+++ b/app/assets/stylesheets/application.css.scss.erb
@@ -56,6 +56,8 @@
 @import "ontology_details_header";
 @import "ontology_viewer";
 @import "browse";
+@import "tools";
+@import "agent_tooltip";
 /* Bootstrap and Font Awesome */
 @import "bootstrap";
 @import "bootstrap_overrides";

--- a/app/assets/stylesheets/tools.scss
+++ b/app/assets/stylesheets/tools.scss
@@ -1,0 +1,13 @@
+.tools-container{
+  svg path {
+    fill: var(--primary-color);
+  }
+  .summary-card{
+    height: 100%;
+    background-color: white;
+  }
+
+  .tool-description{
+    color: var(--gray-color) !important;
+  }
+}

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -44,31 +44,24 @@ class HomeController < ApplicationController
       search: {
         link: "search/ontologies/content",
         icon: "icons/search.svg",
-        title: "Search content (coming)",
-        description: "This tool/service enables users to search for any Resource Description Framework (RDF) element within the portal.
-           Users can search by either the unique identifier (URI) associated with the RDF element or by its label.
-        It facilitates efficient navigation and retrieval of specific RDF elements, enhancing user experience and productivity within the portal.
-        ",
+        title: t('tools.search.title'),
+        description: t('tools.search.description'),
       },
       converter: {
         link: "/content_finder",
         icon: "icons/settings.svg",
-        title: "Content converter (coming)",
-        description: "The Content Converter tool/service offers the capability to convert any RDF element into various formats such as RDF/XML, Turtle, Ntriples, or JSON.
-          This functionality allows users to transform RDF data into formats suitable for different purposes or compatible with various systems and applications.
-          It promotes interoperability and flexibility in handling RDF data within the portal ecosystem."
+        title: t('tools.converter.title'),
+        description: t('tools.converter.description'),
       },
       url_checker: {
         link: check_resolvability_path,
         icon: "check.svg",
-        title: "URI resolvability checker",
-        description: "This tool/service verifies the resolvability of Uniform Resource Identifiers (URIs) and their content negotiability.
-          It checks whether a given URI is accessible and whether the content associated with it can be negotiated based on the client's preferences.
-          This functionality ensures the reliability and accessibility of linked resources within the RDF ecosystem, aiding in maintaining data integrity and facilitating seamless integration with external resources."
+        title: t('tools.url_checker.title'),
+        description: t('tools.url_checker.description')
       }
     }
 
-    @title = "#{helpers.portal_name} tools"
+    @title = "#{helpers.portal_name} #{t('layout.footer.tools')}"
     render 'tools', layout: 'tool'
   end
 

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -25,7 +25,7 @@ class HomeController < ApplicationController
     @upload_benefits = [
       t('home.benefit1'),
       t('home.benefit2'),
-      t('home.benefit3'), 
+      t('home.benefit3'),
       t('home.benefit4'),
       t('home.benefit5')
     ]
@@ -39,6 +39,38 @@ class HomeController < ApplicationController
 
   end
 
+  def tools
+    @tools = {
+      search: {
+        link: "search/ontologies/content",
+        icon: "icons/search.svg",
+        title: "Search content (coming)",
+        description: "This tool/service enables users to search for any Resource Description Framework (RDF) element within the portal.
+           Users can search by either the unique identifier (URI) associated with the RDF element or by its label.
+        It facilitates efficient navigation and retrieval of specific RDF elements, enhancing user experience and productivity within the portal.
+        ",
+      },
+      converter: {
+        link: "/content_finder",
+        icon: "icons/settings.svg",
+        title: "Content converter (coming)",
+        description: "The Content Converter tool/service offers the capability to convert any RDF element into various formats such as RDF/XML, Turtle, Ntriples, or JSON.
+          This functionality allows users to transform RDF data into formats suitable for different purposes or compatible with various systems and applications.
+          It promotes interoperability and flexibility in handling RDF data within the portal ecosystem."
+      },
+      url_checker: {
+        link: check_resolvability_path,
+        icon: "check.svg",
+        title: "URI resolvability checker",
+        description: "This tool/service verifies the resolvability of Uniform Resource Identifiers (URIs) and their content negotiability.
+          It checks whether a given URI is accessible and whether the content associated with it can be negotiated based on the client's preferences.
+          This functionality ensures the reliability and accessibility of linked resources within the RDF ecosystem, aiding in maintaining data integrity and facilitating seamless integration with external resources."
+      }
+    }
+
+    @title = "#{helpers.portal_name} tools"
+    render 'tools', layout: 'tool'
+  end
 
   def all_resources
     @conceptid = params[:conceptid]

--- a/app/helpers/components_helper.rb
+++ b/app/helpers/components_helper.rb
@@ -11,6 +11,23 @@ module ComponentsHelper
       end
     end
   end
+  
+  def search_page_input_component(name:, value: nil, placeholder: , button_icon: 'icons/search.svg', type: 'text', &block)
+    content_tag :div, class: 'search-page-input-container', data: { controller: 'reveal' } do
+      search_input = content_tag :div, class: 'search-page-input' do
+        concat text_field_tag(name, value, type: type, placeholder: placeholder)
+        concat(content_tag(:div, class: 'search-page-button') do
+          render Buttons::RegularButtonComponent.new(id:'search-page-button', value: "Search", variant: "primary", type: "submit") do |btn|
+            btn.icon_right { inline_svg_tag button_icon}
+          end
+        end)
+      end
+
+      options = block_given? ?  capture(&block) : ''
+
+      (search_input + options).html_safe
+    end
+  end
 
   def resolvability_check_tag(url)
     content_tag(:span, check_resolvability_container(url), style: 'display: inline-block;')

--- a/app/views/check_resolvability/index.html.haml
+++ b/app/views/check_resolvability/index.html.haml
@@ -1,11 +1,8 @@
 .search-page-container
   .search-page-subcontainer{'data-controller': 'reveal-component'}
     = form_tag(check_resolvability_path, method: :get, 'data-turbo': true) do
-      .search-page-input-container{'data-controller': 'reveal'}
-        .search-page-input
-          %input{type:"url", placeholder: t("check_resolvability.uri_placeholder"), name: "url", value: @url}
-          %button.search-page-button{type:'submit'}
-            = inline_svg_tag 'icons/search.svg'
+      = search_page_input_component(name: 'url', value: @url, placeholder: t("check_resolvability.uri_placeholder"), type: "url")
+
 
       = render(Layout::RevealComponent.new(toggle: true, selected: false)) do |c|
         - c.button do

--- a/app/views/home/tools.html.haml
+++ b/app/views/home/tools.html.haml
@@ -4,7 +4,7 @@
       = render Layout::CardComponent.new do |c|
         - c.header do |h|
           - h.text do
-            %div.d-flex.flex-column.align-items-center.text-primary
+            %div.d-flex.flex-column.align-items-center.text-primary.pt-4
               =  inline_svg_tag(tool[:icon], height: "50px", width: "50px")
               %h3.text-primary.mt-2
                 = tool[:title]

--- a/app/views/home/tools.html.haml
+++ b/app/views/home/tools.html.haml
@@ -1,0 +1,12 @@
+%div.d-flex.px-5.py-3.rounded.tools-container
+  - @tools.each_value do |tool|
+    = link_to tool[:link], class: "mx-2" do
+      = render Layout::CardComponent.new do |c|
+        - c.header do |h|
+          - h.text do
+            %div.d-flex.flex-column.align-items-center.text-primary
+              =  inline_svg_tag(tool[:icon], height: "50px", width: "50px")
+              %h3.text-primary.mt-2
+                = tool[:title]
+        %p.px-4.tool-description
+          = tool[:description]

--- a/app/views/home/tools.html.haml
+++ b/app/views/home/tools.html.haml
@@ -1,6 +1,6 @@
 %div.d-flex.px-5.py-3.rounded.tools-container
   - @tools.each_value do |tool|
-    = link_to tool[:link], class: "mx-2" do
+    = link_to tool[:link], class: "mx-2 d-block", style: "width: 35%" do
       = render Layout::CardComponent.new do |c|
         - c.header do |h|
           - h.text do

--- a/app/views/layouts/tool.html.haml
+++ b/app/views/layouts/tool.html.haml
@@ -34,8 +34,8 @@
     %div.p-5
       %a.d-flex.flex-column.container-gradient.mx-auto.d-flex.justify-content-center.align-items-center{href: "/", style: 'width: 200px; height: 200px; border-radius: 100px;'}
         %img{:src => asset_path("logo-white.svg"), style: 'width: 100px; height: 100px'}
-        %p.text-white.h3
-          = portal_name
+        %p.text-white.h3.text-center
+          = @title || portal_name
     = yield
 
 

--- a/app/views/search/index.html.haml
+++ b/app/views/search/index.html.haml
@@ -1,15 +1,7 @@
 .search-page-container
   .search-page-subcontainer{'data-controller': 'reveal-component'}
     = form_tag(search_path, method: :get,data:{turbo: true, controller: 'form-url', action: 'submit->form-url#submit'}) do
-      .search-page-input-container{'data-controller': 'reveal'}
-        .search-page-input
-          %input{type:"text", placeholder: t('search.search_place_holder'), name: "q", value: @search_query}
-          .search-page-button
-            = render Buttons::RegularButtonComponent.new(id:'search-page-button', value: "Search", variant: "primary", type: "submit") do |btn|
-              = btn.icon_right do
-                = inline_svg_tag "icons/search.svg"
-
-
+      = search_page_input_component(placeholder: t('search.search_place_holder'), name: "q", value: @search_query) do
         .search-page-advanced{'data-reveal-component-target': 'item', class: "#{@advanced_options_open ? '' : 'd-none'}"}
           .left
             .filter-container

--- a/config/bioportal_config_env.rb.sample
+++ b/config/bioportal_config_env.rb.sample
@@ -239,6 +239,7 @@ $FOOTER_LINKS = {
     products: {
       release_notes: "https://doc.jonquetlab.lirmm.fr/share/e6158eda-c109-4385-852c-51a42de9a412/doc/release-notes-btKjZk5tU2",
       api: "https://data.agroportal.lirmm.fr/",
+      tools: "/tools",
       sparql: "https://sparql.agroportal.lirmm.fr/test/",
       ontoportal: "https://ontoportal.org/"
     },

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -468,6 +468,7 @@ en:
       ontoportal: OntoPortal
       release_notes: Release Notes
       api: API
+      tools: Tools
       sparql: SPARQL
       support: Support
       contact_us: Contact Us
@@ -972,17 +973,17 @@ en:
       and top concept assertion. %{link}
     ontology_obo_language_link: the OBOinOWL parser.
     ontology_obo_language_help: >
-        OBO ontologies submitted to %{portal_name} will be parsed by the OWL-API which integrates %{link} 
-        The resulting RDF triples will then be loaded in %{portal_name} triple-store.
+      OBO ontologies submitted to %{portal_name} will be parsed by the OWL-API which integrates %{link} 
+      The resulting RDF triples will then be loaded in %{portal_name} triple-store.
     ontology_owl_language_link: the Protégé
     ontology_owl_language_help: >
-        OWL ontologies submitted to %{portal_name} will be parsed by the OWL-API. An easy way to verify if your ontology will parse is to open it with
-        %{link}
-        software which does use the same component.
+      OWL ontologies submitted to %{portal_name} will be parsed by the OWL-API. An easy way to verify if your ontology will parse is to open it with
+      %{link}
+      software which does use the same component.
 
     ontology_umls_language_link: by the UMLS2RDF tool.
     ontology_umls_language_help: >
-        UMLS-RRF resources are usually produced %{link}
+      UMLS-RRF resources are usually produced %{link}
 
     groups: Groups
     visibility: Visibility
@@ -1350,3 +1351,22 @@ en:
     cancel: Cancel
     apply: Apply
     unselect_all: Unselect all
+  tools:
+    search:
+      title: "Search content (coming)"
+      description: >
+        This tool/service enables users to search for any Resource Description Framework (RDF) element within the portal.
+        Users can search by either the unique identifier (URI) associated with the RDF element or by its label.
+        It facilitates efficient navigation and retrieval of specific RDF elements, enhancing user experience and productivity within the portal.
+    converter:
+      title: "Content converter (coming)"
+      description: >
+        The Content Converter tool/service offers the capability to convert any RDF element into various formats such as RDF/XML, Turtle, Ntriples, or JSON.
+        This functionality allows users to transform RDF data into formats suitable for different purposes or compatible with various systems and applications.
+        It promotes interoperability and flexibility in handling RDF data within the portal ecosystem.
+    url_checker:
+      title: "URI resolvability checker"
+      description: >
+        This tool/service verifies the resolvability of Uniform Resource Identifiers (URIs) and their content negotiability.
+        It checks whether a given URI is accessible and whether the content associated with it can be negotiated based on the client's preferences.
+        This functionality ensures the reliability and accessibility of linked resources within the RDF ecosystem, aiding in maintaining data integrity and facilitating seamless integration with external resources.

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -79,7 +79,7 @@ fr:
     incomplete_simple_ontology: "Ontologie simple incomplète : %{id}, %{ont}"
   label_xl:
     error_valid_label_xl: "Erreur : Vous devez fournir un identifiant de label_xl valide"
-    
+
   admin:
     query_not_permitted: Requête non autorisée
     update_info_successfully: Informations de mise à jour récupérées avec succès
@@ -313,7 +313,7 @@ fr:
           <blockquote>
             <p>Justification (optionnel)<br>Fournissez ici toute information supplémentaire concernant le terme demandé.</p>
           </blockquote>
-        
+
   home:
     ontoportal_instances: "Autres installations d’OntoPortal"
     bug: Bug
@@ -475,6 +475,7 @@ fr:
       ontoportal: OntoPortal
       release_notes: Notes de version
       api: API
+      tools: Outils
       sparql: SPARQL
       support: Aides
       contact_us: Contactez-nous
@@ -1383,3 +1384,25 @@ fr:
     cancel: Annuler
     apply: Appliquer
     unselect_all: Tout désélectionner
+
+  tools:
+    search:
+      title: "Rechercher du contenu (à venir)"
+      description: >
+        Cet outil/service permet aux utilisateurs de rechercher n'importe quel élément du Cadre de Description des Ressources (RDF) dans le portail.
+        Les utilisateurs peuvent rechercher soit par l'identifiant unique (URI) associé à l'élément RDF, soit par son libellé.
+        Il facilite la navigation efficace et la récupération d'éléments RDF spécifiques, améliorant ainsi l'expérience utilisateur et la productivité au sein du portail.
+
+    converter:
+      title: "Convertisseur de contenu (à venir)"
+      description: >
+        L'outil/service de conversion de contenu offre la possibilité de convertir n'importe quel élément RDF en divers formats tels que RDF/XML, Turtle, Ntriples ou JSON.
+        Cette fonctionnalité permet aux utilisateurs de transformer les données RDF en formats adaptés à différents usages ou compatibles avec divers systèmes et applications.
+        Il favorise l'interopérabilité et la flexibilité dans la manipulation des données RDF au sein de l'écosystème du portail.
+
+    url_checker:
+      title: "Vérificateur de résolvabilité d'URI"
+      description: >
+        Cet outil/service vérifie la résolvabilité des Identifiants Uniformes de Ressource (URI) et leur négociabilité de contenu.
+        Il vérifie si un URI donné est accessible et si le contenu associé peut être négocié en fonction des préférences du client.
+        Cette fonctionnalité garantit la fiabilité et l'accessibilité des ressources liées dans l'écosystème RDF, aidant ainsi à maintenir l'intégrité des données et facilitant l'intégration transparente avec des ressources externes.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,6 +3,7 @@ Rails.application.routes.draw do
   root to: 'home#index'
   mount LetterOpenerWeb::Engine, at: "/letter_opener" if Rails.env.development?
 
+  get'/tools', to: 'home#tools'
   get 'auth/:provider/callback', to: 'login#create_omniauth'
   get 'locale/:language', to: 'language#set_locale_language'
   get 'metadata_export/index'


### PR DESCRIPTION
### Context
This PR adds the tools page, where we will list the possible tools extracted from Ontoportal, as URL checker and content converter, ...
### Changes
*  Add tools page (https://github.com/ontoportal-lirmm/bioportal_web_ui/pull/559/commits/d672a34b941ecafdf8d635fa96faf0ff337f4a54)
![image](https://github.com/ontoportal-lirmm/bioportal_web_ui/assets/29259906/2e021af8-d71a-48ca-8362-d5f9e15678fe)

* Add tools link to the footer](https://github.com/ontoportal-lirmm/bioportal_web_ui/pull/559/commits/6a249644448906134451635b8c11a49034169eaf)
![image](https://github.com/ontoportal-lirmm/bioportal_web_ui/assets/29259906/377877d9-7bc7-4534-825e-fcf237f1be6a)


* Extract search input in the search page to re-use in url checker tool (https://github.com/ontoportal-lirmm/bioportal_web_ui/pull/559/commits/3eaf35bfec6a78deeaadd4f0e1ed9dbc3718f018)