### PR TITLE
Fix: Mappings classes links try to open in the turbo frame

### DIFF
--- a/app/components/chip_button_component.rb
+++ b/app/components/chip_button_component.rb
@@ -1,10 +1,11 @@
 class ChipButtonComponent < ViewComponent::Base
-    def initialize(url: nil, text: nil, type: "static", disabled: false, tooltip: nil  ,**html_options)
+    def initialize(url: nil, text: nil, type: "static", disabled: false, tooltip: nil, data_turbo: 'true'  ,**html_options)
         @url = url
         @text = text
         @type = type
         @disabled = disabled
         @tooltip = tooltip
+        @data_turbo = data_turbo
         @html_options = html_options.merge({href: @url})
     end
 end

--- a/app/components/chip_button_component/chip_button_component.html.haml
+++ b/app/components/chip_button_component/chip_button_component.html.haml
@@ -3,7 +3,7 @@
     %span.chip_button_container{@html_options}
       = @text || content
   - elsif !content
-    %a.chip_button_container_clickable{@html_options}
+    %a.chip_button_container_clickable{@html_options, 'data-turbo': @data_turbo}
       = @text
   - else
     %span.chip_button_container_clickable{@html_options}

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -176,7 +176,7 @@ module ApplicationHelper
                     class: "secondary-button regular-button slim", data: { show_modal_title_value: t('application.add_new_proposal')}
     end
   end
-  
+
 
   def link?(str)
     # Regular expression to match strings starting with "http://" or "https://"
@@ -297,7 +297,7 @@ module ApplicationHelper
     options = {  'data-controller': 'label-ajax' }.merge(data)
     options = options.merge({ target: target }) if target
     content_tag(:span, class: 'mx-1') do
-      render ChipButtonComponent.new(url: link, text: cls_id, type: 'clickable', **options)
+      render ChipButtonComponent.new(url: link, text: cls_id, type: 'clickable', data_turbo: 'false', **options)
     end
   end
 

--- a/app/helpers/mappings_helper.rb
+++ b/app/helpers/mappings_helper.rb
@@ -43,16 +43,16 @@ module MappingsHelper
     if inter_portal_acronym
       data_cls = " data-cls='#{cls.links["self"]}?apikey=' "
       portal_cls = " portal-cls='#{inter_portal_acronym}' "
-      raw("<a class='interportalcls4ajax' #{data_cls} #{portal_cls} #{href_cls} target='_blank'>#{cls.id}</a>")
+      raw("<a data-turbo='false' class='interportalcls4ajax' #{data_cls} #{portal_cls} #{href_cls} target='_blank'>#{cls.id}</a>")
     else
-      raw("<a #{href_cls} target='_blank'>#{cls.id}</a>")
+      raw("<a data-turbo='false' #{href_cls} target='_blank'>#{cls.id}</a>")
     end
 
   end
 
   def ajax_to_internal_cls(cls)
     link_to("#{cls.id}<span href='/ajax/classes/label?ontology=#{cls.links["ontology"]}&concept=#{escape(cls.id)}' class='get_via_ajax'></span>".html_safe,
-            ontology_path(cls.explore.ontology.acronym, p: 'classes', conceptid: cls.id))
+            ontology_path(cls.explore.ontology.acronym, p: 'classes', conceptid: cls.id), data: { turbo: false })
   end
 
   # to get the apikey from the interportal instance of the interportal class.
@@ -80,7 +80,7 @@ module MappingsHelper
   end
 
   def ajax_to_external_cls(cls)
-    raw("<a href='#{cls.links['self']}' target='_blank'>#{get_label_for_external_cls(cls.id)}</a>")
+    raw("<a  data-turbo='false' href='#{cls.links['self']}' target='_blank'>#{get_label_for_external_cls(cls.id)}</a>")
   end
 
   # Replace the inter_portal mapping ontology URI (that link to the API) by the link to the ontology in the UI

--- a/app/views/mappings/_show_line.html.haml
+++ b/app/views/mappings/_show_line.html.haml
@@ -1,4 +1,4 @@
-- process = map.process || {}
+- process = map.process || {} 
 - source = "#{map.source} #{process[:source_name]}"
 - relations = process[:relation]&.each { |relation| get_prefixed_uri(relation)}
 - map_id = map.id.to_s.split("/").last


### PR DESCRIPTION
### Issue description
When you click on a link of a class in the mappings page or the mappings tables, you get an error because the link has data-turbo activated so it try to reload the current frame with the content coming from the link result which is not a turbo frame.

### Demo

https://github.com/ontoportal-lirmm/bioportal_web_ui/assets/61744974/8f281355-27db-4637-821d-732198022b00



