### PR TITLE
Fix: Add multilingual support in annotator select ontologies 

### DIFF
--- a/app/views/annotator/index.html.haml
+++ b/app/views/annotator/index.html.haml
@@ -27,7 +27,7 @@
                 = render(ChipsComponent.new(name: 'exclude_synonyms', label: t('annotator.exclude_synonyms'), checked: params[:exclude_synonyms]))
               
             .select-ontologies
-              = ontologies_selector(id:'annotator_page_ontologies', label: 'Select ontologies' ,name: 'ontologies[]', selected: params[:ontologies]&.split(','))
+              = ontologies_selector(id:'annotator_page_ontologies', label: t('annotator.select_ontologies') ,name: 'ontologies[]', selected: params[:ontologies]&.split(','))
             = show_advanced_options_button(text: t('show_advanced_options'), init: @advanced_options_open)
             = hide_advanced_options_button(text: t('hide_advanced_options'), init: @advanced_options_open)
         .more-advanced-options{'data-reveal-component-target': 'item', class: "#{@advanced_options_open ? '' : 'd-none'}"}

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -303,6 +303,7 @@ en:
               and fungi, in an attempt to replace existing methods of chemical control and avoid extensive use of fungicides, which often lead to resistance in plant pathogens.
               In agriculture, plant growth-promoting and biocontrol microorganisms have emerged as safe alternatives to chemical pesticides. Streptomyces spp. and their
               metabolites may have great potential as excellent agents for controlling various fungal and bacterial phytopathogens.
+    select_ontologies: Select ontologies
   concepts:
     error_valid_concept: "Error: You must provide a valid concept id"
     missing_roots: Missing roots

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -305,7 +305,7 @@ fr:
       et aériennes, dans le but de remplacer les méthodes actuelles de contrôle chimique et d'éviter l'utilisation extensive de fongicides, qui conduisent souvent à une résistance chez les pathogènes des plantes.
       En agriculture, les microorganismes promoteurs de croissance des plantes et de biocontrôle ont émergé comme des alternatives sûres aux pesticides chimiques. Les espèces de Streptomyces et leurs
       métabolites peuvent avoir un grand potentiel en tant qu'agents excellents pour contrôler divers phytopathogènes fongiques et bactériens.
-
+    select_ontologies: Sélectionner des ontologies
   concepts:
     error_valid_concept: "Erreur : Vous devez fournir un identifiant de concept valide"
     missing_roots: Racines manquantes


### PR DESCRIPTION
Adding multilingual support in annotator select ontologies

![Screenshot from 2024-09-23 21-36-36](https://github.com/user-attachments/assets/1d3b6187-7c59-476c-afe6-d8420a5a7a90)

(changed to only modify `select ontologies`)