### PR TITLE
Feature: Scroll to the selected term in the tree view

### DIFF
--- a/app/javascript/controllers/simple_tree_controller.js
+++ b/app/javascript/controllers/simple_tree_controller.js
@@ -10,8 +10,8 @@ export default class extends Controller {
     setTimeout(() => {
       let activeElem = this.element.querySelector('.tree-link.active');
       if (activeElem) {
-        activeElem.scrollIntoView({ behavior: 'smooth', block: 'center' });
-    
+        activeElem.scrollIntoView({ block: 'center' });
+        window.scrollTo({top: 0,});
         if (this.autoClickValue) {
           activeElem.click();
         }

--- a/app/javascript/controllers/simple_tree_controller.js
+++ b/app/javascript/controllers/simple_tree_controller.js
@@ -7,18 +7,17 @@ export default class extends Controller {
   }
 
   connect () {
-    let activeElem = this.element.querySelector('a.active')
-    if (activeElem) {
-      this.element.scrollTo({
-        top: activeElem.offsetTop,
-        behavior: 'smooth'
-      });
-
-      if (this.autoClickValue) {
-        activeElem.click()
+    setTimeout(() => {
+      let activeElem = this.element.querySelector('.tree-link.active');
+      if (activeElem) {
+        activeElem.scrollIntoView({ behavior: 'smooth', block: 'center' });
+    
+        if (this.autoClickValue) {
+          activeElem.click();
+        }
       }
-    }
-    this.#onClickTooManyChildrenInit()
+      this.#onClickTooManyChildrenInit();
+    }, 0);   
   }
 
   select (event) {


### PR DESCRIPTION
### Related issue: 
https://github.com/agroportal/project-management/issues/479
### Explain technical solution
- In the JS we get the active element and then we scroll to keep in in view.
- But the key thing here is to wrap the whole function inside a setTimout of a 0s, why?
  - When JavaScript code is executed directly, it runs synchronously as part of the current execution context.
  - When JavaScript code is executed inside a setTimeout with a delay of 0 milliseconds, it is scheduled to run asynchronously. The function inside setTimeout is scheduled to run after the current execution context completes, meaning it will be placed in the task queue.
  
See this example:
```
console.log('Start');

setTimeout(() => {
  console.log('Inside setTimeout');
}, 0);

console.log('End');
```
Output:
```
Start
End
Inside setTimeout
```
 
**Why we need this**
When we execute the code, to get the active element we need to wait for the turbo frame to be fully rendred

Demo:


https://github.com/ontoportal-lirmm/bioportal_web_ui/assets/61744974/f8e091f4-d296-4e9a-bfa6-a3d15c5dbf6d



