### PR TITLE
Fix: Adjust the fix of concepts details wrong chips URLs

### DIFF
--- a/app/javascript/controllers/label_ajax_controller.js
+++ b/app/javascript/controllers/label_ajax_controller.js
@@ -33,7 +33,7 @@ export default class extends Controller {
                 success: this.#ajaxSuccess.bind(this),
                 error: this.#ajaxError.bind(this)
             });
-          },0)
+          },1)
     }
 
     abort() {


### PR DESCRIPTION
Adjust the fix we did in this PR: https://github.com/ontoportal-lirmm/bioportal_web_ui/pull/638
The solution used in the previous PR was to add a timeout of 0s but in prod it seems like the JS ignore the timeouts of 0s so I used 1ms instead to make it work.