### PR TITLE
Enhancement/properties instances layout

### DIFF
--- a/app/controllers/instances_controller.rb
+++ b/app/controllers/instances_controller.rb
@@ -39,9 +39,8 @@ class InstancesController < ApplicationController
     get_ontology(params)
     @instance = get_instance_details_json(params[:ontology], params[:id] || params[:instanceid], {include: 'all'})
 
-    redirect_to(ontology_path(id: params[:ontology], p: 'instances', instanceid: params[:id] || params[:instanceid], lang: request_lang)) and return unless turbo_frame_request?
+    redirect_to(ontology_path(id: params[:ontology], p: 'instances', instanceid: params[:id] || params[:instanceid], lang: request_lang)) 
 
-    render partial: 'instances/details', layout: nil
   end
 
   private

--- a/app/controllers/properties_controller.rb
+++ b/app/controllers/properties_controller.rb
@@ -34,9 +34,7 @@ class PropertiesController < ApplicationController
     @acronym = params[:ontology]
     @property = get_property(params[:id],  @acronym, include: 'all')
 
-    redirect_to(ontology_path(id: params[:ontology], p: 'properties', propertyid: params[:id], lang: request_lang)) and return unless turbo_frame_request?
-
-    render partial: 'show'
+    redirect_to(ontology_path(id: params[:ontology], p: 'properties', propertyid: params[:id], lang: request_lang))
   end
 
 

--- a/app/views/instances/_instances.html.haml
+++ b/app/views/instances/_instances.html.haml
@@ -9,7 +9,7 @@
 
     - if params[:p].eql?('instances')
       %div#prop_contents{data: {'container-splitter-target': 'container'}}
-        = render partial: 'instances/details'
+        = render partial: 'instances/show', locals: { concept: @concept}
 
 
 

--- a/app/views/instances/_show.html.haml
+++ b/app/views/instances/_show.html.haml
@@ -1,0 +1,16 @@
+= render TurboFrameComponent.new(id: 'instance_show') do
+  - if @instance
+    - if @instance.errors
+      = render Display::AlertComponent.new(type:'info', message: @instance.errors.join)
+    - else
+      = render TabsContainerComponent.new(type:'outline') do |c|
+        - apikey = "#{get_apikey}"
+        - c.pinned_right do
+          %div{'data-concepts-json-target': 'button'}
+            .concepts_json_button
+              = render RoundedButtonComponent.new(link: "#{@ontology.id}/instances/#{escape(@instance["@id"])}?display=all&apikey=#{apikey}", target:'_blank')
+
+        - c.item(title: t('concepts.details'), path: '#details', selected: true, json_link: "#{@ontology.id}/instances/#{escape(@instance.id)}?display=all&apikey=#{apikey}") 
+
+        - c.item_content do
+          = render :partial =>'/instances/details'

--- a/app/views/ontologies/sections/properties.html.haml
+++ b/app/views/ontologies/sections/properties.html.haml
@@ -10,4 +10,5 @@
                                    tree_url:  "/ontologies/#{@ontology.acronym}/properties?propertyid=#{escape(params[:propertyid])}&ontology=#{@ontology.acronym}&auto_click=false&language=#{request_lang}")
 
       %div#prop_contents{data: {'container-splitter-target': 'container'}}
-        = render partial: 'properties/show'
+        = render TurboFrameComponent.new(id: "properties_data") do
+          = render partial: 'properties/show', locals: { property: @property, acronym: @ontology}

--- a/app/views/properties/_details.html.haml
+++ b/app/views/properties/_details.html.haml
@@ -1,0 +1,14 @@
+= render TurboFrameComponent.new(id: 'property_details', data: {"turbo-frame-target": "frame"}) do
+  - properties = LinkedData::Client::Models::Property.properties_to_hash(@property).first
+  = render ConceptDetailsComponent.new(id:'property-details', acronym: @acronym, concept_id: @property.id,
+                  properties: @property.properties,
+                  top_keys: [],
+                  bottom_keys: properties.keys.map(&:to_s),
+                  exclude_keys: []) do |c|
+    - c.header(stripped: true) do |t|
+      - t.add_row({th: t('properties.id')}, {td: link_to_with_actions(@property.id, acronym: @acronym)})
+      - t.add_row({th: t('properties.type')}, {td: @property.type })
+      - t.add_row({th: t('properties.preferred_name')}, {td: display_in_multiple_languages(@property.label)}) unless  @property.label.blank?
+      - t.add_row({th: t('properties.definitions')}, {td: display_in_multiple_languages(@property.definition)}) unless @property.definition.blank?
+      - t.add_row({th: t('properties.domain')}, {td:  get_link_for_cls_ajax(@property.domain, @acronym, '_top')}) unless @property.domain.blank?
+      - t.add_row({th: t('properties.range')}, {td: get_link_for_cls_ajax(@property.range, @acronym, '_top')}) unless @property.range.blank?

--- a/app/views/properties/_show.html.haml
+++ b/app/views/properties/_show.html.haml
@@ -1,18 +1,17 @@
-= render TurboFrameComponent.new(id: 'property_show', data: {"turbo-frame-target": "frame"}) do
+= render TurboFrameComponent.new(id: 'property_show') do
   - if @property
     - if @property.errors
       = render Display::AlertComponent.new(type:'info', message: @property.errors.join)
     - else
       - properties = LinkedData::Client::Models::Property.properties_to_hash(@property).first
-      = render ConceptDetailsComponent.new(id:'property-details', acronym: @acronym, concept_id: @property.id,
-                      properties: @property.properties,
-                      top_keys: [],
-                      bottom_keys: properties.keys.map(&:to_s),
-                      exclude_keys: []) do |c|
-        - c.header(stripped: true) do |t|
-          - t.add_row({th: t('properties.id')}, {td: link_to_with_actions(@property.id, acronym: @acronym)})
-          - t.add_row({th: t('properties.type')}, {td: @property.type })
-          - t.add_row({th: t('properties.preferred_name')}, {td: display_in_multiple_languages(@property.label)}) unless  @property.label.blank?
-          - t.add_row({th: t('properties.definitions')}, {td: display_in_multiple_languages(@property.definition)}) unless @property.definition.blank?
-          - t.add_row({th: t('properties.domain')}, {td:  get_link_for_cls_ajax(@property.domain, @acronym, '_top')}) unless @property.domain.blank?
-          - t.add_row({th: t('properties.range')}, {td: get_link_for_cls_ajax(@property.range, @acronym, '_top')}) unless @property.range.blank?
+      = render TabsContainerComponent.new(type:'outline') do |c|
+        - apikey = "#{get_apikey}"
+        - c.pinned_right do
+          %div{'data-concepts-json-target': 'button'}
+            .concepts_json_button
+              = render RoundedButtonComponent.new(link: "#{@ontology.id}/properties/#{escape(@property.id)}?display=all&apikey=#{apikey}", target:'_blank')
+
+        - c.item(title: t('concepts.details'), path: '#details', selected: true, json_link: "#{@ontology.id}/properties/#{escape(@property.id)}?display=all&apikey=#{apikey}") 
+
+        - c.item_content do
+          = render :partial =>'/properties/details'


### PR DESCRIPTION
**Enhancement**: Properties and Instances layout harmonization ([Issue #706](https://github.com/ontoportal-lirmm/bioportal_web_ui/issues/706))
- Adopted same layout as in `Classes` (Details as a 1st sub-tab)
- Adding in the right the API cotextual button.
