### PR TITLE
Fix: Data tables warning issue

### DIFF
--- a/app/components/table_component/table_component_controller.js
+++ b/app/components/table_component/table_component_controller.js
@@ -10,13 +10,12 @@ export default class extends Controller {
         searching: Boolean,
         noinitsort: Boolean
     }
-    connect(){    
-        let table_component
-        table_component = this.element.childNodes[1]
-        let default_sort_column
-        default_sort_column = parseInt(this.sortcolumnValue, 10)
+    connect(){
+        const table_component = this.element.querySelector('table')
+        const default_sort_column = parseInt(this.sortcolumnValue, 10)
+
         if (this.sortcolumnValue || this.searchingValue || this.pagingValue){
-            let table = new DataTable('#'+table_component.id, {
+            this.table = new DataTable('#'+table_component.id, {
                 paging: this.pagingValue,
                 info: false,
                 searching: this.searchingValue,

--- a/app/helpers/multi_languages_helper.rb
+++ b/app/helpers/multi_languages_helper.rb
@@ -34,7 +34,7 @@ module MultiLanguagesHelper
             text = content_tag(:div, class: 'd-flex align-items-center') do
               content_tag(:span, render(LanguageFieldComponent.new(value: lang, auto_label: true)), class: 'mr-1') + beta_badge(metadata[:badge])
             end
-            link_options = { data: { turbo: true } }
+            link_options = { data: { turbo: false } }
 
             if metadata[:disabled]
               link_options[:class] = 'disabled-link'


### PR DESCRIPTION
### Fixed
- https://github.com/agroportal/project-management/issues/512
- Fix the issue of the duplicated elements when we change the language

The issue was that when refreshing the portal language using turbo, it didn't remove old initialized stimulus elements (tables, selectors) so it duplicated the initialization, the solution was to disable it, as it does not affect the user experience.  

### Screenshots of the issues
![image](https://github.com/ontoportal-lirmm/bioportal_web_ui/assets/61744974/44d478b6-b891-4b09-b0e2-0415600dfaaa)

![image](https://github.com/ontoportal-lirmm/bioportal_web_ui/assets/61744974/61b7ce29-7e55-4a08-8dbd-76f7fe07254f)

