### PR TITLE
Fix: use multilingual helper to select the right label to show in search page

### DIFF
--- a/app/components/display/search_result_component.rb
+++ b/app/components/display/search_result_component.rb
@@ -1,6 +1,8 @@
 class Display::SearchResultComponent < ViewComponent::Base
   include UrlsHelper
   include ModalHelper
+  include MultiLanguagesHelper
+
   renders_many :subresults, Display::SearchResultComponent
   renders_many :reuses, Display::SearchResultComponent
   def initialize(number: 0,title: nil, ontology_acronym: nil ,uri: nil, definition: nil, link: nil,  is_sub_component: false)

--- a/app/components/display/search_result_component/search_result_component.html.haml
+++ b/app/components/display/search_result_component/search_result_component.html.haml
@@ -5,9 +5,8 @@
         .uri
             = @uri
     - if @definition
-        - @definition.each do |definition|
-            .definition
-                = definition
+
+        = display_in_multiple_languages(@definition)
     .actions
         = details_button
         = visualize_button

--- a/app/controllers/concerns/search_aggregator.rb
+++ b/app/controllers/concerns/search_aggregator.rb
@@ -50,8 +50,8 @@ module SearchAggregator
 
   private
 
-  def search_result_elem(class_object, ontology_acronym, title)
-    label = language_hash(class_object.prefLabel)
+  def search_concept_label(label)
+    label = language_hash(label)
 
     if label.is_a?(Hash)
       label = label.values.flatten
@@ -59,6 +59,12 @@ module SearchAggregator
         pref_lab.downcase.include?(@search_query.downcase) || @search_query.downcase.include?(pref_lab.downcase)
       end.first || label.first
     end
+    
+    label
+  end
+  def search_result_elem(class_object, ontology_acronym, title)
+
+    label = search_concept_label(class_object.prefLabel)
 
     {
       uri: class_object.id.to_s,

--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -47,9 +47,7 @@ class SearchController < ApplicationController
       # record_type = format_record_type(result[:recordType], result[:obsolete])
       record_type = ""
 
-      label = main_language_label(result.prefLabel)
-      label = label.first if label.is_a?(Array)
-
+      label = search_concept_label(result.prefLabel)
       target_value = label
 
       case params[:target]

--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -47,11 +47,14 @@ class SearchController < ApplicationController
       # record_type = format_record_type(result[:recordType], result[:obsolete])
       record_type = ""
 
-      target_value = result.prefLabel.select{|x| x.include?( params[:q].delete('*'))}.first || result.prefLabel.first
+      label = main_language_label(result.prefLabel)
+      label = label.first if label.is_a?(Array)
+
+      target_value = label
 
       case params[:target]
       when "name"
-        target_value = result.prefLabel
+        target_value = label
       when "shortid"
         target_value = result.id
       when "uri"

--- a/app/helpers/multi_languages_helper.rb
+++ b/app/helpers/multi_languages_helper.rb
@@ -166,7 +166,7 @@ module MultiLanguagesHelper
       content_tag(:div) do
         raw(label.map do |key, value|
           Array(value).map do |v|
-            content_tag(:div) do
+            content_tag(:div, class: 'definition') do
               concat content_tag(:span, v)
               concat content_tag(:span, key.upcase, class: 'badge badge-secondary ml-1') unless key.to_s.upcase.eql?('NONE') || key.to_s.upcase.eql?('@NONE')
             end


### PR DESCRIPTION
### Context
After https://github.com/ontoportal-lirmm/ontologies_api/pull/82, the search API does the language filter in the backend, so no more needs to be done in UI.

![image](https://github.com/user-attachments/assets/1e68787d-b312-4327-ac75-1e7869fb948f)

### Changes 

-  use multilingual helper to select the right label to show in search page (https://github.com/ontoportal-lirmm/bioportal_web_ui/commit/c05b052e1ca832865dfed80cd2c88e58b97add1e)