### PR TITLE
Feature: Show license notice only for logged in admin users

### DIFF
--- a/app/views/layouts/_notices.html.haml
+++ b/app/views/layouts/_notices.html.haml
@@ -1,4 +1,4 @@
-- if Rails.env.appliance?
+- if session[:user]&.admin? && Rails.env.appliance?
   = license_notification(current_license())
 
 - flash.each do |key, message|


### PR DESCRIPTION
### Changes
Show License notice only for logged in admin users

### Screenshot
<img width="1786" alt="Capture d’écran 2024-09-03 à 15 30 04" src="https://github.com/user-attachments/assets/bd836036-dfca-42bb-b801-a9a2cc7651ae">
