### PR TITLE
Fix: user reset password internationalisation issue

### DIFF
--- a/app/components/card_message_component/card_message_component.html.haml
+++ b/app/components/card_message_component/card_message_component.html.haml
@@ -1,7 +1,7 @@
 .d-flex.justify-content-center.m-4
   .card-message-card
     .d-flex.justify-content-center.mb-4
-      %img{:src => "#{asset_path(icon)}"}/
+      = inline_svg_tag icon
     - if no_title?
       %p.card-message-text
         = @message

--- a/app/controllers/login_controller.rb
+++ b/app/controllers/login_controller.rb
@@ -125,8 +125,9 @@ class LoginController < ApplicationController
     token = params[:tk]
     @user = LinkedData::Client::HTTP.post("/users/reset_password", {username: username, email: email, token: token})
     if @user.is_a?(LinkedData::Client::Models::User)
-      @user.validate_password = true
       login(@user)
+      @user = LinkedData::Client::Models::User.find(@user.id, include: 'all')
+      @user.validate_password = true
       render "users/edit"
     else
       flash[:notice] = @user.errors.first + t('login.reset_password_again')

--- a/app/views/login/lost_password.html.haml
+++ b/app/views/login/lost_password.html.haml
@@ -11,5 +11,5 @@
         %div
       %p.lost-password-description= t('login.email_address_associated')
       %p.lost-password-input-title= t('login.email')
-      = text_field t('login.user'), :email,class: "lost-password-input", placeholder: t('login.email_placeholder')
+      = text_field :user, :email,class: "lost-password-input", placeholder: t('login.email_placeholder')
       %input.lost-password-button{:type => "submit", :value => t('login.send_instructions')}/


### PR DESCRIPTION
### Context
Fix the reset password no more working after the french internationalization of the page 
### Changes
* Fix user reset password internationalization issue (https://github.com/ontoportal-lirmm/bioportal_web_ui/pull/605/commits/f693d291538646f957b1cd98bed9f1abaed8956a)
* Get user info in reset password (https://github.com/ontoportal-lirmm/bioportal_web_ui/pull/605/commits/2ce3d5b11e408fc6ea45c62c175ebd949a6b0283)
* Fix card message component image (https://github.com/ontoportal-lirmm/bioportal_web_ui/pull/605/commits/7f607e3f668ead0eaf89019787f5788778e7b289)