### PR TITLE
Fix: Upload ontology form errors, lost filled inputs 

### DIFF
--- a/app/controllers/concerns/ontology_updater.rb
+++ b/app/controllers/concerns/ontology_updater.rb
@@ -47,7 +47,8 @@ module OntologyUpdater
     @selected_attributes = (Array(errors_attributes) + Array(params[:submission]&.keys)).uniq
     @ontology = ontology_from_params if @ontology.nil?
 
-    @submission = submission_from_params(params[:submission]) if params[:submission] && @submission.nil?
+    @submission = submission_from_params(params[:submission]) if params[:submission] && (@submission.nil? || @submission.errors)
+    
     reset_agent_attributes
     if redirection.is_a?(Hash) && redirection[:id]
       render_turbo_stream replace(redirection[:id], partial: redirection[:partial])

--- a/app/controllers/ontologies_controller.rb
+++ b/app/controllers/ontologies_controller.rb
@@ -152,6 +152,8 @@ class OntologiesController < ApplicationController
     @ontology.viewOf = params.dig(:ontology, :viewOf)
     @submission = LinkedData::Client::Models::OntologySubmission.new
     @submission.hasOntologyLanguage = 'OWL'
+    @submission.released = Date.today.to_s
+    @submission.status = 'production'
     @ontologies = LinkedData::Client::Models::Ontology.all(include: 'acronym', include_views: true, display_links: false, display_context: false)
     @categories = LinkedData::Client::Models::Category.all
     @groups = LinkedData::Client::Models::Group.all

--- a/app/views/ontologies/new.html.haml
+++ b/app/views/ontologies/new.html.haml
@@ -1,7 +1,7 @@
 - @title = t("ontologies.submit_new_ontology")
 
 %div{:style => "margin:10px;"}
-  = form_for :ontology, url: {action: "create"}, html: {id: "ontologyForm", multipart: true} do
+  = form_for :ontology, url: {action: "create"}, html: {id: "ontologyForm", multipart: true, novalidate: true} do
     .upload-ontology-container
       %div{style: 'width: 589px'}
         = error_message_alert


### PR DESCRIPTION
### Changes
- Keep the values of: description, ontology language, status, creation date, contact infos when the user submit a form that contains errors.
- Change the default value of status from alpha to production.
- Change the default value of the creation date from empty to today’s date.
- Fix the issue of getting status field filled with 400 when we submit a wrong form.
- Fix the issue of infinite loading button when we put a wrong URI.