### PR TITLE
Fix: propertyid param auto added to summary page URL

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -367,10 +367,6 @@ class ApplicationController < ActionController::Base
     @concept
   end
 
-  def get_property(id, acronym = params[:acronym], lang = request_lang, include: nil)
-    LinkedData::Client::HTTP.get("/ontologies/#{acronym}/properties/#{helpers.encode_param(id)}", { lang: lang , include: include})
-  end
-
   def get_ontology_submission_ready(ontology)
     # Get the latest 'ready' submission
     submission = ontology.explore.latest_submission({:include_status => 'ready'})

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -22,7 +22,7 @@ class ApplicationController < ActionController::Base
   end
 
   # Sets the locale based on the locale cookie or the value returned by detect_locale.
-  def set_locale    
+  def set_locale
     I18n.locale = cookies[:locale] || detect_locale
     cookies.permanent[:locale] = I18n.locale if cookies[:locale].nil?
     logger.debug "* Locale set to '#{I18n.locale}'"
@@ -30,7 +30,7 @@ class ApplicationController < ActionController::Base
   end
 
   # Returns detedted locale based on the Accept-Language header of the request or the default locale if none is found.
-  def detect_locale    
+  def detect_locale
     languages = request.headers['Accept-Language']&.split(',')
     supported_languages = I18n.available_locales
 
@@ -38,10 +38,10 @@ class ApplicationController < ActionController::Base
       language_code = language.split(/[-;]/).first.downcase.to_sym
       return language_code if supported_languages.include?(language_code)
     end
-    
-    return I18n.default_locale 
+
+    return I18n.default_locale
   end
-  
+
 
   helper :all # include all helpers, all the time
   helper_method :bp_config_json, :current_license, :using_captcha?
@@ -367,6 +367,10 @@ class ApplicationController < ActionController::Base
     @concept
   end
 
+  def get_property(id, acronym = params[:acronym], lang = request_lang, include: nil)
+    LinkedData::Client::HTTP.get("/ontologies/#{acronym}/properties/#{helpers.encode_param(id)}", { lang: lang , include: include})
+  end
+
   def get_ontology_submission_ready(ontology)
     # Get the latest 'ready' submission
     submission = ontology.explore.latest_submission({:include_status => 'ready'})
@@ -385,7 +389,7 @@ class ApplicationController < ActionController::Base
 
   def total_mapping_count
     total_count = 0
-    
+
     begin
       stats = LinkedData::Client::HTTP.get("#{REST_URI}/mappings/statistics/ontologies")
       unless stats.blank?
@@ -397,7 +401,7 @@ class ApplicationController < ActionController::Base
     rescue
       LOG.add :error, e.message
     end
-    
+
     return total_count
   end
 
@@ -421,7 +425,7 @@ class ApplicationController < ActionController::Base
       $trial_license_initialized = true
     end
   end
-  
+
   # Get the submission metadata from the REST API.
   def submission_metadata
     @metadata ||= helpers.submission_metadata

--- a/app/controllers/instances_controller.rb
+++ b/app/controllers/instances_controller.rb
@@ -25,7 +25,7 @@ class InstancesController < ApplicationController
                                                 child_turbo_frame: 'instance_show',
                                                 child_param: :instanceid,
                                                 show_count: is_concept_instance,
-                                                auto_click: params[:instanceid].blank? && page.eql?(1),
+                                                auto_click: false,
                                                 results:  results, next_page:  next_page, total_count: total_count)
 
     if is_concept_instance && page.eql?(1)

--- a/app/controllers/ontologies_controller.rb
+++ b/app/controllers/ontologies_controller.rb
@@ -180,6 +180,8 @@ class OntologiesController < ApplicationController
 
   def instances
 
+    params[:instanceid] = params[:instanceid] || instances_tree_first_id
+
     if params[:instanceid]
       @instance = helpers.get_instance_details_json(@ontology.acronym, params[:instanceid], {include: 'all'})
     end
@@ -557,5 +559,15 @@ class OntologiesController < ApplicationController
     end
   end
 
+  def instances_tree_first_id
+    query, page, page_size = helpers.search_content_params
+    results, _, _, _ = search_ontologies_content(query: query,
+                        page: page,
+                        page_size: page_size,
+                        filter_by_ontologies: [@ontology.acronym],
+                        filter_by_types: ["NamedIndividual"])
+    results.shift
+    return !results.blank? ? results.first[:name] : nil
+  end
 
 end

--- a/app/controllers/ontologies_controller.rb
+++ b/app/controllers/ontologies_controller.rb
@@ -14,6 +14,7 @@ class OntologiesController < ApplicationController
   include SubmissionFilter
   include OntologyContentSerializer
   include UriRedirection
+  include PropertiesHelper
 
   require 'multi_json'
   require 'cgi'

--- a/app/controllers/ontologies_controller.rb
+++ b/app/controllers/ontologies_controller.rb
@@ -180,7 +180,7 @@ class OntologiesController < ApplicationController
 
   def instances
 
