### PR TITLE
Fix: change URL to URI in check resolvability

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1076,21 +1076,21 @@ en:
     close: Close
     submit: Submit
   check_resolvability:
-    check_resolvability_message_1: "The URL is resolvable and support the following formats: %{supported_format}"
-    check_resolvability_message_2: "The URL resolvable but is not content negotiable, support only: %{supported_format}"
-    check_resolvability_message_3: The URL is not resolvable and not content negotiable (returns %{status}).
+    check_resolvability_message_1: "The URI is resolvable and support the following formats: %{supported_format}"
+    check_resolvability_message_2: "The URI resolvable but is not content negotiable, support only: %{supported_format}"
+    check_resolvability_message_3: The URI is not resolvable and not content negotiable (returns %{status}).
     uri_placeholder: Type a URI to test its resolvability
     show_help: Show help
     format_not_specified: Format not specified
     how_it_works:
       title: How it works
       content_1: |
-        The check resolvability tool allows you to test if a given URL is resolvable. It is based on the HTTP HEAD method.
-        We check the resolvability of a URL by sending a HEAD request to the URL and checking if the response status code is 200 (OK) and
+        The check resolvability tool allows you to test if a given URI is resolvable. It is based on the HTTP HEAD method.
+        We check the resolvability of a URI by sending a HEAD request to the URI and checking if the response status code is 200 (OK) and
         the returned content type is equal to one of the following %{resolvability_formats}.
       content_2: |
-        We have a timeout set to %{resolvability_timeout} seconds, so if the URL is not resolvable within that time, the check will fail.
-        And a max redirections set to %{resolvability_max_redirections}, so if the URL is not resolvable within that number of redirections, the check will fail.
+        We have a timeout set to %{resolvability_timeout} seconds, so if the URI is not resolvable within that time, the check will fail.
+        And a max redirections set to %{resolvability_max_redirections}, so if the URI is not resolvable within that number of redirections, the check will fail.
     resolving_uri:
       title: Resolving a URI
       content: |

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -1098,21 +1098,21 @@ fr:
     submit: Soumettre
 
   check_resolvability:
-    check_resolvability_message_1: "L'URL est résolvable et supporte les formats suivants : %{supported_format}"
-    check_resolvability_message_2: "L'URL est résolvable mais n'est pas négociable en contenu, supporte uniquement : %{supported_format}"
-    check_resolvability_message_3: L'URL n'est pas résolvable et n'est pas négociable en contenu (retourne %{status}).
+    check_resolvability_message_1: "L'URI est résolvable et supporte les formats suivants : %{supported_format}"
+    check_resolvability_message_2: "L'URI est résolvable mais n'est pas négociable en contenu, supporte uniquement : %{supported_format}"
+    check_resolvability_message_3: L'URI n'est pas résolvable et n'est pas négociable en contenu (retourne %{status}).
     uri_placeholder: Tapez une URI pour tester sa résolvabilité
     show_help: Afficher l'aide
     format_not_specified: Format non spécifié
     how_it_works:
       title: Comment ça fonctionne
       content_1: |
-        L'outil de vérification de la résolvabilité vous permet de tester si une URL donnée est résolvable. Il est basé sur la méthode HTTP HEAD.
-        Nous vérifions la résolvabilité d'une URL en envoyant une requête HEAD à l'URL et en vérifiant si le code de statut de la réponse est 200 (OK) et
+        L'outil de vérification de la résolvabilité vous permet de tester si une URI donnée est résolvable. Il est basé sur la méthode HTTP HEAD.
+        Nous vérifions la résolvabilité d'une URI en envoyant une requête HEAD à l'URI et en vérifiant si le code de statut de la réponse est 200 (OK) et
         si le type de contenu retourné est égal à l'un des %{resolvability_formats} suivants.
       content_2: |
-        Nous avons un délai d'attente fixé à %{resolvability_timeout} secondes, donc si l'URL n'est pas résolvable dans ce délai, la vérification échouera.
-        Et un nombre maximal de redirections fixé à %{resolvability_max_redirections}, donc si l'URL n'est pas résolvable dans ce nombre de redirections, la vérification échouera.
+        Nous avons un délai d'attente fixé à %{resolvability_timeout} secondes, donc si l'URI n'est pas résolvable dans ce délai, la vérification échouera.
+        Et un nombre maximal de redirections fixé à %{resolvability_max_redirections}, donc si l'URI n'est pas résolvable dans ce nombre de redirections, la vérification échouera.
     resolving_uri:
       title: Résolution d'une URI
       content: |


### PR DESCRIPTION
### Context
fix the word URL to URI in check resolvability in French and English languages
English:
![en_uri](https://github.com/ontoportal-lirmm/bioportal_web_ui/assets/66650181/ff92b82d-09e5-4d83-8338-bd54bd97c773)
French:
![fr_uri](https://github.com/ontoportal-lirmm/bioportal_web_ui/assets/66650181/f9726a93-f23e-4408-ae4d-08702136b758)
