### PR TITLE
Fix: run production mode

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -105,7 +105,6 @@ gem 'net-http', '~> 0.3.2'
 
 # Multi-Provider Authentication
 gem 'omniauth'
-gem 'omniauth-rails_csrf_protection'
 gem 'omniauth-github'
 gem 'omniauth-google-oauth2'
 gem 'omniauth-keycloak'

--- a/bin/ontoportal
+++ b/bin/ontoportal
@@ -135,7 +135,7 @@ dev() {
           bash_cmd+=" (bundle config unset local.ontologies_api_client) &&"
         fi
   done
-  bash_cmd+=" (bundle check || bundle install) && bin/rails db:prepare && bundle exec rails s -b 0.0.0.0 -p 3000"
+  bash_cmd+=" (bundle check || bundle install) && bin/rails secret && EDITOR='nano' bin/rails credentials:edit && bin/rails db:prepare && bundle exec rails s -b 0.0.0.0 -p 3000"
   docker_run_cmd+=" --service-ports dev bash -c \"$bash_cmd\""
   echo "$docker_run_cmd"
   echo "Run: bundle exec rails s -b 0.0.0.0 -p 3000"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -77,6 +77,8 @@ services:
       #RAILS_MASTER_KEY: TODO
       BIOPORTAL_WEB_UI_DATABASE_PASSWORD: root
       MEMCACHE_SERVERS: "cache:11211"
+    ports:
+      - "3000:3000"
     depends_on:
       db:
         condition: service_healthy


### PR DESCRIPTION
This fixes is for using the docker-compose file of the bioportal_web_ui in the ontoportal_docker script: 
- add the port 3000 to run the script correctly
- add some commands when running production mode