### PR TITLE
Fix: new instance details page, properties selected property display and browse page ontology type filter

### DIFF
--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -379,7 +379,7 @@ class AdminController < ApplicationController
 
     return visits_data if analytics.empty?
 
-    analytics.each do |year, year_data|
+    analytics.sort.each do |year, year_data|
       year_data.each do |month, value|
         visits_data[:visits] << value
         visits_data[:labels] << DateTime.parse("#{year}/#{month}").strftime("%b %Y")
@@ -424,8 +424,7 @@ class AdminController < ApplicationController
     end
 
 
-
-    aggregated_data.each do |year, year_data|
+    aggregated_data.sort.each do |year, year_data|
       year_data.each do |month, value|
         visits_data[:visits] << value
         visits_data[:labels] << DateTime.parse("#{year}/#{month}").strftime("%b %Y")
@@ -443,6 +442,7 @@ class AdminController < ApplicationController
     visits_data = { visits: [], labels: [] }
 
     return visits_data if analytics.empty?
+
     analytics.each do |path, count|
       visits_data[:labels] << path
       visits_data[:visits] << count

--- a/app/controllers/concerns/search_content.rb
+++ b/app/controllers/concerns/search_content.rb
@@ -61,7 +61,7 @@ module SearchContent
       "http___www.w3.org_2000_01_rdf-schema_label_txt^30",
       "http___www.w3.org_2000_01_rdf-schema_label_t^30",
     ]
-    ontologies = LinkedData::Client::Models::Ontology.all(include: 'acronym,name', also_include_views: true)
+    ontologies = LinkedData::Client::Models::Ontology.all(include: 'acronym,name,viewOf', also_include_views: true)
     selected_onto = []
 
     q = query.split(' ').first || ''
@@ -106,7 +106,7 @@ module SearchContent
         id: ontology_path(id: x.acronym, p: 'summary'),
         name: x.name,
         acronym: x.acronym,
-        type: 'Ontology',
+        type: x.viewOf.blank? ? 'Ontology' : 'Ontology View',
         label: nil
       }
     end

--- a/app/controllers/concerns/search_content.rb
+++ b/app/controllers/concerns/search_content.rb
@@ -171,7 +171,7 @@ module SearchContent
     when 'NamedIndividual'
       ontology_path(id: ontology, p: 'instances', instanceid: id)
     when 'AnnotationProperty', 'ObjectProperty', 'DatatypeProperty'
-      ontology_path(id: ontology, p: 'properties', instanceid: id)
+      ontology_path(id: ontology, p: 'properties', propertyid: id)
     else
       "/content_finder?acronym=#{ontology}&uri=#{escape(id)}&output_format=html"
     end

--- a/app/controllers/concerns/submission_filter.rb
+++ b/app/controllers/concerns/submission_filter.rb
@@ -216,7 +216,7 @@ module SubmissionFilter
   def ontology_hash(ont, submissions)
     o = {}
     sub = submissions.select{|x| x.ontology&.id.eql?(ont.id)}.first
-    
+
     o[:ontology] = ont
 
     add_ontology_attributes(o, ont)
@@ -235,8 +235,8 @@ module SubmissionFilter
     o[:class_count_formatted] = number_with_delimiter(o[:class_count], delimiter: ',')
     o[:individual_count_formatted] = number_with_delimiter(o[:individual_count], delimiter: ',')
 
-    o[:note_count] = ont.notes.length
-    o[:project_count] = ont.projects.length
+    o[:note_count] = ont.notes&.length || 0
+    o[:project_count] = ont.projects&.length ||
     o[:popularity] = @analytics[ont.acronym] || 0
     o[:rank] = sub&[:rank] || 0
 

--- a/app/controllers/concerns/submission_filter.rb
+++ b/app/controllers/concerns/submission_filter.rb
@@ -337,7 +337,7 @@ module SubmissionFilter
       groups: object_filter(groups, :groups),
       naturalLanguage: object_filter(@languages, :naturalLanguage, "value"),
       hasFormalityLevel: object_filter(@formalityLevel, :hasFormalityLevel),
-      isOfType: object_filter(@isOfType, :isOfType),
+      isOfType: object_filter(@isOfType, :isOfType, "value"),
       # missingStatus: object_filter(@missingStatus, :missingStatus)
     }
   end

--- a/app/controllers/concerns/submission_filter.rb
+++ b/app/controllers/concerns/submission_filter.rb
@@ -24,7 +24,8 @@ module SubmissionFilter
     @analytics = Rails.cache.fetch("ontologies_analytics-#{Time.now.year}-#{Time.now.month}") do
       helpers.ontologies_analytics
     end
