### PR TITLE
Fix: update summary page categories display to show acronym with tooltip

### DIFF
--- a/app/helpers/ontologies_helper.rb
+++ b/app/helpers/ontologies_helper.rb
@@ -328,7 +328,7 @@ module OntologiesHelper
     return domain unless link?(domain)
     acronym = domain.split('/').last.upcase.strip
     category = LinkedData::Client::Models::Category.find(acronym)
-    category.name ? category.name : acronym.titleize
+    category.name ? category.name : domain
   end
 
 

--- a/app/helpers/ontologies_helper.rb
+++ b/app/helpers/ontologies_helper.rb
@@ -324,11 +324,22 @@ module OntologiesHelper
     "<a href='#{ont_url}/?p=#{page_name}'>#{link_name}</a>"
   end
 
-  def show_category_name(domain)
-    return domain unless link?(domain)
+  def category_name_chip_component(domain)
+    text = domain.split('/').last.titleize
+
+
+    return render(ChipButtonComponent.new(text: text, tooltip: domain,  type: "static")) unless link?(domain)
+
+
     acronym = domain.split('/').last.upcase.strip
     category = LinkedData::Client::Models::Category.find(acronym)
-    category.name ? category.name : domain
+
+    if category.name
+      render ChipButtonComponent.new(text: text, tooltip: category.name,  type: "static")
+    else
+      render ChipButtonComponent.new(text: text, tooltip: domain,  url: domain, type: "clickable", target: '_blank')
+    end
+
   end
 
 

--- a/app/views/ontologies/sections/metadata/_ontology_description_section.html.haml
+++ b/app/views/ontologies/sections/metadata/_ontology_description_section.html.haml
@@ -54,7 +54,7 @@
       - l.row do
         = render FieldContainerComponent.new(label: t("ontologies.sections.metadata.categories_and_subjects")) do
           = horizontal_list_container(show_ontology_domains(domains).uniq) do |v|
-            = render ChipButtonComponent.new(text: v.split('/').last.titleize, tooltip: show_category_name(v),  type: "static")
+            = category_name_chip_component(v)
 
     - if  @submission_latest&.pullLocation
       - l.row do

--- a/app/views/ontologies/sections/metadata/_ontology_description_section.html.haml
+++ b/app/views/ontologies/sections/metadata/_ontology_description_section.html.haml
@@ -54,7 +54,7 @@
       - l.row do
         = render FieldContainerComponent.new(label: t("ontologies.sections.metadata.categories_and_subjects")) do
           = horizontal_list_container(show_ontology_domains(domains).uniq) do |v|
-            = render ChipButtonComponent.new(text: show_category_name(v), type: "static")
+            = render ChipButtonComponent.new(text: v.split('/').last.titleize, tooltip: show_category_name(v),  type: "static")
 
     - if  @submission_latest&.pullLocation
       - l.row do

--- a/test/system/submission_flows_test.rb
+++ b/test/system/submission_flows_test.rb
@@ -43,7 +43,7 @@ class SubmissionFlowsTest < ApplicationSystemTestCase
     assert_selector '.alert-message', text: "The ontology is processing."
 
     @new_ontology.hasDomain.each do |cat|
-      assert_text cat.name
+      assert_text cat.acronym.titleize
     end
 
 
@@ -143,7 +143,7 @@ class SubmissionFlowsTest < ApplicationSystemTestCase
     assert_text "#{ontology_2.name} (#{@new_ontology.acronym})"
 
     selected_categories.each do |cat|
-      assert_text cat.name
+      assert_text cat.acronym.titleize
     end
 
     assert_text submission_2.URI
@@ -349,7 +349,7 @@ class SubmissionFlowsTest < ApplicationSystemTestCase
     assert_selector '.alert-message', text: "The ontology is processing."
 
     ontology_2.hasDomain.each do |cat|
-      assert_text cat.name
+      assert_text cat.acronym.titleize
     end
 
     refute_text 'Version IRI'


### PR DESCRIPTION
Fix https://github.com/agroportal/project-management/issues/532

#### Before 
![image](https://github.com/ontoportal-lirmm/bioportal_web_ui/assets/29259906/06afedb5-9b2c-42e9-94ec-bcd207d214af)

#### After 
![image](https://github.com/ontoportal-lirmm/bioportal_web_ui/assets/29259906/45e46b26-0a30-4974-ab62-63faff2b233f)