-    params[:instanceid] = params[:instanceid] || instances_tree_first_id
+    params[:instanceid] = params[:instanceid] || search_first_instance_id
 
     if params[:instanceid]
       @instance = helpers.get_instance_details_json(@ontology.acronym, params[:instanceid], {include: 'all'})
@@ -559,7 +559,7 @@ class OntologiesController < ApplicationController
     end
   end
 
-  def instances_tree_first_id
+  def search_first_instance_id
     query, page, page_size = helpers.search_content_params
     results, _, _, _ = search_ontologies_content(query: query,
                         page: page,

--- a/app/controllers/ontologies_controller.rb
+++ b/app/controllers/ontologies_controller.rb
@@ -566,7 +566,7 @@ class OntologiesController < ApplicationController
                         page_size: page_size,
                         filter_by_ontologies: [@ontology.acronym],
                         filter_by_types: ["NamedIndividual"])
-    results.shift
+    results.shift # Remove the ontology entry
     return !results.blank? ? results.first[:name] : nil
   end
 

--- a/app/controllers/ontologies_controller.rb
+++ b/app/controllers/ontologies_controller.rb
@@ -98,6 +98,10 @@ class OntologiesController < ApplicationController
     @acronym = @ontology.acronym
     @properties = LinkedData::Client::HTTP.get("/ontologies/#{@acronym}/properties/roots", { lang: request_lang })
 
+    unless @property
+      @property = get_property(@properties.first.id,  @acronym, include: 'all')
+    end
+
     if request.xhr?
       return render 'ontologies/sections/properties', layout: false
     else

--- a/app/controllers/properties_controller.rb
+++ b/app/controllers/properties_controller.rb
@@ -1,5 +1,5 @@
 class PropertiesController < ApplicationController
-  include TurboHelper, SearchContent, TermsReuses
+  include TurboHelper, SearchContent, TermsReuses, PropertiesHelper
 
   def index
     acronym = params[:ontology]

--- a/app/controllers/properties_controller.rb
+++ b/app/controllers/properties_controller.rb
@@ -60,9 +60,6 @@ class PropertiesController < ApplicationController
 
   private
 
-  def get_property(id, acronym = params[:acronym], lang = request_lang, include: nil)
-    LinkedData::Client::HTTP.get("/ontologies/#{acronym}/properties/#{helpers.encode_param(id)}", { lang: lang , include: include})
-  end
 
   def property_tree(id, acronym = params[:acronym], lang = request_lang)
     LinkedData::Client::HTTP.get("/ontologies/#{acronym}/properties/#{helpers.encode_param(id)}/tree", { lang: lang })

--- a/app/helpers/ontologies_helper.rb
+++ b/app/helpers/ontologies_helper.rb
@@ -431,7 +431,7 @@ module OntologiesHelper
       block.call
     else
       render TurboFrameComponent.new(id: section_title, src: "/ontologies/#{@ontology.acronym}?p=#{section_title}",
-                                     loading: "eager",
+                                     loading: Rails.env.development? ? "lazy" : "eager",
                                      target: '_top', data: { "turbo-frame-target": "frame" })
     end
   end

--- a/app/helpers/ontologies_helper.rb
+++ b/app/helpers/ontologies_helper.rb
@@ -426,12 +426,12 @@ module OntologiesHelper
     end
   end
 
-  def lazy_load_section(section_title, &block)
+  def lazy_load_section(section_title, lazy_loading, &block)
     if current_section.eql?(section_title)
       block.call
     else
       render TurboFrameComponent.new(id: section_title, src: "/ontologies/#{@ontology.acronym}?p=#{section_title}",
-                                     loading: Rails.env.development?  ? "lazy" : "eager",
+                                     loading: (Rails.env.development? || lazy_loading)  ? "lazy" : "eager",
                                      target: '_top', data: { "turbo-frame-target": "frame" })
     end
   end

--- a/app/helpers/ontologies_helper.rb
+++ b/app/helpers/ontologies_helper.rb
@@ -431,7 +431,7 @@ module OntologiesHelper
       block.call
     else
       render TurboFrameComponent.new(id: section_title, src: "/ontologies/#{@ontology.acronym}?p=#{section_title}",
-                                     loading: Rails.env.development?  ? "lazy" : "eager",
+                                     loading: "eager",
                                      target: '_top', data: { "turbo-frame-target": "frame" })
     end
   end

--- a/app/helpers/ontologies_helper.rb
+++ b/app/helpers/ontologies_helper.rb
@@ -426,12 +426,12 @@ module OntologiesHelper
     end
   end
 
-  def lazy_load_section(section_title, lazy_loading, &block)
+  def lazy_load_section(section_title, &block)
     if current_section.eql?(section_title)
       block.call
     else
       render TurboFrameComponent.new(id: section_title, src: "/ontologies/#{@ontology.acronym}?p=#{section_title}",
-                                     loading: (Rails.env.development? || lazy_loading)  ? "lazy" : "eager",
+                                     loading: Rails.env.development?  ? "lazy" : "eager",
                                      target: '_top', data: { "turbo-frame-target": "frame" })
     end
   end

