### PR TITLE
Feature: Improve Browse page  performance

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -710,9 +710,8 @@ class ApplicationController < ActionController::Base
   
   # Get the submission metadata from the REST API.
   def submission_metadata
-    @metadata ||= JSON.parse(LinkedData::Client::HTTP.get("#{REST_URI}/submission_metadata", {}, raw: true))
+    @metadata ||= helpers.submission_metadata
   end
-  helper_method :submission_metadata
 
   def request_lang
     helpers.request_lang

--- a/app/controllers/ontologies_controller.rb
+++ b/app/controllers/ontologies_controller.rb
@@ -32,14 +32,17 @@ class OntologiesController < ApplicationController
   def index
     @categories = LinkedData::Client::Models::Category.all(display_links: false, display_context: false)
     @groups = LinkedData::Client::Models::Group.all(display_links: false, display_context: false)
-    
+
     @filters = ontology_filters_init(@categories, @groups)
     init_filters(params)
     render 'ontologies/browser/browse'
   end
 
   def ontologies_filter
-    @ontologies, @count, @count_objects, @request_params = submissions_paginate_filter(params)
+    @time = Benchmark.realtime do
+      @ontologies, @count, @count_objects, @request_params = submissions_paginate_filter(params)
+    end
+
     if @page.page.eql?(1)
       streams = [prepend("ontologies_list_view-page-#{@page.page}", partial: 'ontologies/browser/ontologies')]
       streams += @count_objects.map do |section, values_count|
@@ -207,8 +210,8 @@ class OntologiesController < ApplicationController
 
   def content_serializer
     @result = serialize_content(ontology_acronym: params[:acronym],
-                      concept_id: params[:id],
-                      format: params[:output_format])
+                                concept_id: params[:id],
+                                format: params[:output_format])
 
     render 'ontologies/content_serializer', layout: nil
   end

--- a/app/controllers/submissions_controller.rb
+++ b/app/controllers/submissions_controller.rb
@@ -60,7 +60,7 @@ class SubmissionsController < ApplicationController
     display_submission_attributes params[:ontology_id], params[:properties]&.split(','), submissionId: params[:submission_id],
                                   inline_save: params[:inline_save]&.eql?('true')
 
-    attribute_template_output = render_to_string(inline: helpers.render_submission_inputs(params[:container_id] || 'metadata_by_ontology'))
+    attribute_template_output = render_to_string(inline: helpers.render_submission_inputs(params[:container_id] || 'metadata_by_ontology', @submission))
 
     render inline: attribute_template_output
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -197,6 +197,8 @@ module ApplicationHelper
   end
 
   def link_last_part(url)
+    return "" if url.nil?
+
     if url.include?('#')
       url.split('#').last
     else

--- a/app/helpers/fair_score_helper.rb
+++ b/app/helpers/fair_score_helper.rb
@@ -11,16 +11,24 @@ module FairScoreHelper
   def get_fairness_service_url(apikey = user_apikey)
     "#{$FAIRNESS_URL}?portal=#{$HOSTNAME.split('.')[0]}#{apikey.nil? || apikey.empty? ? '' : "&apikey=#{apikey}"}"
   end
+
   def get_fairness_json(ontologies_acronyms, apikey = user_apikey)
-    begin
-      conn = Faraday.new do |conn|
-        conn.options.timeout = 30
+    Rails.cache.fetch("fairness-#{ontologies_acronyms.gsub(',', '-')}", expires: 24.hours) do
+      begin
+        out = {}
+        time = Benchmark.realtime do
+          conn = Faraday.new do |conn|
+            conn.options.timeout = 30
+          end
+          response = conn.get(get_fairness_service_url(apikey) + "&ontologies=#{ontologies_acronyms}&combined")
+          out = MultiJson.load(response.body.force_encoding('ISO-8859-1').encode('UTF-8'))
+        end
+        puts "Call fairness service for: #{ontologies_acronyms} (#{time}s)"
+      rescue
+        Rails.logger.warn t('fair_score.fairness_unreachable_warning')
       end
-      response = conn.get(get_fairness_service_url(apikey) + "&ontologies=#{ontologies_acronyms}&combined")
-      MultiJson.load(response.body.force_encoding('ISO-8859-1').encode('UTF-8'))
-    rescue
-      Rails.logger.warn t('fair_score.fairness_unreachable_warning')
-      {}
+
+      out
     end
   end
 