-    @ontologies = LinkedData::Client::Models::Ontology.all(include: 'notes,projects', also_include_views: true, display_links: false, display_context: false)
+
+    @ontologies = LinkedData::Client::Models::Ontology.all(include: 'all', also_include_views: true, display_links: false, display_context: false)
 
     # get fair scores of all ontologies
     @fair_scores = fairness_service_enabled? ? get_fair_score('all') : nil
@@ -45,11 +46,10 @@ module SubmissionFilter
 
     if search_backend.eql?('index')
       submissions = filter_using_index(**params)
+      submissions = @ontologies.map{ |ont| ontology_hash(ont, submissions) }
     else
-      submissions = filter_using_data(**params)
+      submissions = filter_using_data(@ontologies, **params)
     end
-
-    submissions = submissions.reject { |sub| sub.ontology.nil? }.map { |sub| ontology_hash(sub, @ontologies) }
 
     submissions = sort_submission_by(submissions, @sort_by, @search)
 
@@ -83,15 +83,15 @@ module SubmissionFilter
 
   end
 
-  def filter_using_data(query:, status:, show_views:, private_only:, languages:, page_size:, formality_level:, is_of_type:, groups:, categories:, formats:)
+  def filter_using_data(ontologies, query:, status:, show_views:, private_only:, languages:, page_size:, formality_level:, is_of_type:, groups:, categories:, formats:)
     submissions = LinkedData::Client::Models::OntologySubmission.all(include: BROWSE_ATTRIBUTES.join(','), also_include_views: true, display_links: false, display_context: false)
+    submissions = ontologies.map { |ont| ontology_hash(ont, submissions) }
 
     submissions.map do |s|
-      out = !s.ontology.nil?
-      out = out && ((s.ontology.viewingRestriction.eql?('public') && !private_only) || private_only && s.ontology.viewingRestriction.eql?('private'))
+      out = ((s.ontology.viewingRestriction.eql?('public') && !private_only) || private_only && s.ontology.viewingRestriction.eql?('private'))
       out = out && (groups.blank? || (s.ontology.group.map { |x| helpers.link_last_part(x) } & groups.split(',')).any?)
       out = out && (categories.blank? || (s.ontology.hasDomain.map { |x| helpers.link_last_part(x) } & categories.split(',')).any?)
-      out = out && (status.blank? || status.split(',').include?(s.status))
+      out = out && (status.blank? || status.eql?('alpha,beta,production,retired') || status.split(',').include?(s.status))
       out = out && (formats.blank? || formats.split(',').any? { |f| s.hasOntologyLanguage.eql?(f) })
       out = out && (is_of_type.blank? || is_of_type.split(',').any? { |f| helpers.link_last_part(s.isOfType).eql?(f) })
       out = out && (formality_level.blank? || formality_level.split(',').any? { |f| helpers.link_last_part(s.hasFormalityLevel).eql?(f) })
@@ -213,17 +213,19 @@ module SubmissionFilter
     request_params
   end
 
-  def ontology_hash(sub, ontologies)
+  def ontology_hash(ont, submissions)
     o = {}
-    ont = sub.ontology
-    ont.notes = ontologies.select { |x| x.acronym.eql?(sub.ontology.acronym) }.first&.notes || []
-    ont.projects = ontologies.select { |x| x.acronym.eql?(sub.ontology.acronym) }.first&.projects || []
+    sub = submissions.select{|x| x.ontology&.id.eql?(ont.id)}.first
+
+    o[:ontology] = ont
 
     add_ontology_attributes(o, ont)
     add_submission_attributes(o, sub)
     add_fair_score_metrics(o, ont)
 
-    if sub.metrics
+    o[:hasOntologyLanguage] = sub&.hasOntologyLanguage
+
+    if sub&.metrics
       o[:class_count] = sub.metrics.classes
       o[:individual_count] = sub.metrics.individuals
     else
@@ -236,20 +238,14 @@ module SubmissionFilter
     o[:note_count] = ont.notes.length
     o[:project_count] = ont.projects.length
     o[:popularity] = @analytics[ont.acronym] || 0
-    o[:rank] = sub[:rank]
-    # if o[:type].eql?('ontology_view')
-    #   unless ontologies_hash[ont.viewOf].blank?
-    #     o[:viewOfOnt] = {
-    #       name: ontologies_hash[ont.viewOf].name,
-    #       acronym: ontologies_hash[ont.viewOf].acronym
-    #     }
-    #   end
-    # end
+    o[:rank] = sub&[:rank] || 0
 
