### PR TITLE
Feature: update docker compose to have a production service

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -20,3 +20,5 @@ docker-compose.override.yml
 yarn-error.log
 yarn-debug.log*
 .yarn-integrity
+
+config/credentials/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -38,10 +38,14 @@ RUN yarn install && yarn build
 
 
 
+RUN cp config/bioportal_config_env.rb.sample config/bioportal_config_production.rb
+RUN cp config/bioportal_config_env.rb.sample config/bioportal_config_development.rb
+RUN cp config/database.yml.sample config/database.yml
+
 # Precompile bootsnap code for faster boot times
 RUN bundle exec bootsnap precompile --gemfile app/ lib/
 
-# RUN SECRET_KEY_BASE_DUMMY="1" ./bin/rails assets:precompile
+RUN SECRET_KEY_BASE_DUMMY="1" ./bin/rails assets:precompile
 
 ENV BINDING="0.0.0.0"
 EXPOSE 3000

--- a/Gemfile
+++ b/Gemfile
@@ -1,12 +1,12 @@
 source 'https://rubygems.org'
 
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
-gem 'rails', '7.0.7'
+gem 'rails', '7.0.3'
 
-gem 'jsbundling-rails'
 gem 'chart-js-rails'
-gem 'sassc-rails' #sass-rails replacent
-gem 'terser' #ugilifer replacent
+gem 'jsbundling-rails'
+gem 'sassc-rails' # sass-rails replacent
+gem 'terser' # ugilifer replacent
 
 # See https://github.com/rails/execjs#readme for more supported runtimes
 # gem 'therubyracer', platforms: :ruby
@@ -16,11 +16,8 @@ gem 'bootstrap', '~> 4.2.0'
 gem 'jquery-rails'
 gem 'jquery-ui-rails'
 
-
-
 # The original asset pipeline for Rails [https://github.com/rails/sprockets-rails]
 gem 'sprockets-rails'
-
 
 # Use the Puma web server [https://github.com/puma/puma]
 gem 'puma', '~> 5.0'
@@ -35,10 +32,10 @@ gem 'turbo-rails'
 gem 'stimulus-rails'
 
 # Build JSON APIs with ease [https://github.com/rails/jbuilder]
-#gem "jbuilder"
+# gem "jbuilder"
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
-gem 'tzinfo-data', platforms: %i[ mingw mswin x64_mingw jruby ]
+gem 'tzinfo-data', platforms: %i[mingw mswin x64_mingw jruby]
 
 # To use ActiveModel has_secure_password
 # gem 'bcrypt-ruby', '~> 3.0.0'
@@ -49,41 +46,43 @@ gem 'bootsnap', require: false
 
 gem 'cube-ruby', require: 'cube'
 gem 'dalli'
+gem 'ffi', '~> 1.16.3'
+gem 'flag-icons-rails', '~> 3.4'
 gem 'flamegraph'
 gem 'graphql-client'
 gem 'haml', '~> 5.1'
 gem 'i18n'
-gem 'rails-i18n', '~> 7.0.0'
 gem 'iconv'
+gem 'inline_svg'
+gem 'iso-639', '~> 0.3.6'
+gem 'lookbook', '~> 1.5.5'
 gem 'multi_json'
 gem 'mysql2'
 gem 'oj'
+gem 'ontologies_api_client', git: 'https://github.com/ontoportal-lirmm/ontologies_api_ruby_client.git',
+                             branch: 'development'
 gem 'open_uri_redirections'
 gem 'pry'
 gem 'psych', '< 4'
 gem 'rack-mini-profiler'
 gem 'rails_autolink'
+gem 'rails-i18n', '~> 7.0.0'
 gem 'rdoc'
 gem 'recaptcha', '~> 5.9.0'
 gem 'rest-client'
 gem 'stackprof', require: false
 gem 'thin'
-gem 'view_component', '~> 2.72'
 gem 'turnout'
+gem 'view_component', '~> 2.72'
 gem 'will_paginate', '~> 3.0'
-gem 'inline_svg'
-gem "lookbook", '~> 1.5.5'
-gem 'ontologies_api_client', git: 'https://github.com/ontoportal-lirmm/ontologies_api_ruby_client.git', branch: 'development'
-gem "flag-icons-rails", "~> 3.4"
-gem "iso-639", "~> 0.3.6"
 
 # Multi-Provider Authentication
 gem 'omniauth'
