### PR TITLE
Fix: search and concept mappings styles

### DIFF
--- a/app/assets/stylesheets/mappings.scss
+++ b/app/assets/stylesheets/mappings.scss
@@ -75,4 +75,7 @@ div#map_from_concept_details_table, div#map_to_concept_details_table {
 #concept_mappings_table {
   width: 100%;
 }
+#concept_mappings_table .chip_button_container_clickable{
+  white-space: nowrap;
+}
 

--- a/app/assets/stylesheets/search.scss
+++ b/app/assets/stylesheets/search.scss
@@ -12,7 +12,8 @@
 
 .search-page-input{
   position: relative;
-  padding-bottom: 80px;
+  padding-bottom: 30px;
+  display: flex;
   .search-container{
     top:65px;
   }

--- a/app/views/mappings/_mapping_table.html.haml
+++ b/app/views/mappings/_mapping_table.html.haml
@@ -12,7 +12,7 @@
 = check_box_tag "delete_mappings_permission", @delete_mapping_permission, @delete_mapping_permission, style: "display: none;"
 %div#concept_mappings_tables_div
   = render_alerts_container(MappingsController)
-  %table#concept_mappings_table.zebra{width: "100%", style:'word-break: break-word'}
+  %table#concept_mappings_table.table-content-stripped.table-content{width: "100%", style:'word-break: break-word'}
     %thead
       %tr
         %th= t("mappings.mapping_table.mapping_to")

--- a/app/views/search/index.html.haml
+++ b/app/views/search/index.html.haml
@@ -37,7 +37,7 @@
             .search-page-number-of-results
               = "#{t('search.match_in')} #{@search_results.length} #{t('search.ontologies')}"
           %div.d-flex
-            .search-page-json.mx-4
+            .search-page-json.mx-4.mt-1
               = search_json_link
             .search-page-advanced-button.show-options{class: "#{@advanced_options_open ? 'd-none' : ''}",'data': {'action': 'click->reveal-component#show', 'reveal-component-target': 'showButton'}}
               .icon


### PR DESCRIPTION
### Done in this PR:
- **Update concepts mappings table style**
Before
![Capture d’écran du 2024-04-11 19-41-29](https://github.com/ontoportal-lirmm/bioportal_web_ui/assets/61744974/8867d6a9-fda4-4479-98e7-328ec2ff4c51)

After
![Capture d’écran du 2024-04-11 19-42-54](https://github.com/ontoportal-lirmm/bioportal_web_ui/assets/61744974/10602d29-1f32-4af1-80d9-d3eb1e1fda32)


- **Fix some style issues I found in the search page, like the search button that goes under the search field**


