### PR TITLE
Fix: Reject the current ontology from appearing in the ontologies selector in editing the submission's relations

### DIFF
--- a/app/helpers/submission_inputs_helper.rb
+++ b/app/helpers/submission_inputs_helper.rb
@@ -426,6 +426,8 @@ module SubmissionInputsHelper
                                                                .map { |x| ["#{x.name} (#{x.acronym})", x.id.to_s] }
       @ontology_acronyms << ['', '']
     end
+    
+    @ontology_acronyms = @ontology_acronyms.reject { |acronym, id| id == @ontology.id }
 
     input = ''
 

--- a/app/helpers/submission_inputs_helper.rb
+++ b/app/helpers/submission_inputs_helper.rb
@@ -420,14 +420,14 @@ module SubmissionInputsHelper
     end
   end
 
-  def generate_ontology_select_input(name, label, selected, multiple)
+  def generate_ontology_select_input(name, label, selected, multiple, reject_ontology: @ontology)
     unless @ontology_acronyms
       @ontology_acronyms = LinkedData::Client::Models::Ontology.all(include: 'acronym,name', display_links: false, display_context: false, include_views: true)
                                                                .map { |x| ["#{x.name} (#{x.acronym})", x.id.to_s] }
       @ontology_acronyms << ['', '']
     end
-    
-    @ontology_acronyms = @ontology_acronyms.reject { |acronym, id| id == @ontology.id }
+
+    @ontology_acronyms = @ontology_acronyms.reject { |acronym, id| id == reject_ontology.id }
 
     input = ''
 


### PR DESCRIPTION
Related issue: https://github.com/agroportal/project-management/issues/557#event-12970003146

Screenshot:
![Capture d’écran 2024-05-29 à 17 09 25](https://github.com/ontoportal-lirmm/bioportal_web_ui/assets/61744974/568464a3-900f-4da1-9b60-ac3d593c5361)