-gem "omniauth-rails_csrf_protection"
 gem 'omniauth-github'
 gem 'omniauth-google-oauth2'
-gem 'omniauth-orcid'
 gem 'omniauth-keycloak'
+gem 'omniauth-orcid'
+gem 'omniauth-rails_csrf_protection'
 
 group :staging, :production, :appliance do
   # application monitoring
@@ -110,16 +109,16 @@ group :development do
   gem 'rubocop', require: false
   # gem 'i18n-debug'
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
-  gem 'debug', platforms: %i[ mri mingw x64_mingw ]
+  gem 'debug', platforms: %i[mri mingw x64_mingw]
 
   # Use console on exceptions pages [https://github.com/rails/web-console]
-  gem 'web-console'
   gem 'i18n-tasks'
   gem 'i18n-tasks-csv', '~> 1.1'
+  gem 'web-console'
 
   gem 'deepl-rb'
-  gem 'letter_opener_web', '~> 2.0'
   gem 'haml-rails'
+  gem 'letter_opener_web', '~> 2.0'
 end
 
 group :test, :development do
@@ -132,14 +131,11 @@ group :test do
   gem 'selenium-webdriver'
   gem 'simplecov', require: false
   gem 'simplecov-cobertura' # for codecov.io
-  #gem 'webdrivers'
+  # gem 'webdrivers'
   gem 'webmock'
 end
 
+gem 'net-ftp', '~> 0.2.0', require: false
+gem 'net-http', '~> 0.3.2'
 
-gem "net-ftp", "~> 0.2.0", require: false
-gem "net-http", "~> 0.3.2"
-
-
-
-gem "bugsnag", "~> 6.26"
+gem 'bugsnag', '~> 6.26'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -102,9 +102,7 @@ GEM
       popper_js (>= 1.14.3, < 2)
       sassc-rails (>= 2.0.0)
     brakeman (5.4.1)
-    bugsnag (6.27.0)
-      concurrent-ruby (~> 1.0)
-    builder (3.2.4)
+    builder (3.3.0)
     capistrano (3.18.1)
       airbrussh (>= 1.0.0)
       i18n
@@ -134,10 +132,7 @@ GEM
       railties (> 3.1)
     childprocess (5.0.0)
     coderay (1.1.3)
-    concurrent-ruby (1.3.1)
-    crack (1.0.0)
-      bigdecimal
-      rexml
+    concurrent-ruby (1.3.2)
     crass (1.0.6)
     css_parser (1.17.1)
       addressable
@@ -150,7 +145,6 @@ GEM
       reline (>= 0.3.8)
     deepl-rb (2.5.3)
     diff-lcs (1.5.1)
-    docile (1.4.0)
     domain_name (0.6.20240107)
     ed25519 (1.3.0)
     erubi (1.12.0)
@@ -170,6 +164,7 @@ GEM
       multipart-post (~> 2)
     faraday-net_http (2.1.0)
     ffi (1.17.0-x86_64-linux-gnu)
+    ffi (1.17.0-x86_64-linux-musl)
     flag-icons-rails (3.4.6.1)
       sass-rails
     flamegraph (0.9.5)
@@ -203,13 +198,13 @@ GEM
       domain_name (~> 0.5)
     i18n (1.14.5)
       concurrent-ruby (~> 1.0)
-    i18n-tasks (0.9.37)
+    i18n-tasks (1.0.14)
       activesupport (>= 4.0.2)
       ast (>= 2.1.0)
       erubi
       highline (>= 2.0.0)
       i18n
-      parser (>= 2.2.3.0)
+      parser (>= 3.2.2.1)
       rails-i18n
       rainbow (>= 2.2.2, < 4.0)
       terminal-table (>= 1.5.1)
@@ -247,16 +242,6 @@ GEM
     jwt (2.8.1)
       base64
     language_server-protocol (3.17.0.3)
-    launchy (3.0.1)
-      addressable (~> 2.8)
-      childprocess (~> 5.0)
-    letter_opener (1.10.0)
-      launchy (>= 2.2, < 4)
-    letter_opener_web (2.0.0)
-      actionmailer (>= 5.2)
-      letter_opener (~> 1.7)
-      railties (>= 5.2)
-      rexml
     listen (3.9.0)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