@@ -72,7 +80,7 @@ module FairScoreHelper
   end
 
   def get_not_obtained_score(fair_scores_data, index)
-      fair_scores_data[:criteria][:portalMaxCredits][index] - fair_scores_data[:criteria][:scores][index]
+    fair_scores_data[:criteria][:portalMaxCredits][index] - fair_scores_data[:criteria][:scores][index]
   end
 
   def get_not_obtained_score_normalized(fair_scores_data, index)
@@ -84,7 +92,7 @@ module FairScoreHelper
     elsif score_rest.zero?
         100 - fair_scores_data[:criteria][:normalizedScores][index]
     else
-         0
+      0
     end
 
   end

--- a/app/helpers/metadata_helper.rb
+++ b/app/helpers/metadata_helper.rb
@@ -5,7 +5,9 @@ module MetadataHelper
   end
 
   def submission_metadata
-    @metadata ||= JSON.parse(Net::HTTP.get(URI.parse("#{$REST_URL}/submission_metadata?apikey=#{$API_KEY}")))
+    @metadata ||= Rails.cache.fetch('submission_metadata') do
+      JSON.parse(LinkedData::Client::HTTP.get("/submission_metadata", {}, {raw: true}))
+    end
   end
 
   def attr_metadata(attr_key)

--- a/app/helpers/submission_inputs_helper.rb
+++ b/app/helpers/submission_inputs_helper.rb
@@ -172,7 +172,7 @@ module SubmissionInputsHelper
   end
 
   def has_ontology_language_input(submission = @submission)
-    render(Layout::RevealComponent.new(possible_values: %w[SKOS OBO UMLS OWL], selected: @submission.hasOntologyLanguage)) do |c|
+    render(Layout::RevealComponent.new(possible_values: %w[SKOS OBO UMLS OWL], selected: submission.hasOntologyLanguage)) do |c|
       c.button do
         attribute_input("hasOntologyLanguage")
       end

--- a/app/helpers/submissions_helper.rb
+++ b/app/helpers/submissions_helper.rb
@@ -219,8 +219,9 @@ module SubmissionsHelper
     submission_metadata.select { |x| x["enforce"].include?('Agent') }.map { |x| x["attribute"] }
   end
 
-  def render_submission_inputs(frame_id)
+  def render_submission_inputs(frame_id, submission)
     output = ""
+    @submission = submission
 
     if selected_attribute?('acronym')
       output += ontology_acronym_input(update: true)

--- a/app/javascript/controllers/browse_filters_controller.js
+++ b/app/javascript/controllers/browse_filters_controller.js
@@ -8,10 +8,14 @@ export default class extends Controller {
     }
 
     dispatchInputEvent(event) {
-        if (event.target.name !== "search") {
-            return
+        let value
+        if (event.target instanceof HTMLSelectElement) {
+            value = Array.from(event.target.selectedOptions).map(x => x.value)
+        } else {
+            value = [event.target.value]
         }
-        this.#dispatchEvent("search", [event.target.value])
+
+        this.#dispatchEvent(event.target.name, value)
     }
 
     dispatchFilterEvent(event) {
@@ -43,7 +47,7 @@ export default class extends Controller {
                 break;
             default:
                 checks = this.#getSelectedChecks().map(x => x.value)
-                filter = this.element.id.split("_")[0]
+                filter = event.target.name
         }
 
         this.#dispatchEvent(filter, checks)

--- a/app/views/ontologies/browser/_ontologies.html.haml
+++ b/app/views/ontologies/browser/_ontologies.html.haml
@@ -4,7 +4,7 @@
                                     current_page: @page.page, next_page: @page.nextPage) do |c|
 
   - if @page.page.eql?(1)
-    = content_tag(:p, class: "browse-desc-text", style: "margin-bottom: 12px !important;") { "Showing #{@count} of #{@total_ontologies} (#{sprintf("%.2f", @time)}s)" }
+    = content_tag(:p, class: "browse-desc-text", style: "margin-bottom: 12px !important;") { "#{t("ontologies.showing_ontologies_size", ontologies_size: @count, analytics_size: @total_ontologies)} (#{sprintf("%.2f", @time)}s)" }
 
   - ontologies = c.collection
   - ontologies.each do |ontology|

--- a/app/views/ontologies/browser/_ontologies.html.haml
+++ b/app/views/ontologies/browser/_ontologies.html.haml
@@ -1,7 +1,11 @@
 = render InfiniteScrollComponent.new(id: 'ontologies_list',
                                     collection: @ontologies,
-                                    next_url: ontologies_filter_url(@filters, page: @page.nextPage),
+                                    next_url: ontologies_filter_url(@request_params, page: @page.nextPage),
                                     current_page: @page.page, next_page: @page.nextPage) do |c|
+
+  - if @page.page.eql?(1)
+    = content_tag(:p, class: "browse-desc-text", style: "margin-bottom: 12px !important;") { "Showing #{@count} of #{@total_ontologies} (#{sprintf("%.2f", @time)}s)" }
+
   - ontologies = c.collection
   - ontologies.each do |ontology|
     = render OntologyBrowseCardComponent.new(ontology: ontology)

--- a/app/views/ontologies/browser/browse.html.haml
+++ b/app/views/ontologies/browser/browse.html.haml
@@ -30,7 +30,7 @@
         });
       });
 
