### PR TITLE
Fix: enhance agents errors messages

### DIFF
--- a/app/controllers/agents_controller.rb
+++ b/app/controllers/agents_controller.rb
@@ -345,9 +345,11 @@ class AgentsController < ApplicationController
     errors = []
     response_errors.values.each_with_index do |v, i|
       if v[:existence]
-        errors << "#{response_errors.keys[i].capitalize} is required for agents"
+        errors << "#{response_errors.keys[i].capitalize} #{t('agents.errors.required')}"
       elsif v[:unique_identifiers]
-        errros << "This identifier is already used by another agent"
+        errors << t('agents.errors.used_identifier')
+      elsif v[:no_url]
+        errors << t('agents.errors.invalid_url')
       else
         errors << JSON.pretty_generate(response_errors)
       end

--- a/app/controllers/agents_controller.rb
+++ b/app/controllers/agents_controller.rb
@@ -277,19 +277,9 @@ class AgentsController < ApplicationController
     end
     p[:identifiers]&.each_value do |identifier|
       if identifier[:schemaAgency].downcase.eql?('orcid')
-        normalized_orcid = normalize_orcid(identifier[:notation])
-        if normalized_orcid
-          identifier[:notation] = normalized_orcid
-        else
-          identifier[:notation] = "invalid_orcid"
-        end
+        identifier[:notation] = normalize_orcid(identifier[:notation])
       else
-        normalized_ror = normalize_ror(identifier[:notation])
-        if normalized_ror
-          identifier[:notation] = normalized_ror
-        else
-          identifier[:notation] = "invalid_ror"
-        end
+        identifier[:notation] = normalize_ror(identifier[:notation])
       end
     end
 
@@ -328,9 +318,6 @@ class AgentsController < ApplicationController
     when /\Awww\.orcid\.org\/\d{4}-\d{4}-\d{4}-\d{4}\z/
       # Case 5: ORCID with "www." without scheme
       orcid = orcid.split('/').last
-
-    else
-      return nil
     end
 
     return orcid
@@ -349,14 +336,11 @@ class AgentsController < ApplicationController
     when /\Aror\.org\/(0\w{6}\d{2})\z/
       # Case 3: ROR without scheme (http/https), extract the ROR ID
       ror = ror.split('/').last
-
-    else
-      return nil
     end
 
     return ror
   end
-  
+
   def generate_errors(response_errors)
     errors = []
     response_errors.values.each_with_index do |v, i|

--- a/app/controllers/agents_controller.rb
+++ b/app/controllers/agents_controller.rb
@@ -56,7 +56,7 @@ class AgentsController < ApplicationController
         if v[:existence]
           errors << "#{response_errors(new_agent).keys[i].capitalize} is required for agents"
         elsif v[:unique_identifiers]
-          errros << "This identifier is already used by another agent"
+          errors << "This identifier is already used by another agent"
         else
           errors << JSON.pretty_generate(response_errors(new_agent))
         end
@@ -109,6 +109,10 @@ class AgentsController < ApplicationController
       response_errors(agent_update).values.first.values.each_with_index do |v, i|
         if v[:existence]
           errors << "#{response_errors(agent_update).values.first.keys[i].capitalize} is required for agents"
+        elsif v[:unique_identifiers]
+          errros << "This identifier is already used by another agent"
+        else
+          errors << JSON.pretty_generate(response_errors(new_agent))
         end
       end
       render_turbo_stream alert_error(id: alert_id) { errors.join(', ') }
@@ -290,7 +294,7 @@ class AgentsController < ApplicationController
       end
     end
     p[:identifiers]&.each_value do |identifier|
-      if identifier[:schemaAgency].eql?('orcid')
+      if identifier[:schemaAgency].downcase.eql?('orcid')
         normalized_orcid = normalize_orcid(identifier[:notation])
         if normalized_orcid
           identifier[:notation] = normalized_orcid

--- a/app/controllers/agents_controller.rb
+++ b/app/controllers/agents_controller.rb
@@ -54,9 +54,9 @@ class AgentsController < ApplicationController
       errors = []
       response_errors(new_agent).values.each_with_index do |v, i|
         if v[:existence]
-          errors << "#{response_errors(new_agent).keys[i].capitalize} is required for agents"
+          errors << "#{response_errors(new_agent).keys[i].capitalize} #{t('agents.errors.required')}"
         elsif v[:unique_identifiers]
-          errors << "This identifier is already used by another agent"
+          errors << t('agents.errors.used_identifier')
         else
           errors << JSON.pretty_generate(response_errors(new_agent))
         end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -655,6 +655,7 @@ en:
     errors:
       required: is required and cannot be empty
       used_identifier: This identifier is already used by another agent
+      invalid_url: The identifier must be a valid ORCID/ROR URL
     not_found_agent: Agent with id %{id}
     add_agent: New Agent added successfully
     update_agent: Agent successfully updated

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -652,6 +652,9 @@ en:
         actions: Actions
         see_other_properties: See other properties
   agents:
+    errors:
+      required: is required and cannot be empty
+      used_identifier: This identifier is already used by another agent
     not_found_agent: Agent with id %{id}
     add_agent: New Agent added successfully
     update_agent: Agent successfully updated

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -663,6 +663,9 @@ fr:
 
 
   agents:
+    errors:
+      required: est requis et ne peut pas être vide
+      used_identifier: Cet identifiant est déjà utilisé par un autre agent
     not_found_agent: Agent avec id %{id}
     add_agent: Nouvel agent ajouté avec succès
     update_agent: Agent mis à jour avec succès

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -666,6 +666,7 @@ fr:
     errors:
       required: est requis et ne peut pas être vide
       used_identifier: Cet identifiant est déjà utilisé par un autre agent
+      invalid_url: L'identifiant doit être une URL ORCID/ROR valide
     not_found_agent: Agent avec id %{id}
     add_agent: Nouvel agent ajouté avec succès
     update_agent: Agent mis à jour avec succès


### PR DESCRIPTION
related issue:
https://github.com/agroportal/project-management/issues/577

related back PR:
https://github.com/ontoportal-lirmm/ontologies_linked_data/pull/152

Changes:
- Humanization of the agents form errors (errors handled: nil/empty required values errors, unique identifiers errors).

- Accept all forms of ORCIDs (16 digits, ORCID URL with or without "www." and with or without scheme http/https) then in all cases we pass it in this form to the back: 1234-1234-1234-1234

- Accept all forms of RORs (9 characters, Full URL with 'https://ror.org/' with or without scheme http/https) then in all cases we pass it in this form to the back: 02mn0vt57

- If the orcid is not valid, we pass the value invalid_orcid and the back generates an error

- if the ror is not valid, we pass the value invalid_ror and the back generates an error


Demos:
- Errors

https://github.com/user-attachments/assets/62b8d0e3-4884-4024-b320-76dbf613069e


- ORCID

https://github.com/user-attachments/assets/c69a15b4-ceb6-4533-89de-6d8c6701a177