@@ -287,7 +272,7 @@ GEM
     method_source (1.1.0)
     mime-types (3.5.2)
       mime-types-data (~> 3.2015)
-    mime-types-data (3.2024.0507)
+    mime-types-data (3.2024.0604)
     mini_mime (1.1.5)
     minitest (5.23.1)
     msgpack (1.7.2)
@@ -299,7 +284,7 @@ GEM
     net-ftp (0.2.1)
       net-protocol
       time
-    net-http (0.3.2)
+    net-http (0.4.1)
       uri
     net-imap (0.4.12)
       date
@@ -316,7 +301,7 @@ GEM
       net-protocol
     net-ssh (7.2.3)
     netrc (0.11.0)
-    newrelic_rpm (9.9.0)
+    newrelic_rpm (9.10.2)
     nio4r (2.7.3)
     nokogiri (1.15.6-x86_64-linux)
       racc (~> 1.4)
@@ -327,7 +312,7 @@ GEM
       rack (>= 1.2, < 4)
       snaky_hash (~> 2.0)
       version_gem (~> 1.1)
-    oj (3.16.3)
+    oj (3.16.4)
       bigdecimal (>= 3.0)
     omniauth (2.1.2)
       hashie (>= 3.4.6)
@@ -356,7 +341,7 @@ GEM
       actionpack (>= 4.2)
       omniauth (~> 2.0)
     open_uri_redirections (0.2.1)
-    parallel (1.24.0)
+    parallel (1.25.1)
     parser (3.3.2.0)
       ast (~> 2.4.1)
       racc
@@ -486,15 +471,6 @@ GEM
       rubyzip (>= 1.2.2, < 3.0)
       websocket (~> 1.0)
     sexp_processor (4.17.1)
-    simplecov (0.22.0)
-      docile (~> 1.1)
-      simplecov-html (~> 0.11)
-      simplecov_json_formatter (~> 0.1)
-    simplecov-cobertura (2.1.0)
-      rexml
-      simplecov (~> 0.19)
-    simplecov-html (0.12.3)
-    simplecov_json_formatter (0.1.4)
     snaky_hash (2.0.1)
       hashie
       version_gem (~> 1.1, >= 1.1.1)
@@ -502,9 +478,9 @@ GEM
     sprockets (4.2.1)
       concurrent-ruby (~> 1.0)
       rack (>= 2.2.4, < 4)
-    sprockets-rails (3.4.2)
-      actionpack (>= 5.2)
-      activesupport (>= 5.2)
+    sprockets-rails (3.5.1)
+      actionpack (>= 6.1)
+      activesupport (>= 6.1)
       sprockets (>= 3.0.0)
     sshkit (1.22.2)
       base64
@@ -652,4 +628,4 @@ DEPENDENCIES
   will_paginate (~> 3.0)
 
 BUNDLED WITH
-   2.3.23
+   2.4.22

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -17,67 +17,67 @@ GIT
 GEM
   remote: https://rubygems.org/
   specs:
-    actioncable (7.0.7)
-      actionpack (= 7.0.7)
-      activesupport (= 7.0.7)
+    actioncable (7.0.3)
+      actionpack (= 7.0.3)
+      activesupport (= 7.0.3)
       nio4r (~> 2.0)
       websocket-driver (>= 0.6.1)
-    actionmailbox (7.0.7)
-      actionpack (= 7.0.7)
-      activejob (= 7.0.7)
-      activerecord (= 7.0.7)
-      activestorage (= 7.0.7)
-      activesupport (= 7.0.7)
+    actionmailbox (7.0.3)
+      actionpack (= 7.0.3)
+      activejob (= 7.0.3)
+      activerecord (= 7.0.3)
+      activestorage (= 7.0.3)
+      activesupport (= 7.0.3)
       mail (>= 2.7.1)
       net-imap
       net-pop
       net-smtp
-    actionmailer (7.0.7)
-      actionpack (= 7.0.7)
-      actionview (= 7.0.7)
-      activejob (= 7.0.7)
-      activesupport (= 7.0.7)
+    actionmailer (7.0.3)
+      actionpack (= 7.0.3)
+      actionview (= 7.0.3)
+      activejob (= 7.0.3)
+      activesupport (= 7.0.3)
       mail (~> 2.5, >= 2.5.4)
       net-imap
       net-pop
       net-smtp
       rails-dom-testing (~> 2.0)
