### PR TITLE
Fix: Check resolvability redirection

### DIFF
--- a/app/helpers/check_resolvability_helper.rb
+++ b/app/helpers/check_resolvability_helper.rb
@@ -60,11 +60,7 @@ module CheckResolvabilityHelper
       end
 
       if response.is_a?(Net::HTTPRedirection) && response['location']
-        if !uri.to_s.start_with?(response['location']) && uri.to_s.include?(response['location'].chomp('/'))
-          uri = URI.parse(uri.scheme + '://' + uri.host + '/' + response['location'])
-        else
-          uri = URI.parse(response['location'])
-        end
+        uri = URI.join(uri, response['location'])
         redirections << uri
         redirect_count += 1
       end
@@ -85,7 +81,7 @@ module CheckResolvabilityHelper
     supported_format = negotiation_formats.find_all do |format|
       begin
         redirections[format] = follow_redirection(url, format, timeout_seconds)
-        redirections[:result].eql?(2)
+        redirections[format][:result].eql?(2)
       rescue StandardError => e
         redirections[format] = resolvability_status(e.message, [], [], result: 0)
         false


### PR DESCRIPTION
### Context
- https://github.com/ontoportal-lirmm/bioportal_web_ui/issues/692

### Solution
Use URI.join
```ruby
      if response.is_a?(Net::HTTPRedirection) && response['location']
        uri = URI.join(uri, response['location'])
```
With URI.join we can handle redirection when response['location'] is relative path or it's absolute path or if it's new URI
- Examples

| Original URI                    | Response Location         | `URI.join` Result                  |
|---------------------------------|---------------------------|------------------------------------|
| `http://example.com/path/`      | `/newpath/something/`          | `http://example.com/newpath/something/` |
| `http://example.com/path/`      | `newpath/something/`           | `http://example.com/path/newpath/something/` |
| `http://example.com/path/`      | `https://anotherdomain.com/` | `https://anotherdomain.com/`       |
| `http://example.com/path/`      | `../relativepath/`        | `http://example.com/relativepath/` |
| `http://example.com/path/`      | `?query=params`           | `http://example.com/path/?query=params` |
| `http://example.com/path/`      | `#section`                | `http://example.com/path/#section`  |


for the bug of `https://w3id.org/mod` the redirection with URI.join will be to `https://w3id.org/mod/` and not to `https://w3id.org/https://w3id.org/mod/`

![check_resolvability_redirection](https://github.com/ontoportal-lirmm/bioportal_web_ui/assets/66650181/8fa21411-50b4-43e0-8747-7332f86bffe4)
