### PR TITLE
Fix: Disable multiple identifiers for agents

### DIFF
--- a/app/controllers/agents_controller.rb
+++ b/app/controllers/agents_controller.rb
@@ -273,6 +273,7 @@ class AgentsController < ApplicationController
         v
       end
     end
+    p[:identifiers] = p[:identifiers].reject{ |key, value| value["notation"].empty? }
     identifiers_schemaAgency = params[:agentType].eql?('person') ? 'ORCID' : 'ROR'
     p[:identifiers]&.each_value do |identifier|
       identifier[:schemaAgency] = identifiers_schemaAgency

--- a/app/views/agents/_form.html.haml
+++ b/app/views/agents/_form.html.haml
@@ -9,7 +9,7 @@
   = hidden_field_tag :deletable, deletable if deletable
   = hidden_field_tag agent_field_name(:id, name_prefix), agent.id if agent.id
 
-  - if is_organization?(agent) && params[:parent_id]
+  - if params[:show_affiliations].eql?('false')
     = hidden_field_tag agent_field_name(:agentType, name_prefix), agent.agentType
   - else
     %tr

--- a/app/views/agents/_form.html.haml
+++ b/app/views/agents/_form.html.haml
@@ -55,32 +55,19 @@
   %tr
     %th
       = t("agents.form.identifiers")
-
+    - identifier = agent&.identifiers&.first
     %td.top
       %div.agents-identifiers{'data-form-options-display-target':"option2",  class: !is_organization?(agent) && 'd-none'}
-        = render NestedFormInputsComponent.new do |c|
-          - c.template do
-            = agent_identifier_input('NEW_RECORD', name_prefix)
-
-          - c.empty_state do
-            = hidden_field_tag agent_field_name('',  name_prefix+"[#{Array(agent.identifiers).size}]")
-
-          - Array(agent.identifiers).each_with_index do |identifier, i|
-            - c.row do
-              = agent_identifier_input(i.to_s.upcase, name_prefix, identifier.notation)
+        - if identifier&.schemaAgency&.eql?('ROR')
+          = agent_identifier_input('0', name_prefix, identifier.notation)
+        - else
+          = agent_identifier_input('0', name_prefix)
 
       %div.agents-identifiers{'data-form-options-display-target':"option1",  class: is_organization?(agent) && 'd-none'}
-        = render NestedFormInputsComponent.new do |c|
-          - c.template do
-            = agent_identifier_input('NEW_RECORD', name_prefix, is_organization: false)
-
-          - c.empty_state do
-            = hidden_field_tag agent_field_name('',  name_prefix+"[#{Array(agent.identifiers).size}]")
-
-          - Array(agent.identifiers).each_with_index do |identifier, i|
-            - c.row do
-              = agent_identifier_input(i.to_s.upcase, name_prefix, identifier.notation, is_organization: false)
-
+        - if identifier&.schemaAgency&.eql?('ORCID')
+          = agent_identifier_input('1', name_prefix, identifier.notation, is_organization: false)
+        - else
+          = agent_identifier_input('1', name_prefix, is_organization: false)
 
   - if show_affiliations
     %tr{'data-form-options-display-target':"option1",  class: is_organization?(agent) && 'd-none'}

--- a/app/views/agents/_form.html.haml
+++ b/app/views/agents/_form.html.haml
@@ -55,8 +55,9 @@
   %tr
     %th
       = t("agents.form.identifiers")
+
     %td.top
-      %div.agents-identifiers{'data-form-options-display-target':"option1",  class: is_organization?(agent) && 'd-none'}
+      %div.agents-identifiers{'data-form-options-display-target':"option2",  class: !is_organization?(agent) && 'd-none'}
         = render NestedFormInputsComponent.new do |c|
           - c.template do
             = agent_identifier_input('NEW_RECORD', name_prefix)
@@ -68,7 +69,7 @@
             - c.row do
               = agent_identifier_input(i.to_s.upcase, name_prefix, identifier.notation)
 
-      %div.agents-identifiers{'data-form-options-display-target':"option2",  class: !is_organization?(agent) && 'd-none'}
+      %div.agents-identifiers{'data-form-options-display-target':"option1",  class: is_organization?(agent) && 'd-none'}
         = render NestedFormInputsComponent.new do |c|
           - c.template do
             = agent_identifier_input('NEW_RECORD', name_prefix, is_organization: false)

--- a/test/application_system_test_case.rb
+++ b/test/application_system_test_case.rb
@@ -104,7 +104,6 @@ class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
     element = find(ts_wrapper_selector)
     element.click
 
-
     return unless page.has_selector?("#{ts_wrapper_selector} > .ts-dropdown")
 
     if multiple
@@ -152,10 +151,10 @@ class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
   end
 
   def agent_fill(agent, parent_id: nil, is_affiliation: false)
-    id = agent.id ? "/#{agent.id}": ''
+    id = agent.id ? "/#{agent.id}" : ''
     form = all("form[action=\"/agents#{id}\"]").first
-    within form  do
-      choose "", option: agent.agentType, allow_label_click: true  unless is_affiliation
+    within form do
+      choose "", option: agent.agentType, allow_label_click: true unless is_affiliation
       fill_in 'name', with: agent.name
 
       if agent.agentType.eql?('organization')
@@ -168,8 +167,13 @@ class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
         fill_in 'email', with: agent.email
       end
 
-      list_inputs ".agents-identifiers",
-                  "[identifiers]", agent.identifiers
+      identifier = agent.identifiers.first
+
+      if agent.agentType.eql?('organization')
+        fill_in "_identifiers_0_notation", with: identifier['notation']
+      else
+        fill_in "_identifiers_1_notation", with: identifier['notation']
+      end
 
       if is_affiliation || agent.agentType.eql?('organization')
         refute_selector ".agents-affiliations"

--- a/test/fixtures/agents.yml
+++ b/test/fixtures/agents.yml
@@ -4,8 +4,6 @@ agent1:
   email: "jonh@test.com"
   identifiers:
     - notation: "0000-0001-2345-6789"
-    - notation: "0000-0001-2345-6788"
-    - notation: "0000-0001-2345-6788"
   affiliations:
     - name: "Research Institute X"
       agentType: "organization"


### PR DESCRIPTION
Fix the issues 2 and 3 here:
https://github.com/agroportal/project-management/issues/598#event-13766344360

Done in this PR:
- Fix: identifier for organizations is ror and for persons is orcid (I found that reversed in the code)
- Disable multiple identifers for agents in agents form (1 orcid for persons, 1 ror for organizations)
- Fix a lost code from this PR: https://github.com/ontoportal-lirmm/bioportal_web_ui/pull/721