-    actionpack (7.0.7)
-      actionview (= 7.0.7)
-      activesupport (= 7.0.7)
-      rack (~> 2.0, >= 2.2.4)
+    actionpack (7.0.3)
+      actionview (= 7.0.3)
+      activesupport (= 7.0.3)
+      rack (~> 2.0, >= 2.2.0)
       rack-test (>= 0.6.3)
       rails-dom-testing (~> 2.0)
       rails-html-sanitizer (~> 1.0, >= 1.2.0)
-    actiontext (7.0.7)
-      actionpack (= 7.0.7)
-      activerecord (= 7.0.7)
-      activestorage (= 7.0.7)
-      activesupport (= 7.0.7)
+    actiontext (7.0.3)
+      actionpack (= 7.0.3)
+      activerecord (= 7.0.3)
+      activestorage (= 7.0.3)
+      activesupport (= 7.0.3)
       globalid (>= 0.6.0)
       nokogiri (>= 1.8.5)
-    actionview (7.0.7)
-      activesupport (= 7.0.7)
+    actionview (7.0.3)
+      activesupport (= 7.0.3)
       builder (~> 3.1)
       erubi (~> 1.4)
       rails-dom-testing (~> 2.0)
       rails-html-sanitizer (~> 1.1, >= 1.2.0)
-    activejob (7.0.7)
-      activesupport (= 7.0.7)
+    activejob (7.0.3)
+      activesupport (= 7.0.3)
       globalid (>= 0.3.6)
-    activemodel (7.0.7)
-      activesupport (= 7.0.7)
-    activerecord (7.0.7)
-      activemodel (= 7.0.7)
-      activesupport (= 7.0.7)
-    activestorage (7.0.7)
-      actionpack (= 7.0.7)
-      activejob (= 7.0.7)
-      activerecord (= 7.0.7)
-      activesupport (= 7.0.7)
+    activemodel (7.0.3)
+      activesupport (= 7.0.3)
+    activerecord (7.0.3)
+      activemodel (= 7.0.3)
+      activesupport (= 7.0.3)
+    activestorage (7.0.3)
+      actionpack (= 7.0.3)
+      activejob (= 7.0.3)
+      activerecord (= 7.0.3)
+      activesupport (= 7.0.3)
       marcel (~> 1.0)
       mini_mime (>= 1.1.0)
-    activesupport (7.0.7)
+    activesupport (7.0.3)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 1.6, < 2)
       minitest (>= 5.1)
@@ -92,6 +92,8 @@ GEM
       execjs (~> 2)
     base64 (0.2.0)
     bcrypt_pbkdf (1.1.1)
+    bcrypt_pbkdf (1.1.1-arm64-darwin)
+    bcrypt_pbkdf (1.1.1-x86_64-darwin)
     bigdecimal (3.1.8)
     bindata (2.5.0)
     bindex (0.8.1)
@@ -102,6 +104,8 @@ GEM
       popper_js (>= 1.14.3, < 2)
       sassc-rails (>= 2.0.0)
     brakeman (5.4.1)
+    bugsnag (6.27.0)
+      concurrent-ruby (~> 1.0)
     builder (3.3.0)
     capistrano (3.18.1)
       airbrussh (>= 1.0.0)
@@ -133,6 +137,9 @@ GEM
     childprocess (5.0.0)
     coderay (1.1.3)
     concurrent-ruby (1.3.2)
+    crack (1.0.0)
+      bigdecimal
+      rexml
     crass (1.0.6)
     css_parser (1.17.1)
       addressable
@@ -145,6 +152,7 @@ GEM
       reline (>= 0.3.8)
     deepl-rb (2.5.3)
     diff-lcs (1.5.1)
+    docile (1.4.0)
     domain_name (0.6.20240107)
     ed25519 (1.3.0)
     erubi (1.12.0)
@@ -163,8 +171,7 @@ GEM
     faraday-multipart (1.0.4)
       multipart-post (~> 2)
     faraday-net_http (2.1.0)
-    ffi (1.17.0-x86_64-linux-gnu)
-    ffi (1.17.0-x86_64-linux-musl)
+    ffi (1.16.3)
     flag-icons-rails (3.4.6.1)
       sass-rails
     flamegraph (0.9.5)
@@ -198,13 +205,13 @@ GEM
       domain_name (~> 0.5)
     i18n (1.14.5)
       concurrent-ruby (~> 1.0)
