### PR TITLE
Feature: Add cookie banner

### DIFF
--- a/app/assets/stylesheets/bioportal.scss
+++ b/app/assets/stylesheets/bioportal.scss
@@ -1044,3 +1044,43 @@ turbo-frame[busy] ~ .show-if-loading {
 .hide{
   display:none;
 }
+
+.cookies-modal {
+  position: fixed;
+  height: auto;
+  top: initial;
+  left: initial;
+  right: 10px;
+  bottom: 10px;
+  transform: initial;
+  grid-template-rows: minmax(0, 1fr);
+  z-index: 99999;
+  background: white;
+  border-style: solid;
+  border-color: #f2f2f2;
+  border-radius: 0;
+  border-width: 0;
+  padding: 15px 20px;
+  display: grid;
+  grid-gap: 10px;
+  box-shadow: rgba(0, 0, 0, 0.19) 0px 10px 20px, rgba(0, 0, 0, 0.23) 0px 6px 6px;
+  width: 526px;
+  grid-row-gap: 10px;
+
+  h4{
+    justify-self: center;
+    font-size: 16px;
+    color: var(--primary-color);
+    font-weight: 500;
+  }
+  p {
+    word-wrap: break-word;
+    font-size: 12px;
+    margin-bottom: 5px;
+  }
+  .cookie-privacy-link {
+    font-size: 12px;
+    text-align: center;
+    text-decoration: underline;
+  }
+}

--- a/app/assets/stylesheets/bioportal.scss
+++ b/app/assets/stylesheets/bioportal.scss
@@ -1050,20 +1050,20 @@ turbo-frame[busy] ~ .show-if-loading {
   height: auto;
   top: initial;
   left: initial;
-  right: 10px;
-  bottom: 10px;
+  bottom: 30px;
+  right: 30px;
   transform: initial;
   grid-template-rows: minmax(0, 1fr);
   z-index: 99999;
   background: white;
   border-style: solid;
   border-color: #f2f2f2;
-  border-radius: 0;
+  border-radius: 8px;
   border-width: 0;
   padding: 15px 20px;
   display: grid;
   grid-gap: 10px;
-  box-shadow: rgba(0, 0, 0, 0.19) 0px 10px 20px, rgba(0, 0, 0, 0.23) 0px 6px 6px;
+  box-shadow: rgba(0, 0, 0, 0.1) 0px 4px 8px, rgba(0, 0, 0, 0.1) 0px 2px 4px;
   width: 526px;
   grid-row-gap: 10px;
 

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -40,6 +40,11 @@ class HomeController < ApplicationController
 
   end
 
+  def set_cookies
+    session[:cookies_accepted] = params[:cookies] if params[:cookies]
+    render 'cookies', layout: nil
+  end
+
   def tools
     @tools = {
       search: {

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -176,7 +176,7 @@ module ApplicationHelper
                     class: "secondary-button regular-button slim", data: { show_modal_title_value: t('application.add_new_proposal')}
     end
   end
-  
+
 
   def link?(str)
     # Regular expression to match strings starting with "http://" or "https://"
@@ -516,8 +516,8 @@ module ApplicationHelper
     end
   end
 
-  def link_button_component(href: , value: , id:, size: nil)
-    render Buttons::RegularButtonComponent.new(id:id, value: value, variant: "primary", type: 'link', href: href, size: size)
+  def link_button_component(href: , value: , id:, size: nil, variant: 'primary')
+    render Buttons::RegularButtonComponent.new(id:id, value: value, variant: variant, type: 'link', href: href, size: size)
   end
 
   def save_button_component(class_name: nil, id: , value:, data: nil, size: nil, type: nil)

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -516,6 +516,10 @@ module ApplicationHelper
     end
   end
 
+  def link_button_component(href: , value: , id:, size: nil)
+    render Buttons::RegularButtonComponent.new(id:id, value: value, variant: "primary", type: 'link', href: href, size: size)
+  end
+
   def save_button_component(class_name: nil, id: , value:, data: nil, size: nil, type: nil)
     content_tag(:div, data: data, class: class_name) do
       render Buttons::RegularButtonComponent.new(id:id, value: value, variant: "primary", state: 'regular', size: size, type: type) do |btn|

--- a/app/views/home/cookies.html.haml
+++ b/app/views/home/cookies.html.haml
@@ -11,8 +11,8 @@
         = t('cookies_modal.paragraph3')
       %div.d-flex
         %div.w-50
-          = link_button_component(id:'accept-cookie-selector', value: t('cookies_modal.accept_button'), href: cookies_path(cookies: true), size: "slim")
-        %div.w-50.ml-1
-          = link_button_component(id:'deny-cookie-selector', value: t('cookies_modal.deny_button'), href: cookies_path(cookies: false), size: "slim")
+          = link_button_component(id:'accept-cookie-selector', value: t('cookies_modal.accept_button'), href: cookies_path(cookies: true), size: "slim", variant: 'primary')
+        %div.w-50.ml-2
+          = link_button_component(id:'deny-cookie-selector', value: t('cookies_modal.deny_button'), href: cookies_path(cookies: false), size: "slim", variant: 'secondary')
       %div.cookie-privacy-link
         = link_to t('cookies_modal.privacy_link'), $FOOTER_LINKS.dig(:sections, :agreements, :privacy_policy)

--- a/app/views/home/cookies.html.haml
+++ b/app/views/home/cookies.html.haml
@@ -1,0 +1,18 @@
+= turbo_frame_tag :cookies_modal do
+  - if session[:cookies_accepted].nil? # don't re-render if a true/false selected
+    %section.cookies-modal
+      %h4
+        = t('cookies_modal.title')
+      %p
+        = t('cookies_modal.paragraph1')
+      %p
+        = t('cookies_modal.paragraph2')
+      %p
+        = t('cookies_modal.paragraph3')
+      %div.d-flex
+        %div.w-50
+          = link_button_component(id:'accept-cookie-selector', value: t('cookies_modal.accept_button'), href: cookies_path(cookies: true), size: "slim")
+        %div.w-50.ml-1
+          = link_button_component(id:'deny-cookie-selector', value: t('cookies_modal.deny_button'), href: cookies_path(cookies: false), size: "slim")
+      %div.cookie-privacy-link
+        = link_to t('cookies_modal.privacy_link'), $FOOTER_LINKS.dig(:sections, :agreements, :privacy_policy)

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -39,6 +39,7 @@
 </head>
 <body class="<%= controller_name %> <%= action_name %>">
   <%=render partial: 'layouts/topnav'%>
-  
-  <div class="flex-grow-1">
+	<%= turbo_frame_tag :cookies_modal, src: cookies_path if session[:cookies_accepted].nil? %>
+
+	<div class="flex-grow-1">
     <%=render partial: 'layouts/notices'%>

--- a/app/views/layouts/appliance.html.haml
+++ b/app/views/layouts/appliance.html.haml
@@ -26,7 +26,8 @@
 
   %body{:class => "#{controller_name} #{action_name}"}
     = render partial: "layouts/topnav"
-    
+    = turbo_frame_tag :cookies_modal, src: cookies_path if session[:cookies_accepted].nil?
+
     %div.flex-grow-1
       = render partial: "layouts/notices"
       = modal_frame_container

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1383,7 +1383,7 @@ en:
       instruction_4_content: "Run the following command to test the redirection configuration `sudo nginx -t`"
       instruction_5: "Reload Nginx to apply the changes:"
       instruction_5_content: "Restart the nginx server to apply the redirection using this command `sudo systemctl reload nginx`"
-    
+
   components:
     check_resolvability: checking resolvability...
     error_block: child_data_generator block did not provide all the child arguements
@@ -1478,3 +1478,11 @@ en:
     location: "Location: %{location}"
     tags: Tags
     feedback: Feedback
+  cookies_modal:
+    title: "Manage Cookie Consent"
+    paragraph1: "We use cookies to help you navigate efficiently and perform certain functions. You will find detailed information about all cookies in the \"Privacy Statement\" link."
+    paragraph2: "We also use third-party cookies that help us analyse how you use this website, store your preferences, and provide the content that is relevant to you. These cookies will only be stored in your browser with your prior consent."
+    paragraph3: "Please note that disabling such cookies may affect your browsing experience."
+    accept_button: "Accept"
+    deny_button: "Deny"
+    privacy_link: "Privacy Statement"

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -301,9 +301,9 @@ fr:
     total_results: Résultats totaux
     insert_sample_text: Insérer un texte d'exemple
     sample_text: Il y a eu de nombreuses études récentes sur l'utilisation d'antagonistes microbiens pour contrôler les maladies causées par des bactéries phytopathogènes telluriques
-              et aériennes, dans le but de remplacer les méthodes actuelles de contrôle chimique et d'éviter l'utilisation extensive de fongicides, qui conduisent souvent à une résistance chez les pathogènes des plantes.
-              En agriculture, les microorganismes promoteurs de croissance des plantes et de biocontrôle ont émergé comme des alternatives sûres aux pesticides chimiques. Les espèces de Streptomyces et leurs
-              métabolites peuvent avoir un grand potentiel en tant qu'agents excellents pour contrôler divers phytopathogènes fongiques et bactériens.
+      et aériennes, dans le but de remplacer les méthodes actuelles de contrôle chimique et d'éviter l'utilisation extensive de fongicides, qui conduisent souvent à une résistance chez les pathogènes des plantes.
+      En agriculture, les microorganismes promoteurs de croissance des plantes et de biocontrôle ont émergé comme des alternatives sûres aux pesticides chimiques. Les espèces de Streptomyces et leurs
+      métabolites peuvent avoir un grand potentiel en tant qu'agents excellents pour contrôler divers phytopathogènes fongiques et bactériens.
 
   concepts:
     error_valid_concept: "Erreur : Vous devez fournir un identifiant de concept valide"
@@ -1516,3 +1516,12 @@ fr:
     location: "Emplacement: %{location}"
     tags: Tags
     feedback: Feedback
+
+  cookies_modal:
+    title: "Gérer le consentement des cookies"
+    paragraph1: "Nous utilisons des cookies pour vous aider à naviguer efficacement et à effectuer certaines fonctions. Vous trouverez des informations détaillées sur tous les cookies dans le lien \"Déclaration de confidentialité\"."
+    paragraph2: "Nous utilisons également des cookies tiers qui nous aident à analyser comment vous utilisez ce site Web, à stocker vos préférences et à fournir le contenu qui vous est pertinent. Ces cookies ne seront stockés dans votre navigateur qu'avec votre consentement préalable."
+    paragraph3: "Veuillez noter que la désactivation de ces cookies peut affecter votre expérience de navigation."
+    accept_button: "Accepter"
+    deny_button: "Refuser"
+    privacy_link: "Déclaration de confidentialité"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,5 @@
 Rails.application.routes.draw do
+  match 'cookies', to: 'home#set_cookies', via: [:post, :get]
 
   root to: 'home#index'
   mount LetterOpenerWeb::Engine, at: "/letter_opener" if Rails.env.development?


### PR DESCRIPTION
fix https://github.com/lifewatch-eric/ecoportal_web_ui/issues/61, add a cookie banner to accept or deny the usage of cookies, and the decision is saved for the session.

https://github.com/ontoportal-lirmm/bioportal_web_ui/assets/29259906/fe667c72-03d7-4fc3-910c-bb4cb3e7f2d2


### Changes
* Add set cookie action (https://github.com/ontoportal-lirmm/bioportal_web_ui/commit/e296856460bc0c9fa45d817ccdaf0545051d0bc0)
* Add link button, component helper (https://github.com/ontoportal-lirmm/bioportal_web_ui/commit/294b78ffe70e6a578d97a9083421c0ec76cf8078)
* Add coolie modal view (https://github.com/ontoportal-lirmm/bioportal_web_ui/commit/91163888cf5eba7ac359b4ad2741291ee63889d1)