--- a/app/helpers/properties_helper.rb
+++ b/app/helpers/properties_helper.rb
@@ -12,14 +12,12 @@ module PropertiesHelper
   def property_tree_data(acronym, child, language)
     href = property_link(acronym, child, language)
     children_link = property_children_link(acronym, child, language)
-    data = {
-      propertyid: child.id
-    }
+    data = {}
     [children_link, data, href]
   end
 
   def property_tree_component(root, selected_concept, acronym, language, sub_tree: false, id: nil, auto_click: false, submission: @submission)
-    tree_component(root, selected_concept, target_frame: 'property_show', sub_tree: sub_tree, id: id, submission: submission) do |child|
+    tree_component(root, selected_concept, target_frame: 'property_show', sub_tree: sub_tree, id: id, auto_click: auto_click, submission: submission) do |child|
       property_tree_data(acronym, child, language)
     end
   end

--- a/app/helpers/properties_helper.rb
+++ b/app/helpers/properties_helper.rb
@@ -19,7 +19,7 @@ module PropertiesHelper
   end
 
   def property_tree_component(root, selected_concept, acronym, language, sub_tree: false, id: nil, auto_click: false, submission: @submission)
-    tree_component(root, selected_concept, target_frame: 'property_show', sub_tree: sub_tree, id: id, auto_click: auto_click, submission: submission) do |child|
+    tree_component(root, selected_concept, target_frame: 'property_show', sub_tree: sub_tree, id: id, submission: submission) do |child|
       property_tree_data(acronym, child, language)
     end
   end

--- a/app/helpers/properties_helper.rb
+++ b/app/helpers/properties_helper.rb
@@ -12,12 +12,14 @@ module PropertiesHelper
   def property_tree_data(acronym, child, language)
     href = property_link(acronym, child, language)
     children_link = property_children_link(acronym, child, language)
-    data = {}
+    data = {
+      propertyid: child.id
+    }
     [children_link, data, href]
   end
 
   def property_tree_component(root, selected_concept, acronym, language, sub_tree: false, id: nil, auto_click: false, submission: @submission)
-    tree_component(root, selected_concept, target_frame: 'property_show', sub_tree: sub_tree, id: id, auto_click: auto_click, submission: submission) do |child|
+    tree_component(root, selected_concept, target_frame: 'property_show', sub_tree: sub_tree, id: id, auto_click: false, submission: submission) do |child|
       property_tree_data(acronym, child, language)
     end
   end

--- a/app/helpers/properties_helper.rb
+++ b/app/helpers/properties_helper.rb
@@ -33,4 +33,8 @@ module PropertiesHelper
       t('properties.no_properties_alert', acronym: @ontology.acronym)
     end
   end
+
+  def get_property(id, acronym = params[:acronym], lang = request_lang, include: nil)
+    LinkedData::Client::HTTP.get("/ontologies/#{acronym}/properties/#{helpers.encode_param(id)}", { lang: lang , include: include})
+  end
 end

--- a/app/javascript/controllers/history_controller.js
+++ b/app/javascript/controllers/history_controller.js
@@ -4,7 +4,6 @@ import { HistoryService } from "../mixins/useHistory";
 // Connects to data-controller="history"
 export default class extends Controller {
     connect() {
-        console.log('hello world')
         this.history = new HistoryService()
     }
     updateURL(event) {

--- a/app/views/layouts/_ontology_viewer.html.haml
+++ b/app/views/layouts/_ontology_viewer.html.haml
@@ -52,8 +52,7 @@
             - t.item_content do
               %div.p-1{data: section_data(section_title)}
                 = language_selector_hidden_tag(section_title) if ontology_data_section?(section_title)
-                - lazy_loading = section_title.eql?('properties')
-                = lazy_load_section(section_title, lazy_loading) { yield }
+                = lazy_load_section(section_title) { yield }
 
 
   = render partial: "layouts/footer"

--- a/app/views/layouts/_ontology_viewer.html.haml
+++ b/app/views/layouts/_ontology_viewer.html.haml
@@ -52,7 +52,8 @@
             - t.item_content do
               %div.p-1{data: section_data(section_title)}
                 = language_selector_hidden_tag(section_title) if ontology_data_section?(section_title)
-                = lazy_load_section(section_title) { yield }
+                - lazy_loading = section_title.eql?('properties')
+                = lazy_load_section(section_title, lazy_loading) { yield }
 
 
   = render partial: "layouts/footer"


### PR DESCRIPTION
### Related issue
https://github.com/ontoportal-lirmm/bioportal_web_ui/issues/715

### Description of the solution
I disabled auto clicking on the first element of the tree (still will be highlighted) and made by default the right section initialized with the details of this first element.
So we get the exact behavior we want (like for the concepts tab)