-    i18n-tasks (1.0.14)
+    i18n-tasks (0.9.37)
       activesupport (>= 4.0.2)
       ast (>= 2.1.0)
       erubi
       highline (>= 2.0.0)
       i18n
-      parser (>= 3.2.2.1)
+      parser (>= 2.2.3.0)
       rails-i18n
       rainbow (>= 2.2.2, < 4.0)
       terminal-table (>= 1.5.1)
@@ -242,6 +249,16 @@ GEM
     jwt (2.8.1)
       base64
     language_server-protocol (3.17.0.3)
+    launchy (3.0.1)
+      addressable (~> 2.8)
+      childprocess (~> 5.0)
+    letter_opener (1.10.0)
+      launchy (>= 2.2, < 4)
+    letter_opener_web (2.0.0)
+      actionmailer (>= 5.2)
+      letter_opener (~> 1.7)
+      railties (>= 5.2)
+      rexml
     listen (3.9.0)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
@@ -284,7 +301,7 @@ GEM
     net-ftp (0.2.1)
       net-protocol
       time
-    net-http (0.4.1)
+    net-http (0.3.2)
       uri
     net-imap (0.4.12)
       date
@@ -301,8 +318,18 @@ GEM
       net-protocol
     net-ssh (7.2.3)
     netrc (0.11.0)
-    newrelic_rpm (9.10.2)
+    newrelic_rpm (9.9.0)
     nio4r (2.7.3)
+    nokogiri (1.15.6-aarch64-linux)
+      racc (~> 1.4)
+    nokogiri (1.15.6-arm-linux)
+      racc (~> 1.4)
+    nokogiri (1.15.6-arm64-darwin)
+      racc (~> 1.4)
+    nokogiri (1.15.6-x86-linux)
+      racc (~> 1.4)
+    nokogiri (1.15.6-x86_64-darwin)
+      racc (~> 1.4)
     nokogiri (1.15.6-x86_64-linux)
       racc (~> 1.4)
     oauth2 (2.0.9)
@@ -364,20 +391,20 @@ GEM
       rack (~> 2.2, >= 2.2.4)
     rack-test (2.1.0)
       rack (>= 1.3)
-    rails (7.0.7)
-      actioncable (= 7.0.7)
-      actionmailbox (= 7.0.7)
-      actionmailer (= 7.0.7)
-      actionpack (= 7.0.7)
-      actiontext (= 7.0.7)
-      actionview (= 7.0.7)
-      activejob (= 7.0.7)
-      activemodel (= 7.0.7)
-      activerecord (= 7.0.7)
-      activestorage (= 7.0.7)
-      activesupport (= 7.0.7)
+    rails (7.0.3)
+      actioncable (= 7.0.3)
+      actionmailbox (= 7.0.3)
+      actionmailer (= 7.0.3)
+      actionpack (= 7.0.3)
+      actiontext (= 7.0.3)
+      actionview (= 7.0.3)
+      activejob (= 7.0.3)
+      activemodel (= 7.0.3)
+      activerecord (= 7.0.3)
+      activestorage (= 7.0.3)
+      activesupport (= 7.0.3)
       bundler (>= 1.15.0)
-      railties (= 7.0.7)
+      railties (= 7.0.3)
     rails-dom-testing (2.2.0)
       activesupport (>= 5.0.0)
       minitest
@@ -392,9 +419,9 @@ GEM
       actionview (> 3.1)
       activesupport (> 3.1)
       railties (> 3.1)
-    railties (7.0.7)
-      actionpack (= 7.0.7)
-      activesupport (= 7.0.7)
+    railties (7.0.3)
+      actionpack (= 7.0.3)
+      activesupport (= 7.0.3)
       method_source
       rake (>= 12.2)
       thor (~> 1.0)
@@ -471,6 +498,15 @@ GEM
       rubyzip (>= 1.2.2, < 3.0)
       websocket (~> 1.0)
     sexp_processor (4.17.1)
+    simplecov (0.22.0)
+      docile (~> 1.1)
+      simplecov-html (~> 0.11)
+      simplecov_json_formatter (~> 0.1)
+    simplecov-cobertura (2.1.0)
+      rexml
+      simplecov (~> 0.19)
+    simplecov-html (0.12.3)
+    simplecov_json_formatter (0.1.4)
     snaky_hash (2.0.1)
       hashie
       version_gem (~> 1.1, >= 1.1.1)
