### PR TITLE
Feature: Add properties range domain the propery show page 

### DIFF
--- a/app/controllers/ontologies_controller.rb
+++ b/app/controllers/ontologies_controller.rb
@@ -98,8 +98,7 @@ class OntologiesController < ApplicationController
   def properties
     @acronym = @ontology.acronym
     @properties = LinkedData::Client::HTTP.get("/ontologies/#{@acronym}/properties/roots", { lang: request_lang })
-
-    @property = get_property(@properties.first.id,  @acronym, include: 'all') unless @property || @properties.empty?
+    @property = get_property(params[:propertyid] || @properties.first.id,  @acronym, include: 'all') unless @property || @properties.empty?
 
     if request.xhr?
       render 'ontologies/sections/properties', layout: false

--- a/app/views/properties/_show.html.haml
+++ b/app/views/properties/_show.html.haml
@@ -3,14 +3,17 @@
     - if @property.errors
       = render Display::AlertComponent.new(type:'info', message: @property.errors.join)
     - else
+      - properties = LinkedData::Client::Models::Property.properties_to_hash(@property).first
       = render ConceptDetailsComponent.new(id:'property-details', acronym: @acronym, concept_id: @property.id,
-                      properties: OpenStruct.new(LinkedData::Client::Models::Property.properties_to_hash(@property).first),
+                      properties: @property.properties,
                       top_keys: [],
-                      bottom_keys: [],
+                      bottom_keys: properties.keys.map(&:to_s),
                       exclude_keys: []) do |c|
         - c.header(stripped: true) do |t|
-          - t.add_row({th: t('properties.id')}, {td: link_to_with_actions(c.concept_properties[:id][:values], acronym: @acronym)}) if c.concept_properties[:id][:values].present?
-          - t.add_row({th: t('properties.type')}, {td: c.concept_properties[:type][:values] }) if c.concept_properties[:id][:values].present?
-          - t.add_row({th: t('properties.preferred_name')}, {td: display_in_multiple_languages(c.concept_properties[:label][:values])}) if  c.concept_properties[:label][:values].present?
-          - t.add_row({th: t('properties.definitions')}, {td: display_in_multiple_languages(c.concept_properties[:definition][:values])}) if c.concept_properties[:definition][:values].present?
-          - t.add_row({th: t('properties.parent')}, {td: display_in_multiple_languages(c.concept_properties[:parents][:values])}) if c.concept_properties[:parents][:values].present?
+          - t.add_row({th: t('properties.id')}, {td: link_to_with_actions(@property.id, acronym: @acronym)})
+          - t.add_row({th: t('properties.type')}, {td: @property.type })
+          - t.add_row({th: t('properties.preferred_name')}, {td: display_in_multiple_languages(@property.label)}) unless  @property.label.blank?
+          - t.add_row({th: t('properties.definitions')}, {td: display_in_multiple_languages(@property.definition)}) unless @property.definition.blank?
+          - t.add_row({th: t('properties.parent')}, {td: display_in_multiple_languages(@property.parents)}) unless @property.parents.blank?
+          - t.add_row({th: t('properties.domain')}, {td:  get_link_for_cls_ajax(@property.domain, @acronym)}) unless @property.domain.blank?
+          - t.add_row({th: t('properties.range')}, {td: get_link_for_cls_ajax(@property.range, @acronym)}) unless @property.range.blank?

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1436,6 +1436,8 @@ en:
     preferred_name: Preferred name
     definitions: Definitions
     parent: Parent
+    domain: Domain
+    range: Range
     no_properties_alert: "%{acronym} does not contain properties"
   visits:
     ontology_visits: Ontology visits

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -1468,6 +1468,8 @@ fr:
     preferred_name: Nom préféré
     definitions: Définitions
     parent: Parent
+    domain: Domaine
+    range: Étendue
     no_properties_alert: "%{acronym} ne contient pas de propriétés"
 
   visits:


### PR DESCRIPTION
fix https://github.com/ontoportal-lirmm/bioportal_web_ui/issues/708, now we have two new lines for describing the range and domain and range of a Property. In addition, the raw data section is now filled with all the properties related to that property.
![image](https://github.com/user-attachments/assets/28617932-00db-4368-b84d-76bc6fdf1164)
   
