### PR TITLE
Fix: Remove duplicated ontology scheme rows

### DIFF
--- a/app/components/concept_details_component/concept_details_component.html.haml
+++ b/app/components/concept_details_component/concept_details_component.html.haml
@@ -8,6 +8,7 @@
         - if @bottom_keys.present?
           - top_set, leftover_set, bottom_set = filter_properties(@top_keys, @bottom_keys, @exclude_keys, prefix_properties(@concept_properties))
           - leftover_set = convert_dates(leftover_set)
+          - leftover_set = leftover_set.reject { |key, _| top_set.key?(key) } #remove duplicated rows in top_set
           - row_hash_properties(top_set, @acronym).each do |row|
             - t.add_row(*row)
 


### PR DESCRIPTION
Related issue: https://github.com/agroportal/project-management/issues/514

![image](https://github.com/ontoportal-lirmm/bioportal_web_ui/assets/61744974/002e1e1e-fac7-4927-8026-c24752d8c3d0)