@@ -544,7 +580,20 @@ GEM
     zeitwerk (2.6.15)
 
 PLATFORMS
+  aarch64-linux
+  aarch64-linux-gnu
+  aarch64-linux-musl
+  arm-linux
+  arm-linux-gnu
+  arm-linux-musl
+  arm64-darwin
+  x86-linux
+  x86-linux-gnu
+  x86-linux-musl
+  x86_64-darwin
   x86_64-linux
+  x86_64-linux-gnu
+  x86_64-linux-musl
 
 DEPENDENCIES
   bcrypt_pbkdf (>= 1.0, < 2.0)
@@ -565,6 +614,7 @@ DEPENDENCIES
   debug
   deepl-rb
   ed25519 (>= 1.2, < 2.0)
+  ffi (~> 1.16.3)
   flag-icons-rails (~> 3.4)
   flamegraph
   graphql-client
@@ -602,7 +652,7 @@ DEPENDENCIES
   psych (< 4)
   puma (~> 5.0)
   rack-mini-profiler
-  rails (= 7.0.7)
+  rails (= 7.0.3)
   rails-i18n (~> 7.0.0)
   rails_autolink
   rdoc

--- a/bin/ontoportal
+++ b/bin/ontoportal
@@ -135,8 +135,8 @@ dev() {
           bash_cmd+=" (bundle config unset local.ontologies_api_client) &&"
         fi
   done
-  bash_cmd+=" (bundle check || bundle install || bundle update) && bin/rails db:prepare && bundle exec rails s -b 0.0.0.0 -p 3000"
-  docker_run_cmd+=" --service-ports rails bash -c \"$bash_cmd\""
+  bash_cmd+=" (bundle check || bundle install) && bin/rails db:prepare && bundle exec rails s -b 0.0.0.0 -p 3000"
+  docker_run_cmd+=" --service-ports dev bash -c \"$bash_cmd\""
   echo "$docker_run_cmd"
   echo "Run: bundle exec rails s -b 0.0.0.0 -p 3000"
   eval "$docker_run_cmd"
@@ -188,7 +188,7 @@ test() {
 # Function to handle the "run" option
 run() {
   echo "Run: $*"
-  docker compose run --rm -it rails bash -c "$*"
+  docker compose run --rm -it dev bash -c "$*"
 }
 
 create_config_files

--- a/config/environment.rb
+++ b/config/environment.rb
@@ -1,5 +1,18 @@
 # Load the Rails application.
 require_relative "application"
 
+# Remove this after migrating to Rails 7.1 (https://github.com/rails/rails/issues/32947#issuecomment-1356391185)
+class Rails::Application
+  def secret_key_base
+    if Rails.env.development? || Rails.env.test? || ENV["SECRET_KEY_BASE_DUMMY"]
+      secrets.secret_key_base ||= generate_development_secret
+    else
+      validate_secret_key_base(
+        ENV["SECRET_KEY_BASE"] || credentials.secret_key_base || secrets.secret_key_base
+      )
+    end
+  end
+end
+
 # Initialize the Rails application.
 Rails.application.initialize!

--- a/config/initializers/graphql_client.rb
+++ b/config/initializers/graphql_client.rb
@@ -1,17 +1,17 @@
 # frozen_string_literal: true
-
-require 'graphql/client'
-require 'graphql/client/http'
-
-module GitHub
-  HTTPAdapter = GraphQL::Client::HTTP.new('https://api.github.com/graphql') do
-    def headers(_context)
-      { 'Authorization': "Bearer #{Rails.application.credentials.dig(:kgcl, :github_access_token)}" }
-    end
-  end
-
-  Client = GraphQL::Client.new(
-    schema: File.join(Rails.root, 'data', 'schema.json').to_s,
-    execute: HTTPAdapter
-  )
-end
+# Disable as no used in ontoportal-lirmm branch and causing problems with docker image build
+# require 'graphql/client'
+# require 'graphql/client/http'
+#
+# module GitHub
+#   HTTPAdapter = GraphQL::Client::HTTP.new('https://api.github.com/graphql') do
+#     def headers(_context)
+#       { 'Authorization': "Bearer #{Rails.application.credentials.dig(:kgcl, :github_access_token)}" }
+#     end
+#   end
+#
+#   Client = GraphQL::Client.new(
+#     schema: File.join(Rails.root, 'data', 'schema.json').to_s,
+#     execute: HTTPAdapter
+#   )
+# end

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,15 +1,32 @@
 x-app: &default-app
-  image: agroportal/ontoportal_web_ui:development
+  image: agroportal/ontoportal_web_ui:2.8.0
   env_file:
     - ".env"
   tty: true
   volumes:
-    - .:/app
-    - bundle:/usr/local/bundle
+    - bundle:/srv/ontoportal/bundle
     - node:/node_modules
     - rails_cache:/app/tmp/cache
     - assets:/app/public/assets
     - /var/run/docker.sock:/var/run/docker.sock
+    - .:/app
+  depends_on:
+    db:
+      condition: service_healthy
+    cache:
+      condition: service_started
+    node:
+      condition: service_started
+  links:
+    - db
+    - cache
+  environment: &env
+    BUNDLE_WITHOUT: ""
+    BUNDLE_PATH: /srv/ontoportal/bundle
+    DB_HOST: db
+    CACHE_HOST: cache
+  ports:
+    - "3000:3000"
   tmpfs:
     - /tmp
     - /app/tmp/pids
@@ -28,12 +45,12 @@ services:
     healthcheck:
       test: ["CMD", "mysqladmin", "ping", "-h", "localhost"]
       timeout: 5s
-      retries: 3  
+      retries: 3
 
   cache:
     image: memcached:latest
     restart: unless-stopped
-    command: [ "-m", "1024" ]
+    command: ["-m", "1024"]
     networks:
       - default
     ports:
@@ -41,36 +58,48 @@ services:
   node:
     <<: *default-app
     command: "yarn build --watch"
+    depends_on:
+      - cache
+      - db
 
-  rails:
+  dev:
     <<: *default-app
+
+  production:
+    <<: *default-app
+    command: "bundle exec puma -C config/puma.rb"
+    environment:
+      <<: *env
+      RAILS_ENV: "appliance"
+      BUNDLE_WITHOUT: "development test"
+      #SECRET_KEY_BASE: TODO
+      #RAILS_MASTER_KEY: TODO
+      BIOPORTAL_WEB_UI_DATABASE_PASSWORD: root
+      MEMCACHE_SERVERS: "cache:11211"
     depends_on:
       db:
         condition: service_healthy
       cache:
         condition: service_started
-      node:
-        condition: service_started
-    links:
-      - db
-      - cache
-    environment:
-      BUNDLE_WITHOUT: ''
-      DB_HOST: db
-      CACHE_HOST: cache
-    ports:
-      - "3000:3000"
+    volumes:
+      - bundle:/usr/local/bundle
+      - node:/node_modules
+      - rails_cache:/app/tmp/cache
+      - assets:/app/public/assets
+      - app_ui:/app
+
   test:
     <<: *default-app
     depends_on:
       - db
       - cache
       - chrome-server
-    network_mode: 'host'
+    network_mode: "host"
     environment:
-      BUNDLE_WITHOUT: ''
+      BUNDLE_WITHOUT: ""
       DB_HOST: 127.0.0.1
       CACHE_HOST: 127.0.0.1
+
   chrome-server:
     image: selenium/standalone-chrome:112.0-chromedriver-112.0-grid-4.9.0-20230421
     shm_size: 2g
@@ -84,3 +113,4 @@ volumes:
   rails_cache:
   assets:
   node:
+  app_ui:


### PR DESCRIPTION
### Changes 
* Update Dockerfile to precompile assets and create config files (https://github.com/ontoportal-lirmm/bioportal_web_ui/pull/666/commits/d59fb84357ed4460d6f226629b1cc5a8f87581a9)
* Disable graphql initializer as not used and raise issues with docker (https://github.com/ontoportal-lirmm/bioportal_web_ui/pull/666/commits/813a55409f924a2c7a0448e2249414243ddc5929)
* Docker ignores local credentials files so that will be created when on run (https://github.com/ontoportal-lirmm/bioportal_web_ui/pull/666/commits/96a4d05f39ec9f0de788aa1c4f21cb6eb6aa5406)
* Update docker-compose file to have two services for dev and production (https://github.com/ontoportal-lirmm/bioportal_web_ui/pull/666/commits/c25f6682794ee32c0f59b3a7466f03b957b56091)