-    %div{data: { controller: "turbo-frame history browse-filters" , "turbo-frame-url-value": "/ontologies_filter", action: "change->browse-filters#dispatchFilterEvent changed->history#updateURL changed->turbo-frame#updateFrame"}}
+    %div{data: { controller: "turbo-frame history browse-filters" , "turbo-frame-url-value": "/ontologies_filter?page=1&#{request.original_url.split('?').last}", action: "change->browse-filters#dispatchFilterEvent changed->history#updateURL changed->turbo-frame#updateFrame"}}
 
       .browse-sub-container
         .browse-first-row{data:{controller: "browse-filters", action: "change->browse-filters#dispatchFilterEvent changed->history#updateURL"}}
@@ -61,7 +61,7 @@
                     .browse-filter-checks-container
                       - values.first.each do |object|
                         - title = (key.eql?(:categories) || key.eql?(:groups)) ? nil : ''
-                        = group_chip_component(name: key, object: object, checked: values[1]&.include?(object["id"]), title: title) do |c|
+                        = group_chip_component(name: key, object: object, checked: values[1]&.include?(object["id"]) || values[1]&.include?(object["value"]) , title: title) do |c|
                           - c.count do
                             %span.badge.badge-light.ml-1
                               = turbo_frame_tag "count_#{key}_#{object["id"]}", busy: true
@@ -76,15 +76,10 @@
                 %select#format.browse-format-filter{:name => "format"}
                   = options_for_select(@formats, @selected_format)
                 %select#Sort_by.browse-sort-by-filter{:name => "Sort_by"}
-                  = options_for_select(@sorts_options, @selected_sort_by)
+                  = options_for_select(@sorts_options, @sort_by)
           .browse-ontologies
-            = render TurboFrameComponent.new(id:"ontologies_list_container", data:{"turbo-frame-target":"frame", "turbo-frame-url-value": "/ontologies_filter"}) do |container|
-              = turbo_frame_tag "ontologies_filter_count_request" do
-                = browser_counter_loader
-              = render TurboFrameComponent.new(id: "ontologies_list_view-page-1" , src: "/ontologies_filter?page=1&#{request.original_url.split('?').last}") do |list|
-                - list.loader do
-                  - ontologies_browse_skeleton
-              - container.loader do
+            = render TurboFrameComponent.new(id: "ontologies_list_view-page-1" , src: "/ontologies_filter?page=1&#{request.original_url.split('?').last}", data:{"turbo-frame-target":"frame", "turbo-frame-url-value": "/ontologies_filter"}) do |list|
+              - list.loader do
                 = browser_counter_loader
                 - ontologies_browse_skeleton
 

--- a/app/views/ontologies/ontologies_selector/ontologies_selector_results.html.haml
+++ b/app/views/ontologies/ontologies_selector/ontologies_selector_results.html.haml
@@ -2,7 +2,7 @@
     .ontologies-selector-results
         .horizontal-line                  
         .results-number
