### PR TITLE
Fix: handle the case reset_agents in edit submissions error state are already Agents

### DIFF
--- a/app/controllers/concerns/ontology_updater.rb
+++ b/app/controllers/concerns/ontology_updater.rb
@@ -86,7 +86,10 @@ module OntologyUpdater
   def reset_agent_attributes
     helpers.agent_attributes.each do |attr|
       current_val = @submission[attr]
-      new_values = Array(current_val).map { |x| LinkedData::Client::Models::Agent.find(x.split('/').last) }
+      new_values = Array(current_val).map do |x|
+        next x if x.is_a?(LinkedData::Client::Models::Agent)
+        LinkedData::Client::Models::Agent.find(x.split('/').last)
+      end
 
       new_values = new_values.first unless current_val.is_a?(Array)
 


### PR DESCRIPTION
fix https://github.com/ontoportal-lirmm/bioportal_web_ui/issues/586
![image](https://github.com/ontoportal-lirmm/bioportal_web_ui/assets/29259906/b2c5e714-8c00-4c1d-8a2a-a099319dd1f4)

### Changes 
* handle the case reset_agents in edit submissions error state are already Agents (https://github.com/ontoportal-lirmm/bioportal_web_ui/commit/ea168c62359aadd8e52a69f5474aa6b38681ce88) 
