### PR TITLE
Fix : Add language-specific anchors to footer section links and the cookie banner

### DIFF
--- a/app/views/home/cookies.html.haml
+++ b/app/views/home/cookies.html.haml
@@ -10,4 +10,4 @@
       %div
         = link_button_component(id:'accept-cookie-selector', value: t('cookies_modal.accept_button'), href: cookies_path(cookies: true), size: "slim", variant: 'primary')
       %div.cookie-privacy-link
-        = link_to t('cookies_modal.privacy_link'), $FOOTER_LINKS.dig(:sections, :agreements, :privacy_policy)
+        = link_to t('cookies_modal.privacy_link'), "#{$FOOTER_LINKS.dig(:sections, :agreements, :privacy_policy)}#{t('cookies_modal.privacy_policy_anchor')}"

--- a/app/views/layouts/_footer.html.haml
+++ b/app/views/layouts/_footer.html.haml
@@ -22,8 +22,7 @@
           %div
 
             - section_links.each do |section , link|
-              - anchor_key = "layout.footer.#{section}_anchor"
-              - anchor = I18n.exists?(anchor_key) ? t(anchor_key) : ""
+              - anchor = I18n.t("layout.footer.#{section}_anchor", default: "")
               %a{:href => "#{link}#{anchor}", :target => "_blank"}
                 = t("layout.footer."+section.to_s)
           

--- a/app/views/layouts/_footer.html.haml
+++ b/app/views/layouts/_footer.html.haml
@@ -20,8 +20,11 @@
           %h2
             = t("layout.footer."+key.to_s)
           %div
+
             - section_links.each do |section , link|
-              %a{:href => link, :target => "_blank"}
+              - anchor_key = "layout.footer.#{section}_anchor"
+              - anchor = I18n.exists?(anchor_key) ? t(anchor_key) : ""
+              %a{:href => "#{link}#{anchor}", :target => "_blank"}
                 = t("layout.footer."+section.to_s)
           
 

--- a/config/bioportal_config_env.rb.sample
+++ b/config/bioportal_config_env.rb.sample
@@ -305,8 +305,8 @@ $FOOTER_LINKS = {
     },
     agreements: {
       terms: $TERMS_AND_CONDITIONS_LINK,
-      privacy_policy: "https://doc.jonquetlab.lirmm.fr/share/e6158eda-c109-4385-852c-51a42de9a412/doc/terms-conditions-naDsDo2Zxq#h-privacy-policy",
-      legal_notices: "https://doc.jonquetlab.lirmm.fr/share/e6158eda-c109-4385-852c-51a42de9a412/doc/terms-conditions-naDsDo2Zxq#h-legal-notice"
+      privacy_policy: "https://doc.jonquetlab.lirmm.fr/share/e6158eda-c109-4385-852c-51a42de9a412/doc/terms-conditions-naDsDo2Zxq",
+      legal_notices: "https://doc.jonquetlab.lirmm.fr/share/e6158eda-c109-4385-852c-51a42de9a412/doc/terms-conditions-naDsDo2Zxq"
     },
     about: {
       about_us: "https://github.com/agroportal/project-management",

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -519,8 +519,11 @@ en:
       issues_and_requests: Issues and Requests
       agreements: Legal
       terms: Terms and Conditions
+      terms_anchor: "#h-agroportal-terms-and-conditions-english"
       privacy_policy: Privacy Policy
+      privacy_policy_anchor: "#h-privacy-policy"
       legal_notices: Legal Notices
+      legal_notices_anchor: "#h-legal-notice"
       cite_us: Cite Us
       acknowledgments: Acknowledgments
       about: About

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1497,6 +1497,7 @@ en:
     paragraph2: "The cookies are functional and non-optional. By staying on %{portal}, you acknowledge the information was delivered to you."
     accept_button: "Accept"
     privacy_link: "Privacy policy"
+    privacy_policy_anchor: "#h-privacy-policy"
   taxonomy:
     groups_and_categories: Groups and Categories
     description: In AgroPortal, ontologies are organized in groups and tagged with categories. Typically, groups associate ontologies from the same project or organization for better identification of the provenance. Whereas categories are about subjects/topics and enable to classify ontologies. As of 2016, AgroPortal's categories were established in cooperation with FAO AIMS. In 2024, we moved to UNESCO nomenclature for fields of science and technology. Groups and categories, along with other metadata, can be used on the “Browse” page of AgroPortal to filter out the list of ontologies.

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -524,8 +524,11 @@ fr:
       issues_and_requests: Problèmes et demandes
       agreements: Légal
       terms: Termes et conditions
+      terms_anchor: "#h-conditions-generales-dutilisation-dagroportal-francais"
       privacy_policy: Politique de confidentialité
+      privacy_policy_anchor: "#h-vie-privee"
       legal_notices: Mentions légales
+      legal_notices_anchor: "#h-mentions-legales"
       cite_us: Citez-nous
       acknowledgments: Remerciements
       about: À propos

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -1535,6 +1535,7 @@ fr:
     paragraph2: "Les cookies sont fonctionnels et non facultatifs. En restant sur %{portal}, vous reconnaissez que les informations vous ont été transmises."
     accept_button: "Accepter"
     privacy_link: "Vie privé"
+    privacy_policy_anchor: "#h-vie-privee"
   taxonomy:
     groups_and_categories: Groupes et Catégories
     description: Dans AgroPortal, les ontologies sont organisées en groupes et étiquetées avec des catégories. Typiquement, les groupes associent des ontologies provenant du même projet ou de la même organisation pour une meilleure identification de la provenance. Tandis que les catégories concernent des sujets/thématiques et permettent de classifier les ontologies. En 2016, les catégories d'AgroPortal ont été établies en coopération avec FAO AIMS. En 2024, nous sommes passés à la nomenclature de l'UNESCO pour les domaines des sciences et des technologies. Les groupes et les catégories, ainsi que d'autres métadonnées, peuvent être utilisés sur la page “Parcourir” d'AgroPortal pour filtrer la liste des ontologies.


### PR DESCRIPTION
Related [issue #755](https://github.com/ontoportal-lirmm/bioportal_web_ui/issues/755).
![Screenshot from 2024-09-29 09-33-16](https://github.com/user-attachments/assets/4f74bdd0-7fa8-4d87-89b0-ece1b29b0438)

Adding language-specific anchors to footer section links and the cookie banner so that it points to the correct language section in the docs.

NB:
- Anchors must be removed from the [config file](https://github.com/ontoportal-lirmm/bioportal_web_ui/blob/master/config/bioportal_config_env.rb.sample):
https://github.com/ontoportal-lirmm/bioportal_web_ui/blob/4cdc1aaefb84c1e8609e88e4ec70041e82631abb/config/bioportal_config_env.rb.sample#L288-L292