### PR TITLE
Feature: remove subject values from the project and usage block in summary page

### DIFF
--- a/app/controllers/ontologies_controller.rb
+++ b/app/controllers/ontologies_controller.rb
@@ -342,7 +342,7 @@ class OntologiesController < ApplicationController
     @community_properties = properties_hash_values(category_attributes["community"] + [:notes])
     @identifiers = properties_hash_values([:URI, :versionIRI, :identifier])
     @identifiers["ontology_portal_uri"] = ["#{$UI_URL}/ontologies/#{@ontology.acronym}", "#{portal_name} URI"]
-    @projects_properties = properties_hash_values(category_attributes["usage"])
+    @projects_properties = properties_hash_values(category_attributes["usage"] - ["hasDomain"])
     @ontology_icon_links = [%w[summary/download dataDump],
                             %w[summary/homepage homepage],
                             %w[summary/documentation documentation],


### PR DESCRIPTION
fix https://github.com/ontoportal-lirmm/bioportal_web_ui/issues/654

Remove the subject fields from the Project and usage block in the summary page 
#### Before
![image](https://github.com/ontoportal-lirmm/bioportal_web_ui/assets/29259906/a918b869-0fc2-4acd-a4c5-8e37b02ede1c)

#### After 
![image](https://github.com/ontoportal-lirmm/bioportal_web_ui/assets/29259906/a8db11f9-8583-4173-a40b-1b5ab5fa1881)
