### PR TITLE
Feature: add a script to import or export a CSV of the i18n locales

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -115,6 +115,8 @@ group :development do
   # Use console on exceptions pages [https://github.com/rails/web-console]
   gem 'web-console'
   gem 'i18n-tasks'
+  gem 'i18n-tasks-csv', '~> 1.1'
+
   gem 'deepl-rb'
   gem 'letter_opener_web', '~> 2.0'
   gem 'haml-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -92,13 +92,6 @@ GEM
       execjs (~> 2)
     base64 (0.2.0)
     bcrypt_pbkdf (1.1.0)
-    better_html (2.0.2)
-      actionview (>= 6.0)
-      activesupport (>= 6.0)
-      ast (~> 2.0)
-      erubi (~> 1.4)
-      parser (>= 2.4)
-      smart_properties
     bigdecimal (3.1.6)
     bindata (2.5.0)
     bindex (0.8.1)
@@ -205,17 +198,18 @@ GEM
       domain_name (~> 0.5)
     i18n (1.14.1)
       concurrent-ruby (~> 1.0)
-    i18n-tasks (1.0.13)
+    i18n-tasks (0.9.37)
       activesupport (>= 4.0.2)
       ast (>= 2.1.0)
-      better_html (>= 1.0, < 3.0)
       erubi
       highline (>= 2.0.0)
       i18n
-      parser (>= 3.2.2.1)
+      parser (>= 2.2.3.0)
       rails-i18n
       rainbow (>= 2.2.2, < 4.0)
       terminal-table (>= 1.5.1)
+    i18n-tasks-csv (1.1)
+      i18n-tasks (~> 0.9)
     iconv (1.0.8)
     importmap-rails (2.0.1)
       actionpack (>= 6.0.0)
@@ -496,7 +490,6 @@ GEM
       simplecov (~> 0.19)
     simplecov-html (0.12.3)
     simplecov_json_formatter (0.1.4)
-    smart_properties (1.17.0)
     snaky_hash (2.0.1)
       hashie
       version_gem (~> 1.1, >= 1.1.1)
@@ -594,6 +587,7 @@ DEPENDENCIES
   html2haml
   i18n
   i18n-tasks
+  i18n-tasks-csv (~> 1.1)
   iconv
   importmap-rails
   inline_svg

--- a/config/i18n-tasks.yml
+++ b/config/i18n-tasks.yml
@@ -1,0 +1,8 @@
+# config/i18n-tasks.yml
+<% require 'i18n-tasks-csv' %>
+
+csv:
+  export:
+    - "tmp/i18n-export/main.csv"
+  import:
+    - tmp/i18n-export/main.csv


### PR DESCRIPTION
### Context
This PR adds the possibility to import or export in CSV, the locale files  

#### Export 
```
 bundle exec i18n-tasks csv-export
```
#### Import
```
 bundle exec i18n-tasks csv-import
```

I will import from or export into `tmp/i18n-export/main.csv` 