-    o
+    OpenStruct.new(o)
   end
 
   def add_submission_attributes(ont_hash, sub)
+    return if sub.nil?
+
     ont_hash[:submissionStatus] = sub.submissionStatus
     ont_hash[:deprecated] = sub.deprecated
     ont_hash[:status] = sub.status

--- a/app/controllers/concerns/submission_filter.rb
+++ b/app/controllers/concerns/submission_filter.rb
@@ -146,9 +146,9 @@ module SubmissionFilter
     elsif sort_by.eql?('metrics_individuals')
       submissions = submissions.sort_by { |x| -x[:individual_count] }
     elsif sort_by.eql?('creationDate')
-      submissions = submissions.sort_by { |x| -x[:creationDate] }
+      submissions = submissions.sort_by { |x| x[:creationDate] || '' }.reverse
     elsif sort_by.eql?('released')
-      submissions = submissions.sort_by { |x| -x[:released] }
+      submissions = submissions.sort_by { |x| x[:released] || '' }.reverse
     elsif sort_by.eql?('ontology_name')
       submissions = submissions.sort_by { |x| -x[:name] }
     end
@@ -216,7 +216,7 @@ module SubmissionFilter
   def ontology_hash(ont, submissions)
     o = {}
     sub = submissions.select{|x| x.ontology&.id.eql?(ont.id)}.first
-
+    
     o[:ontology] = ont
 
     add_ontology_attributes(o, ont)

--- a/app/helpers/fair_score_helper.rb
+++ b/app/helpers/fair_score_helper.rb
@@ -13,7 +13,7 @@ module FairScoreHelper
   end
 
   def get_fairness_json(ontologies_acronyms, apikey = user_apikey)
-    Rails.cache.fetch("fairness-#{ontologies_acronyms.gsub(',', '-')}", expires: 24.hours) do
+    Rails.cache.fetch("fairness-#{ontologies_acronyms.gsub(',', '-')}-#{apikey}", expires: 24.hours) do
       begin
         out = {}
         time = Benchmark.realtime do


### PR DESCRIPTION
### Changes

* Fix the paginated list selected value to not select on each new page (https://github.com/ontoportal-lirmm/bioportal_web_ui/pull/596/commits/fd971a90b3758fdfc56c336943857e127bf56fb1)
* Fix instance search type filter to not include everything (https://github.com/ontoportal-lirmm/bioportal_web_ui/pull/596/commits/74737dcf92366efc5811cc09dc7f6125a7e13f4f)
* Fix the auto-selection of `isOfType` filter on browse page (https://github.com/ontoportal-lirmm/bioportal_web_ui/pull/596/commits/096e8f5e35accb42d5a41e70453414372b719d54)
* Fix search properties redirection to use `propertyid` not `instanceid` (https://github.com/ontoportal-lirmm/bioportal_web_ui/pull/596/commits/4f8ca1a72e79915b178a0e4197c7bafc70c66ad7) (fix https://github.com/agroportal/project-management/issues/521)
* Fix admin ontologies visits sorting (https://github.com/ontoportal-lirmm/bioportal_web_ui/pull/596/commits/3351a1e82844c72b4c78f6c99b0741f5f8b11872) (fix https://github.com/ontoportal-lirmm/bioportal_web_ui/issues/587)
* Fix ontologies browse page to show ontologies with no submissions (https://github.com/ontoportal-lirmm/bioportal_web_ui/pull/596/commits/41d14c80b999852a32aff32bdbfc1cb6a3f93aec) (fix https://github.com/ontoportal-lirmm/bioportal_web_ui/issues/571)
* Fix the sort by dates order in browse page (https://github.com/ontoportal-lirmm/bioportal_web_ui/pull/596/commits/6195e3bbb9db2084c45c3cb7f452d293e5f0d9e1)
* Add apikey to the fairness cache key (https://github.com/ontoportal-lirmm/bioportal_web_ui/pull/596/commits/723a601dce7a994eb206633c96f5bef9fbd2b18f)
* Show in the search box result "ontology view" for views (https://github.com/ontoportal-lirmm/bioportal_web_ui/pull/596/commits/396864867484c5db5aaee2640e30a5d4f123eb56) (fix https://github.com/ontoportal-lirmm/bioportal_web_ui/issues/570)