### PR TITLE
Fix: Annotator fast context special chars issues & statistics page syntax error

### DIFF
--- a/app/controllers/annotator_controller.rb
+++ b/app/controllers/annotator_controller.rb
@@ -37,7 +37,7 @@ class AnnotatorController < ApplicationController
     if params[:text] && !params[:text].empty?
       @init_whole_word_only = true
       api_params = {
-        text: escape(params[:text]),
+        text: params[:text],
         ontologies: params[:ontologies],
         semantic_types: params[:semantic_types],
         semantic_groups: params[:semantic_groups],

--- a/app/controllers/annotator_controller.rb
+++ b/app/controllers/annotator_controller.rb
@@ -37,7 +37,7 @@ class AnnotatorController < ApplicationController
     if params[:text] && !params[:text].empty?
       @init_whole_word_only = true
       api_params = {
-        text: params[:text],
+        text: remove_special_chars(params[:text]),
         ontologies: params[:ontologies],
         semantic_types: params[:semantic_types],
         semantic_groups: params[:semantic_groups],
@@ -208,6 +208,14 @@ class AnnotatorController < ApplicationController
     filtered_params = optional_params.reject { |_, value| value.nil? }
     optional_params_str = filtered_params.map { |param, value| "#{param}=#{value}" }.join("&")
     return base_url + optional_params_str + "&apikey=#{$API_KEY}"
+  end
+
+  def remove_special_chars(input)
+    regex = /^[a-zA-Z0-9\s]*$/
+    unless input.match?(regex)
+      input.gsub!(/[^\w\s]/, '')
+    end
+    input
   end
 
 end

--- a/app/views/statistics/index.html.haml
+++ b/app/views/statistics/index.html.haml
@@ -5,9 +5,9 @@
       = t('statistics.lead', last_years: Date.today.year - Date.parse(@merged_data[:labels].first).year)
 %div.container
   %div
-    = chart_component(title: nil, type: 'line', show_legend: true,
-                              labels: @merged_data[:labels],
-                              datasets: visits_chart_dataset_array({ t('statistics.ontologies'): @merged_data[:visits][2] ,t('statistics.users'): @merged_data[:visits][0], t('statistics.projects'): @merged_data[:visits][1]}, fill: false))
+    = chart_component(title: nil, type: 'line', show_legend: true, 
+                      labels: @merged_data[:labels], datasets: visits_chart_dataset_array({ t('statistics.ontologies') => @merged_data[:visits][2], 
+                      t('statistics.users') => @merged_data[:visits][0], t('statistics.projects') => @merged_data[:visits][1] }, fill: false))
 
   %div.pb-3.pb-md-4
     - size = @merged_data[:labels].size - 1

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -342,7 +342,7 @@ en:
     paste_text_prompt: Enter a paragraph of text or some keywords...
     recommender_annotator: Recommender and Annotator
     support_and_collaborations: Support & Collaborations
-    ontoportal_instances: Ontoportal Instances
+    ontoportal_instances: Other OntoPortal Instances
     see_details: See details
     info_tooltip_text: "You are seing the average scores for all the public ontologies in AgroPortal. FAIR scores are computed with the O'FAIRe methodology. More details here: https://github.com/agroportal/fairness"
     average: Average

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -315,7 +315,7 @@ fr:
           </blockquote>
         
   home:
-    ontoportal_instances: "Instances d'Ontoportal"
+    ontoportal_instances: "Autres installations d’OntoPortal"
     bug: Bug
     proposition: Proposition
     question: Question


### PR DESCRIPTION
### Done in this PR:
- Fix statistics page syntax error.
- Update ontoportal instances home section title (english: Other OntoPortal Instances, french: Autres installations d’OntoPortal).
- Fix fast context option in annotator page (but the input text doesn't accept special chars anymore, when you type a text that contains special chars, then we take off this chars and we do the submit)