### PR TITLE
Fix: trim the copied text in the clipboard stimulus controller

### DIFF
--- a/app/components/clipboard_component/clipboard_component_controller.js
+++ b/app/components/clipboard_component/clipboard_component_controller.js
@@ -10,7 +10,7 @@ export default class extends Controller {
   
   copy () {
     const text = this.contentTarget.innerHTML || this.contentTarget.value
-    navigator.clipboard.writeText(text).then(() => {
+    navigator.clipboard.writeText(text.trim()).then(() => {
       this.#copied()
     })
   }


### PR DESCRIPTION
Trim text in the copy button in the clipboard stimulus controller

https://github.com/ontoportal-lirmm/bioportal_web_ui/assets/66650181/4fadd337-1a6d-495f-9dcf-e6b5fd072220

