### PR TITLE
Feature: hide analytics features if not enabled

### DIFF
--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -7,9 +7,15 @@ class HomeController < ApplicationController
   include FairScoreHelper
 
   def index
-    @analytics =  helpers.ontologies_analytics
+    @analytics = helpers.ontologies_analytics
     # Calculate BioPortal summary statistics
-    @ont_count = @analytics.keys.size
+
+    @ont_count = if @analytics.empty?
+                   LinkedData::Client::Models::Ontology.all.size
+                 else
+                   @analytics.keys.size
+                 end
+
     metrics = LinkedData::Client::Models::Metrics.all
     metrics = metrics.each_with_object(Hash.new(0)) do |h, sum|
       h.to_hash.slice(:classes, :properties, :individuals).each { |k, v| sum[k] += v }

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -37,9 +37,14 @@ module ApplicationHelper
   def resolve_namespaces
     RESOLVE_NAMESPACE
   end
+
   def ontologies_analytics
-    data = LinkedData::Client::Analytics.last_month.onts
-    data.map{|x| [x[:ont].to_s, x[:views]]}.to_h
+    begin
+      data = LinkedData::Client::Analytics.last_month.onts
+      data.map{|x| [x[:ont].to_s, x[:views]]}.to_h
+    rescue StandardError
+      {}
+    end
   end
 
   def get_apikey
@@ -176,7 +181,7 @@ module ApplicationHelper
                     class: "secondary-button regular-button slim", data: { show_modal_title_value: t('application.add_new_proposal')}
     end
   end
-  
+
 
   def link?(str)
     # Regular expression to match strings starting with "http://" or "https://"

--- a/app/views/admin/index.html.haml
+++ b/app/views/admin/index.html.haml
@@ -15,7 +15,11 @@
     - selected = params[:section] || sections.first.downcase
     = render Layout::VerticalTabsComponent.new(header:  t('admin.index.administration_console'), titles: sections, selected: selected, url_parameter: 'section') do |t|
       - t.item_content do
-        = render 'analytics'
+        - if @ontology_visits[:visits].empty?
+          %div.d-flex.justify-content-center
+            Google analytics not enabled
+        - else 
+          = render 'analytics'
       - t.item_content do
         = render 'main'
       - t.item_content do

--- a/app/views/home/index.html.haml
+++ b/app/views/home/index.html.haml
@@ -173,7 +173,7 @@
             %h4
               = format_number_abbreviated(@users_count)
             %p= t("home.users")
-      .home-statistics-link.justify-content-end
+      .home-statistics-link.justify-content-end{style: @analytics.empty? && "visibility: hidden"}
         = link_to t("home.see_details"),'/statistics', target: "_blank"
 
   - if @slices


### PR DESCRIPTION
This PR hides analytics-related features if not enabled, 
### Changes
* Hide see details buttons on the home page if  analytics are not enabled (fix https://github.com/lifewatch-eric/ecoportal_web_ui/issues/51)
* Hide the analytics admin page if analytics are not enabled
* Use TripleStore to show ontology count metrics on the home page if analytics are not enabled (fix https://github.com/lifewatch-eric/ecoportal_web_ui/issues/50)