### PR TITLE
Fix: set as default language to portal language if naturalLanguage is empty

### DIFF
--- a/app/helpers/multi_languages_helper.rb
+++ b/app/helpers/multi_languages_helper.rb
@@ -72,6 +72,9 @@ module MultiLanguagesHelper
   def content_languages(submission = @submission || @submission_latest)
     current_lang = request_lang.downcase
     submission_lang = submission_languages(submission)
+
+    submission_lang = [current_lang.to_s]  if submission_lang.empty?
+
     # Transform each language into a select option
     submission_lang = submission_lang.map do |lang|
       lang = lang.split('/').last.upcase
@@ -96,7 +99,7 @@ module MultiLanguagesHelper
     languages, selected = content_languages
     render Input::LanguageSelectorComponent.new(id: id, name: name, enable_all: true,
                                                 languages: languages,
-                                                selected: selected || 'all',
+                                                selected: selected || request_lang,
                                                 'data-tooltip-interactive-value': true,
                                                 'data-select-input-searchable-value': false,
                                                 title: content_language_help_text)


### PR DESCRIPTION
fix https://github.com/agroportal/project-management/issues/547

The issue appears when ontology does not have language defined in the submission naturalLanguage, e.g localhost:3000/ontologies/BAGO?p=classes, where all language is selected by default, but in reality it is the default portal language (English) that is displayed.

### Before 
![image](https://github.com/user-attachments/assets/ff89824e-f28c-4196-bef8-8e045f22b20b)

### After
![image](https://github.com/user-attachments/assets/c3ec1063-fa45-4f94-8d4e-b2e15ea85d8e)