-            = "Showing #{@ontologies.length} of #{@total_ontologies_number}" 
+            = t("ontologies.showing_ontologies_size", ontologies_size: @ontologies.length, analytics_size: @total_ontologies_number)
             %span.select-all{'data-action': 'click->ontologies-selector#selectall'}
                 = t('ontologies_selector.select_all')
         .ontologies

--- a/app/views/submissions/_form_content.html.haml
+++ b/app/views/submissions/_form_content.html.haml
@@ -2,7 +2,7 @@
   = turbo_frame_tag 'test', target: '_top' do
     = error_message_alert
     = form_for :submission, url: ontology_submission_path(params["ontology_id"], params["id"]), html: { id: "ontology_submission_form", method: :put, multipart: true, 'data-turbo': true, novalidate: 'true'} do
-      = render_submission_inputs('')
+      = render_submission_inputs('', @submission)
       %hr#edit-ontology-actions-devider
       .edit-ontology-actions
         .save-button


### PR DESCRIPTION
### Context 
See https://github.com/agroportal/project-management/issues/241 and https://github.com/ontoportal-lirmm/bioportal_web_ui/issues/425

### Changes
* Optimize fetched attributes in the browse page in API mode (https://github.com/ontoportal-lirmm/bioportal_web_ui/pull/572/commits/e554b9dcb490a5426f32a8aebeac43b71cfa5a84)
* Paginate the browse page 
* Update ontologies browse to use API or Index (https://github.com/ontoportal-lirmm/bioportal_web_ui/pull/572/commits/9c659e5414fd357e61c70faa008673728d74c28d)
* Add cache for the fair_score and submission endpoint (https://github.com/ontoportal-lirmm/bioportal_web_ui/pull/572/commits/17888ef535ca9c80f1d37c256ea1f456a50a7766)
* Internationalize a sentence in the browse and ontologies selector views (https://github.com/ontoportal-lirmm/bioportal_web_ui/pull/572/commits/2bdb90cb32b5c39c0e4873bae7e096083d564dde)
* Fix browse hasFormality and isOfType filters (https://github.com/ontoportal-lirmm/bioportal_web_ui/pull/572/commits/53cc4b4857d0fd4e5f105da10ea2448fa4c30a4a)
* Prioritize API filtring over the index in the browse page (https://github.com/ontoportal-lirmm/bioportal_web_ui/pull/572/commits/5d2c2f0a84d54a8872b571cf4abe722f27c10cc5)


### Benchmarks 

#### Different options + with or without cache
  | Current code - Triple store (without cache) | New code - Triple store (without cache) | Current code- Triple store (with cache) | New code -  SOLR | New code -  Triple store (with cache)
-- | -- | -- | -- | -- | --
Browse all (70% usage) | 3.9s | 2.98s | 2s | 0.93s | 0.21s
Search ACRONYM: AGROVOC (15% usage) | 3.6s | 3.01s | 1.8s | 0.48s | 0.12s
Search Name: `INRAE Thesaurus` (10% usage) (| 3.2s | 2.66s | 1.74s | 0.45s | 0.10s
Search Description: `This vocabulary is a first formalization of the INSPIRE` (5% usage) | 3.5s | 2.55s | 2.1s | 0.73s | 0.15s

#### Different options summary

  | Current code - triple store | New code - Triple store  | New code -  SOLR
-- | -- | -- | --
Browse all cold run | 3.9s | 2.98s | 0.93s
Browse all cached run | 2s | 0.21s | 0.93s
  |   |   |  
2 X Browse all | 3.9s  + 2s  = 5.9s | 2.98s +  0.21s  = 3,1s | 0.93s + 0.93s = 1,86s
3 X Browse all | 3.9s  + 2s + 2s = 7.9s | 2.98s +  0.21s +  0.21s = 3,4s | 0.93s + 0.93s + 0.93s = 2,7s
4 X Browse all | 3.9s  + 2s + 2s +2s = 9.9s | 2.98s +  0.21s +  0.21s + 0,21s = 3,6s | 0.93s + 0.93s + 0.93s  + 0,93s = 3,7s
  |   |   |  
Advantage | Time dependent of request complexity    | Less complex + Federation compliant | Better cold start + Time dependent of request complexity  + better result ranking
Disadvantage | More complex + Federation no compliant + 4store does not support pagination | Cold start | More complex + Federation no compliant



