### PR TITLE
Feature: Add  performance monitoring section to the admin page 

### DIFF
--- a/.github/workflows/tests-real-data-stageportal.yml
+++ b/.github/workflows/tests-real-data-stageportal.yml
@@ -27,10 +27,10 @@ jobs:
           - "3306:3306"
         env:
           MYSQL_ROOT_PASSWORD: root
-      memcached:
-        image: memcached:1.6
+      redis:
+        image: redis:latest
         ports:
-          - 11211:11211
+          - 6379:6379
     steps:
       - name: Checkout code
         uses: actions/checkout@v3

--- a/.github/workflows/tests-system.yml
+++ b/.github/workflows/tests-system.yml
@@ -28,10 +28,10 @@ jobs:
           - "3306:3306"
         env:
           MYSQL_ROOT_PASSWORD: root
-      memcached:
-        image: memcached:1.6
+      redis:
+        image: redis:latest
         ports:
-          - 11211:11211
+          - 6379:6379
       chrome-server:
         image: selenium/standalone-chrome:112.0-chromedriver-112.0-grid-4.9.0-20230421
         options: "--shm-size=2g"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -28,10 +28,11 @@ jobs:
           - "3306:3306"
         env:
           MYSQL_ROOT_PASSWORD: root
-      memcached:
-        image: memcached:1.6
+      redis:
+        image: redis:latest
         ports:
-          - 11211:11211
+          - 6379:6379
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v3

--- a/Gemfile
+++ b/Gemfile
@@ -101,8 +101,7 @@ gem 'iso-639', '~> 0.3.6'
 gem 'countries', '~> 5.7'
 
 # Custom API client
-gem 'ontologies_api_client', git: 'https://github.com/ontoportal-lirmm/ontologies_api_ruby_client.git', branch: 'development'
-# Ruby 2.7.8 pinned gems (to remove when migrating to Ruby >= 3.0)
+gem 'ontologies_api_client', git: 'https://github.com/ontoportal-lirmm/ontologies_api_ruby_client.git', branch: 'feature/add-rails-performance'
 
 gem 'ffi', '~> 1.16.3'
 gem 'net-ftp', '~> 0.2.0', require: false
@@ -118,6 +117,9 @@ gem 'omniauth-orcid'
 
 # Used to generate colors randomly
 gem "color", "~> 1.8"
+
+# Application performance monitoring
+gem 'rails_performance'
 
 group :staging, :production, :appliance do
   # Application performance monitoring

--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,6 @@ source 'https://rubygems.org'
 # Main Rails gem
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
 gem 'rails', '7.0.4'
-
 # JavaScript bundling for Rails
 gem 'jsbundling-rails'
 
@@ -101,8 +100,10 @@ gem 'iso-639', '~> 0.3.6'
 gem 'countries', '~> 5.7'
 
 # Custom API client
-gem 'ontologies_api_client', git: 'https://github.com/ontoportal-lirmm/ontologies_api_ruby_client.git', branch: 'feature/add-rails-performance'
+gem 'ontologies_api_client', git: 'https://github.com/ontoportal-lirmm/ontologies_api_ruby_client.git', branch: 'development'
 
+# Pined gems for ruby < 3
+gem 'concurrent-ruby', '1.3.4'
 gem 'ffi', '~> 1.16.3'
 gem 'net-ftp', '~> 0.2.0', require: false
 gem 'net-http', '~> 0.3.2'
@@ -119,7 +120,7 @@ gem 'omniauth-orcid'
 gem "color", "~> 1.8"
 
 # Application performance monitoring
-gem 'rails_performance'
+gem 'rails_performance', '1.2.3'
 
 group :staging, :production, :appliance do
   # Application performance monitoring

--- a/Gemfile
+++ b/Gemfile
@@ -35,7 +35,7 @@ gem 'puma', '~> 5.0'
 
 # Use JavaScript with ESM import maps
 # [https://github.com/rails/importmap-rails]
-gem 'importmap-rails'
+gem 'importmap-rails', '2.0.1'
 
 # Hotwire's SPA-like page accelerator
 # [https://turbo.hotwired.dev]
@@ -55,8 +55,9 @@ gem 'tzinfo-data', platforms: %i[mingw mswin x64_mingw jruby]
 # Reduces boot times through caching; required in config/boot.rb
 gem 'bootsnap', require: false
 
-# Memcached client for Ruby
-gem 'dalli'
+# For Rails cache store support
+gem 'redis'
+gem 'redis-rails'
 
 # GraphQL client for Ruby
 gem 'graphql-client'
@@ -65,7 +66,7 @@ gem 'graphql-client'
 gem 'haml', '~> 5.1'
 
 # Internationalization (i18n)
-gem 'i18n'
+gem 'i18n', '~> 1.14.6'
 gem 'rails-i18n', '~> 7.0.0'
 
 # MySQL database adapter

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: https://github.com/ontoportal-lirmm/ontologies_api_ruby_client.git
-  revision: 7423b46ff6fa7e5ef0f1d36548f7c04466939f71
-  branch: development
+  revision: c473aae92493c2e0de08f0af8ed5812349db9621
+  branch: feature/add-rails-performance
   specs:
     ontologies_api_client (2.2.0)
       activesupport (~> 7.0.4)
@@ -13,6 +13,7 @@ GIT
       multi_json
       oj
       parallel
+      rails_performance
       request_store
       spawnling (= 2.1.5)
 
@@ -104,6 +105,7 @@ GEM
       popper_js (>= 1.14.3, < 2)
       sassc-rails (>= 2.0.0)
     brakeman (5.4.1)
+    browser (5.3.1)
     bugsnag (6.27.1)
       concurrent-ruby (~> 1.0)
     builder (3.3.0)
@@ -139,16 +141,13 @@ GEM
     coderay (1.1.3)
     color (1.8)
     concurrent-ruby (1.3.4)
-    countries (5.7.2)
-      unaccent (~> 0.3)
+    connection_pool (2.4.1)
     crack (1.0.0)
       bigdecimal
       rexml
     crass (1.0.6)
     css_parser (1.17.1)
       addressable
-    csv (3.3.0)
-    dalli (3.2.8)
     date (3.3.4)
     debug (1.9.2)
       irb (~> 1.10)
@@ -161,7 +160,7 @@ GEM
     erubi (1.13.0)
     erubis (2.7.0)
     excon (0.112.0)
-    execjs (2.10.0)
+    execjs (2.9.1)
     faraday (2.0.1)
       faraday-net_http (~> 2.0)
       ruby2_keywords (>= 0.0.4)
@@ -179,7 +178,7 @@ GEM
       sass-rails
     globalid (1.2.1)
       activesupport (>= 6.1)
-    graphql (2.3.19)
+    graphql (2.3.17)
       base64
       fiber-storage
     graphql-client (0.23.0)
@@ -307,7 +306,7 @@ GEM
       time
     net-http (0.3.2)
       uri
-    net-imap (0.4.17)
+    net-imap (0.4.16)
       date
       net-protocol
     net-pop (0.1.2)
@@ -381,6 +380,8 @@ GEM
     rack-protection (3.2.0)
       base64 (>= 0.1.0)
       rack (~> 2.2, >= 2.2.4)
+    rack-session (1.0.2)
+      rack (< 3)
     rack-test (2.1.0)
       rack (>= 1.3)
     rails (7.0.4)
@@ -407,6 +408,11 @@ GEM
     rails-i18n (7.0.9)
       i18n (>= 0.7, < 2)
       railties (>= 6.0.0, < 8)
+    rails_performance (1.2.2)
+      browser
+      railties
+      redis
+      redis-namespace
     railties (7.0.4)
       actionpack (= 7.0.4)
       activesupport (= 7.0.4)
@@ -424,6 +430,28 @@ GEM
     recaptcha (5.9.0)
       json
     redcarpet (3.6.0)
+    redis (5.3.0)
+      redis-client (>= 0.22.0)
+    redis-actionpack (5.4.0)
+      actionpack (>= 5, < 8)
+      redis-rack (>= 2.1.0, < 4)
+      redis-store (>= 1.1.0, < 2)
+    redis-activesupport (5.3.0)
+      activesupport (>= 3, < 8)
+      redis-store (>= 1.3, < 2)
+    redis-client (0.22.2)
+      connection_pool
+    redis-namespace (1.11.0)
+      redis (>= 4)
+    redis-rack (3.0.0)
+      rack-session (>= 0.2.0)
+      redis-store (>= 1.2, < 2)
+    redis-rails (5.0.2)
+      redis-actionpack (>= 5.0, < 6)
+      redis-activesupport (>= 5.0, < 6)
+      redis-store (>= 1.2, < 2)
+    redis-store (1.11.0)
+      redis (>= 4, < 6)
     regexp_parser (2.9.2)
     reline (0.5.10)
       io-console (~> 0.5)
@@ -434,9 +462,9 @@ GEM
       http-cookie (>= 1.0.2, < 2.0)
       mime-types (>= 1.16, < 4.0)
       netrc (~> 0.8)
-    rexml (3.3.9)
+    rexml (3.3.8)
     rouge (4.4.0)
-    rspec-core (3.13.2)
+    rspec-core (3.13.1)
       rspec-support (~> 3.13.0)
     rspec-expectations (3.13.3)
       diff-lcs (>= 1.2.0, < 2.0)
@@ -527,12 +555,11 @@ GEM
     time (0.4.0)
       date
     timeout (0.4.1)
-    turbo-rails (2.0.11)
+    turbo-rails (2.0.10)
       actionpack (>= 6.0.0)
       railties (>= 6.0.0)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
-    unaccent (0.4.0)
     unicode-display_width (2.6.0)
     uri (0.13.1)
     version_gem (1.1.4)
@@ -578,8 +605,6 @@ DEPENDENCIES
   capybara
   chart-js-rails
   color (~> 1.8)
-  countries (~> 5.7)
-  dalli
   debug
   deepl-rb
   ed25519 (>= 1.2, < 2.0)
@@ -589,10 +614,10 @@ DEPENDENCIES
   haml (~> 5.1)
   haml-rails
   html2haml
-  i18n
+  i18n (~> 1.14.6)
   i18n-tasks
   i18n-tasks-csv (~> 1.1)
-  importmap-rails
+  importmap-rails (= 2.0.1)
   inline_svg
   iso-639 (~> 0.3.6)
   jquery-rails
@@ -617,7 +642,10 @@ DEPENDENCIES
   puma (~> 5.0)
   rails (= 7.0.4)
   rails-i18n (~> 7.0.0)
+  rails_performance
   recaptcha (~> 5.9.0)
+  redis
+  redis-rails
   rest-client
   rspec-rails
   rubocop
@@ -637,4 +665,4 @@ DEPENDENCIES
   will_paginate (~> 3.0)
 
 BUNDLED WITH
-   2.4.22
+   2.3.23

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,11 +1,11 @@
 GIT
   remote: https://github.com/ontoportal-lirmm/ontologies_api_ruby_client.git
-  revision: c473aae92493c2e0de08f0af8ed5812349db9621
-  branch: feature/add-rails-performance
+  revision: 2e02a09829b9fe8ef05a8d242d7d67af343cecdb
+  branch: development
   specs:
     ontologies_api_client (2.2.0)
       activesupport (~> 7.0.4)
-      excon
+      excon (= 0.112.0)
       faraday
       faraday-excon (~> 2.0.0)
       faraday-multipart
@@ -13,7 +13,6 @@ GIT
       multi_json
       oj
       parallel
-      rails_performance
       request_store
       spawnling (= 2.1.5)
 
@@ -95,7 +94,7 @@ GEM
       execjs (~> 2)
     base64 (0.2.0)
     bcrypt_pbkdf (1.1.1)
-    bigdecimal (3.1.8)
+    bigdecimal (3.1.9)
     bindata (2.5.0)
     bindex (0.8.1)
     bootsnap (1.18.4)
@@ -109,7 +108,7 @@ GEM
     bugsnag (6.27.1)
       concurrent-ruby (~> 1.0)
     builder (3.3.0)
-    capistrano (3.19.1)
+    capistrano (3.19.2)
       airbrussh (>= 1.0.0)
       i18n
       rake (>= 10.0.0)
@@ -120,7 +119,7 @@ GEM
       capistrano (~> 3.0)
     capistrano-passenger (0.2.1)
       capistrano (~> 3.0)
-    capistrano-rails (1.6.3)
+    capistrano-rails (1.7.0)
       capistrano (~> 3.1)
       capistrano-bundler (>= 1.1, < 3)
     capistrano-yarn (2.0.2)
@@ -141,26 +140,29 @@ GEM
     coderay (1.1.3)
     color (1.8)
     concurrent-ruby (1.3.4)
-    connection_pool (2.4.1)
+    connection_pool (2.5.0)
+    countries (5.7.2)
+      unaccent (~> 0.3)
     crack (1.0.0)
       bigdecimal
       rexml
     crass (1.0.6)
     css_parser (1.17.1)
       addressable
-    date (3.3.4)
-    debug (1.9.2)
+    csv (3.3.2)
+    date (3.4.1)
+    debug (1.10.0)
       irb (~> 1.10)
       reline (>= 0.3.8)
-    deepl-rb (3.0.2)
+    deepl-rb (3.2.0)
     diff-lcs (1.5.1)
     docile (1.4.1)
     domain_name (0.6.20240107)
     ed25519 (1.3.0)
-    erubi (1.13.0)
+    erubi (1.13.1)
     erubis (2.7.0)
     excon (0.112.0)
-    execjs (2.9.1)
+    execjs (2.10.0)
     faraday (2.0.1)
       faraday-net_http (~> 2.0)
       ruby2_keywords (>= 0.0.4)
@@ -169,8 +171,8 @@ GEM
       faraday (~> 2.0.0.alpha.pre.2)
     faraday-follow_redirects (0.3.0)
       faraday (>= 1, < 3)
-    faraday-multipart (1.0.4)
-      multipart-post (~> 2)
+    faraday-multipart (1.1.0)
+      multipart-post (~> 2.0)
     faraday-net_http (2.1.0)
     ffi (1.16.3)
     fiber-storage (1.0.0)
@@ -178,10 +180,10 @@ GEM
       sass-rails
     globalid (1.2.1)
       activesupport (>= 6.1)
-    graphql (2.3.17)
+    graphql (2.4.8)
       base64
       fiber-storage
-    graphql-client (0.23.0)
+    graphql-client (0.25.0)
       activesupport (>= 3.0)
       graphql (>= 1.13.0)
     haml (5.2.2)
@@ -192,7 +194,7 @@ GEM
       activesupport (>= 5.1)
       haml (>= 4.0.6)
       railties (>= 5.1)
-    hashdiff (1.1.1)
+    hashdiff (1.1.2)
     hashie (5.0.0)
     highline (2.1.0)
     html2haml (2.3.0)
@@ -203,9 +205,9 @@ GEM
     htmlbeautifier (1.4.3)
     htmlentities (4.3.4)
     http-accept (1.7.0)
-    http-cookie (1.0.7)
+    http-cookie (1.0.8)
       domain_name (~> 0.5)
-    i18n (1.14.6)
+    i18n (1.14.7)
       concurrent-ruby (~> 1.0)
     i18n-tasks (0.9.37)
       activesupport (>= 4.0.2)
@@ -219,15 +221,16 @@ GEM
       terminal-table (>= 1.5.1)
     i18n-tasks-csv (1.1)
       i18n-tasks (~> 0.9)
-    importmap-rails (2.0.3)
+    importmap-rails (2.0.1)
       actionpack (>= 6.0.0)
       activesupport (>= 6.0.0)
       railties (>= 6.0.0)
     inline_svg (1.10.0)
       activesupport (>= 3.0)
       nokogiri (>= 1.6)
-    io-console (0.7.2)
-    irb (1.14.1)
+    io-console (0.8.0)
+    irb (1.15.0)
+      pp (>= 0.6.0)
       rdoc (>= 4.0.0)
       reline (>= 0.4.2)
     iso-639 (0.3.8)
@@ -240,7 +243,7 @@ GEM
       railties (>= 3.2.16)
     jsbundling-rails (1.3.1)
       railties (>= 6.0.0)
-    json (2.7.4)
+    json (2.9.1)
     json-jwt (1.16.7)
       activesupport (>= 4.2)
       aes_key_wrap
@@ -248,7 +251,7 @@ GEM
       bindata
       faraday (~> 2.0)
       faraday-follow_redirects
-    jwt (2.9.3)
+    jwt (2.10.1)
       base64
     language_server-protocol (3.17.0.3)
     launchy (3.0.1)
@@ -264,8 +267,8 @@ GEM
     listen (3.9.0)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
-    logger (1.6.1)
-    loofah (2.23.1)
+    logger (1.6.5)
+    loofah (2.24.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.12.0)
     lookbook (1.5.5)
@@ -293,10 +296,10 @@ GEM
     mime-types (3.6.0)
       logger
       mime-types-data (~> 3.2015)
-    mime-types-data (3.2024.1001)
+    mime-types-data (3.2025.0107)
     mini_mime (1.1.5)
-    minitest (5.25.1)
-    msgpack (1.7.3)
+    minitest (5.25.4)
+    msgpack (1.7.5)
     multi_json (1.15.0)
     multi_xml (0.6.0)
     multipart-post (2.4.1)
@@ -306,7 +309,7 @@ GEM
       time
     net-http (0.3.2)
       uri
-    net-imap (0.4.16)
+    net-imap (0.4.18)
       date
       net-protocol
     net-pop (0.1.2)
@@ -321,9 +324,9 @@ GEM
       net-protocol
     net-ssh (7.3.0)
     netrc (0.11.0)
-    newrelic_rpm (9.14.0)
-    nio4r (2.7.3)
-    nokogiri (1.15.6-x86_64-linux)
+    newrelic_rpm (9.16.1)
+    nio4r (2.7.4)
+    nokogiri (1.15.7-x86_64-linux)
       racc (~> 1.4)
     oauth2 (2.0.9)
       faraday (>= 0.17.3, < 3.0)
@@ -332,7 +335,7 @@ GEM
       rack (>= 1.2, < 4)
       snaky_hash (~> 2.0)
       version_gem (~> 1.1)
-    oj (3.16.6)
+    oj (3.16.9)
       bigdecimal (>= 3.0)
       ostruct (>= 0.2)
     omniauth (2.1.2)
@@ -342,8 +345,8 @@ GEM
     omniauth-github (2.0.1)
       omniauth (~> 2.0)
       omniauth-oauth2 (~> 1.8)
-    omniauth-google-oauth2 (1.2.0)
-      jwt (>= 2.9)
+    omniauth-google-oauth2 (1.2.1)
+      jwt (>= 2.9.2)
       oauth2 (~> 2.0)
       omniauth (~> 2.0)
       omniauth-oauth2 (~> 1.8)
@@ -361,16 +364,20 @@ GEM
     omniauth-rails_csrf_protection (1.0.2)
       actionpack (>= 4.2)
       omniauth (~> 2.0)
-    ostruct (0.6.0)
+    ostruct (0.6.1)
     parallel (1.26.3)
-    parser (3.3.5.0)
+    parser (3.3.7.0)
       ast (~> 2.4.1)
       racc
     popper_js (1.16.1)
-    pry (0.14.2)
+    pp (0.6.2)
+      prettyprint
+    prettyprint (0.2.0)
+    pry (0.15.2)
       coderay (~> 1.1)
       method_source (~> 1.0)
-    psych (5.1.2)
+    psych (5.2.3)
+      date
       stringio
     public_suffix (5.1.1)
     puma (5.6.9)
@@ -382,7 +389,7 @@ GEM
       rack (~> 2.2, >= 2.2.4)
     rack-session (1.0.2)
       rack (< 3)
-    rack-test (2.1.0)
+    rack-test (2.2.0)
       rack (>= 1.3)
     rails (7.0.4)
       actioncable (= 7.0.4)
@@ -402,13 +409,13 @@ GEM
       activesupport (>= 5.0.0)
       minitest
       nokogiri (>= 1.6)
-    rails-html-sanitizer (1.6.0)
+    rails-html-sanitizer (1.6.2)
       loofah (~> 2.21)
-      nokogiri (~> 1.14)
-    rails-i18n (7.0.9)
+      nokogiri (>= 1.15.7, != 1.16.7, != 1.16.6, != 1.16.5, != 1.16.4, != 1.16.3, != 1.16.2, != 1.16.1, != 1.16.0.rc1, != 1.16.0)
+    rails-i18n (7.0.10)
       i18n (>= 0.7, < 2)
       railties (>= 6.0.0, < 8)
-    rails_performance (1.2.2)
+    rails_performance (1.2.3)
       browser
       railties
       redis
@@ -425,21 +432,21 @@ GEM
     rb-fsevent (0.11.2)
     rb-inotify (0.11.1)
       ffi (~> 1.0)
-    rdoc (6.7.0)
+    rdoc (6.11.0)
       psych (>= 4.0.0)
     recaptcha (5.9.0)
       json
     redcarpet (3.6.0)
     redis (5.3.0)
       redis-client (>= 0.22.0)
-    redis-actionpack (5.4.0)
-      actionpack (>= 5, < 8)
+    redis-actionpack (5.5.0)
+      actionpack (>= 5)
       redis-rack (>= 2.1.0, < 4)
       redis-store (>= 1.1.0, < 2)
     redis-activesupport (5.3.0)
       activesupport (>= 3, < 8)
       redis-store (>= 1.3, < 2)
-    redis-client (0.22.2)
+    redis-client (0.23.2)
       connection_pool
     redis-namespace (1.11.0)
       redis (>= 4)
@@ -452,8 +459,8 @@ GEM
       redis-store (>= 1.2, < 2)
     redis-store (1.11.0)
       redis (>= 4, < 6)
-    regexp_parser (2.9.2)
-    reline (0.5.10)
+    regexp_parser (2.10.0)
+    reline (0.6.0)
       io-console (~> 0.5)
     request_store (1.7.0)
       rack (>= 1.4)
@@ -462,9 +469,9 @@ GEM
       http-cookie (>= 1.0.2, < 2.0)
       mime-types (>= 1.16, < 4.0)
       netrc (~> 0.8)
-    rexml (3.3.8)
-    rouge (4.4.0)
-    rspec-core (3.13.1)
+    rexml (3.4.0)
+    rouge (4.5.1)
+    rspec-core (3.13.2)
       rspec-support (~> 3.13.0)
     rspec-expectations (3.13.3)
       diff-lcs (>= 1.2.0, < 2.0)
@@ -472,7 +479,7 @@ GEM
     rspec-mocks (3.13.2)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.13.0)
-    rspec-rails (7.0.1)
+    rspec-rails (7.1.0)
       actionpack (>= 7.0)
       activesupport (>= 7.0)
       railties (>= 7.0)
@@ -480,18 +487,18 @@ GEM
       rspec-expectations (~> 3.13)
       rspec-mocks (~> 3.13)
       rspec-support (~> 3.13)
-    rspec-support (3.13.1)
-    rubocop (1.67.0)
+    rspec-support (3.13.2)
+    rubocop (1.70.0)
       json (~> 2.3)
       language_server-protocol (>= 3.17.0)
       parallel (~> 1.10)
       parser (>= 3.3.0.2)
       rainbow (>= 2.2.2, < 4.0)
-      regexp_parser (>= 2.4, < 3.0)
-      rubocop-ast (>= 1.32.2, < 2.0)
+      regexp_parser (>= 2.9.3, < 3.0)
+      rubocop-ast (>= 1.36.2, < 2.0)
       ruby-progressbar (~> 1.7)
-      unicode-display_width (>= 2.4.0, < 3.0)
-    rubocop-ast (1.32.3)
+      unicode-display_width (>= 2.4.0, < 4.0)
+    rubocop-ast (1.37.0)
       parser (>= 3.3.1.0)
     ruby-progressbar (1.13.0)
     ruby2_keywords (0.0.5)
@@ -499,7 +506,7 @@ GEM
     ruby_parser (3.21.1)
       racc (~> 1.5)
       sexp_processor (~> 4.16)
-    rubyzip (2.3.2)
+    rubyzip (2.4.1)
     sass-rails (6.0.0)
       sassc-rails (~> 2.1, >= 2.1.1)
     sassc (2.4.0)
@@ -514,7 +521,7 @@ GEM
       rexml (~> 3.2, >= 3.2.5)
       rubyzip (>= 1.2.2, < 3.0)
       websocket (~> 1.0)
-    sexp_processor (4.17.2)
+    sexp_processor (4.17.3)
     simplecov (0.22.0)
       docile (~> 1.1)
       simplecov-html (~> 0.11)
@@ -544,24 +551,26 @@ GEM
     stimulus-rails (1.3.4)
       railties (>= 6.0.0)
     string-similarity (2.1.0)
-    stringio (3.1.1)
+    stringio (3.1.2)
     temple (0.10.3)
-    terminal-table (3.0.2)
-      unicode-display_width (>= 1.1.1, < 3)
-    terser (1.2.4)
+    terminal-table (1.6.0)
+    terser (1.2.5)
       execjs (>= 0.3.0, < 3)
     thor (1.3.2)
-    tilt (2.4.0)
-    time (0.4.0)
+    tilt (2.6.0)
+    time (0.4.1)
       date
-    timeout (0.4.1)
-    turbo-rails (2.0.10)
+    timeout (0.4.3)
+    turbo-rails (2.0.11)
       actionpack (>= 6.0.0)
       railties (>= 6.0.0)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
-    unicode-display_width (2.6.0)
-    uri (0.13.1)
+    unaccent (0.4.0)
+    unicode-display_width (3.1.4)
+      unicode-emoji (~> 4.0, >= 4.0.4)
+    unicode-emoji (4.0.4)
+    uri (1.0.2)
     version_gem (1.1.4)
     view_component (2.83.0)
       activesupport (>= 5.2.0, < 8.0)
@@ -577,7 +586,8 @@ GEM
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
     websocket (1.2.11)
-    websocket-driver (0.7.6)
+    websocket-driver (0.7.7)
+      base64
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
     will_paginate (3.3.1)
@@ -588,7 +598,6 @@ GEM
 
 PLATFORMS
   x86_64-linux
-  x86_64-linux-musl
 
 DEPENDENCIES
   bcrypt_pbkdf (>= 1.0, < 2.0)
@@ -605,6 +614,8 @@ DEPENDENCIES
   capybara
   chart-js-rails
   color (~> 1.8)
+  concurrent-ruby (= 1.3.4)
+  countries (~> 5.7)
   debug
   deepl-rb
   ed25519 (>= 1.2, < 2.0)
@@ -642,7 +653,7 @@ DEPENDENCIES
   puma (~> 5.0)
   rails (= 7.0.4)
   rails-i18n (~> 7.0.0)
-  rails_performance
+  rails_performance (= 1.2.3)
   recaptcha (~> 5.9.0)
   redis
   redis-rails
@@ -665,4 +676,4 @@ DEPENDENCIES
   will_paginate (~> 3.0)
 
 BUNDLED WITH
-   2.3.23
+   2.3.3

--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -110,9 +110,9 @@ class AdminController < ApplicationController
   def clearcache
     response = {errors: nil, success: ''}
 
-    if @cache.respond_to?(:flush_all)
+    if @cache.respond_to?(:flushdb)
       begin
-        @cache.flush_all
+        @cache.flushdb
         response[:success] = t('admin.cache_flush_success')
       rescue Exception => e
         response[:errors] = t('admin.cache_flush_error', class: e.class, message: e.message)
@@ -130,33 +130,8 @@ class AdminController < ApplicationController
         end
       end
     end
-
   end
 
-  def resetcache
-    response = {errors: nil, success: ''}
-
-    if @cache.respond_to?(:reset)
-      begin
-        @cache.reset
-        response[:success] = t('admin.cache_reset_success')
-      rescue Exception => e
-        response[:errors] = t('admin.cache_reset_error', message: e.message)
-      end
-    else
-      response[:errors] =  t('admin.no_reset_command')
-    end
-
-    respond_to do |format|
-      format.turbo_stream do
-        if response[:errors]
-          render_turbo_stream alert(type: 'danger') { response[:errors].to_s }
-        else
-          render_turbo_stream alert(type: 'success') { response[:success] }
-        end
-      end
-    end
-  end
 
   def clear_goo_cache
     response = {errors: nil, success: ''}
@@ -286,7 +261,7 @@ class AdminController < ApplicationController
   private
 
   def cache_setup
-    @cache = Rails.cache.instance_variable_get("@data")
+    @cache = Rails.cache.redis
   end
 
   def _ontologies_report

--- a/app/views/admin/_main.html.haml
+++ b/app/views/admin/_main.html.haml
@@ -4,7 +4,6 @@
       = t('admin.main.cache_management')
     %dive.site-admin-page-section.d-flex
       = action_button(t('admin.main.clear_cache'), admin_clearcache_path, class_style: 'btn btn-primary mx-1')
-      = action_button(t('admin.main.reset_cache'), admin_resetcache_path, class_style: 'btn btn-primary mx-1')
       = action_button(t('admin.main.clear_goo_cache'), admin_clear_goo_cache_path, class_style: 'btn btn-primary mx-1')
       = action_button(t('admin.main.clear_http_cache'), admin_clear_http_cache_path, class_style: 'btn btn-primary mx-1')
 

--- a/app/views/admin/_monitoring.html.haml
+++ b/app/views/admin/_monitoring.html.haml
@@ -1,0 +1,2 @@
+%div
+  %iframe.embed-responsive.w-100.border{src: 'rails/performance', style: 'height:100vh;'}

--- a/app/views/admin/index.html.haml
+++ b/app/views/admin/index.html.haml
@@ -11,7 +11,7 @@
 
 %div
   %div.mx-1
-    - sections = [t('admin.index.analytics'), t('admin.index.site_administration'),t('admin.index.ontology_administration'),  t('admin.index.licensing'), t('admin.index.users'), t('admin.index.metadata_administration'), t('admin.index.groups'), t('admin.index.categories'), t('admin.index.persons_and_organizations'), t('admin.index.sparql'), t('admin.index.search')]
+    - sections = [t('admin.index.analytics'), t('admin.index.site_administration'),  "Performance Monitoring", t('admin.index.ontology_administration'),  t('admin.index.licensing'), t('admin.index.users'), t('admin.index.metadata_administration'), t('admin.index.groups'), t('admin.index.categories'), t('admin.index.persons_and_organizations'), t('admin.index.sparql'), t('admin.index.search')]
     - selected = params[:section] || sections.first.downcase
     = render Layout::VerticalTabsComponent.new(header:  t('admin.index.administration_console'), titles: sections, selected: selected, url_parameter: 'section') do |t|
       - t.item_content do
@@ -22,6 +22,8 @@
           = render 'analytics'
       - t.item_content do
         = render 'main'
+      - t.item_content do
+        = render 'monitoring'
       - t.item_content do
         %div
           %table{:style => "float:left;"}

--- a/config/cable.yml
+++ b/config/cable.yml
@@ -6,5 +6,5 @@ test:
 
 production:
   adapter: redis
-  url: <%= ENV.fetch("REDIS_URL") { "redis://localhost:6379/1" } %>
+  url: <%= "redis://#{ENV.fetch("CACHE_HOST", "localhost")}:6379/1" %>
   channel_prefix: bioportal_web_ui_production

--- a/config/environments/appliance.rb
+++ b/config/environments/appliance.rb
@@ -78,7 +78,7 @@ BioportalWebUi::Application.configure do
   require Rails.root.join('config', "bioportal_config_#{Rails.env}.rb")
 
   # Use a different cache store in the appliance.
-  config.cache_store = :mem_cache_store, ENV["MEMCACHE_SERVERS"] || "localhost:11211", { :namespace => 'bioportal_web_ui', :expires_in => 1.day }
+  config.cache_store = :redis_cache_store, { url: "redis://#{ENV.fetch("CACHE_HOST", "localhost")}:6379/1", namespace: 'bioportal_web_ui' }
 
 
   # Disable serving static files from the `/public` folder by default since

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -34,7 +34,7 @@ Rails.application.configure do
     config.action_controller.perform_caching = true
     config.action_controller.enable_fragment_cache_logging = true
 
-    config.cache_store = :memory_store
+    config.cache_store = :redis_cache_store, { url: "redis://#{ENV.fetch("CACHE_HOST", "localhost")}:6379/1", namespace: 'bioportal_web_ui' }
     config.public_file_server.headers = {
       "Cache-Control" => "public, max-age=#{2.days.to_i}"
     }
@@ -70,8 +70,8 @@ Rails.application.configure do
   # Suppress logger output for asset requests.
   config.assets.quiet = true
 
-  # memcache setup
-  config.cache_store = ActiveSupport::Cache::MemCacheStore.new('cache:11211', namespace: 'BioPortal')
+  # cache setup
+  config.cache_store = :redis_cache_store, { url: "redis://#{ENV.fetch("CACHE_HOST", "localhost")}:6379/1", namespace: 'bioportal_web_ui' }
 
   # Silence cache output
   config.cache_store.logger = Logger.new("/dev/null") if config.cache_store.respond_to?(:logger)

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -59,7 +59,7 @@ Rails.application.configure do
   config.log_tags = [:request_id]
 
   # Use a different cache store in production.
-  # config.cache_store = :mem_cache_store
+  # config.cache_store = :redis_cache_store, { url: "redis://#{ENV.fetch("CACHE_HOST", "localhost")}:6379/1", namespace: 'bioportal_web_ui' }
 
   # Use a real queuing backend for Active Job (and separate queues per environment).
   # config.active_job.queue_adapter     = :resque
@@ -97,8 +97,7 @@ Rails.application.configure do
   end
 
   # Use a different cache store in production.
-  config.cache_store = :mem_cache_store, ENV['MEMCACHE_SERVERS'] || 'localhost:11211',
-                       { namespace: 'bioportal_web_ui', expires_in: 1.day }
+  config.cache_store = :redis_cache_store, { url: "redis://#{ENV.fetch("CACHE_HOST", "localhost")}:6379/1", namespace: 'bioportal_web_ui' }
 
   # Add custom data attributes to sanitize allowed list
   config.action_view.sanitized_allowed_attributes = %w[id class style data-cls data-ont]

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -78,7 +78,7 @@ BioportalWebUi::Application.configure do
   require Rails.root.join('config', "bioportal_config_#{Rails.env}.rb")
 
   # Use a different cache store in staging.
-  config.cache_store = :mem_cache_store, ENV["MEMCACHE_SERVERS"] || "localhost:11211", { namespace: 'bioportal_web_ui', expires_in: 1.day }
+  config.cache_store = :redis_cache_store, { url: "redis://#{ENV.fetch("CACHE_HOST", "localhost")}:6379/1", namespace: 'bioportal_web_ui' }
 
   # Disable serving static files from the `/public` folder by default since
   # Apache or NGINX already handles this.

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -27,7 +27,8 @@ Rails.application.configure do
   # Show full error reports and disable caching.
   config.consider_all_requests_local       = true
   config.action_controller.perform_caching = false
-  config.cache_store = ActiveSupport::Cache::MemCacheStore.new('localhost:11211', namespace: 'BioPortal')
+
+  config.cache_store = :redis_cache_store, { url: "redis://#{ENV.fetch("CACHE_HOST", "localhost")}:6379/1", namespace: 'bioportal_web_ui' }
 
   # Raise exceptions instead of rendering exception templates.
   config.action_dispatch.show_exceptions = false

--- a/config/initializers/rails_performance.rb
+++ b/config/initializers/rails_performance.rb
@@ -1,0 +1,39 @@
+require 'rails_performance'
+RailsPerformance.setup do |config|
+  config.redis = Redis::Namespace.new("#{Rails.env}-rails-performance", redis: Rails.cache.redis)
+  config.duration = 7.days
+
+  config.debug = false # currently not used>
+  config.enabled = true
+
+  # default path where to mount gem
+  config.mount_at = '/rails/performance'
+
+  # protect your Performance Dashboard with HTTP BASIC password
+  config.http_basic_authentication_enabled = false
+  config.http_basic_authentication_user_name = 'rails_performance'
+  config.http_basic_authentication_password = 'password12'
+
+  # if you need an additional rules to check user permissions
+  config.verify_access_proc = proc { |controller| true }
+  # for example when you have `current_user`
+  # config.verify_access_proc = proc { |controller| controller.current_user && controller.current_user.admin? }
+
+  # You can ignore endpoints with Rails standard notation controller#action
+  # config.ignored_endpoints = ['HomeController#contact']
+
+  # store custom data for the request
+  # config.custom_data_proc = proc do |env|
+  #   request = Rack::Request.new(env)
+  #   {
+  #     email: request.env['warden'].user&.email, # if you are using Devise for example
+  #     user_agent: request.env['HTTP_USER_AGENT']
+  #   }
+  # end
+
+  # config home button link
+  config.home_link = '/'
+  config.skipable_rake_tasks = ['webpacker:compile']
+  config.include_rake_tasks = false
+  config.include_custom_events = true
+end if defined?(RailsPerformance)

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -85,8 +85,6 @@ en:
     cache_flush_success: UI cache successfully flushed
     cache_flush_error: "Problem flushing the UI cache - %{class}: %{message}"
     no_flush_command: "The UI cache does not respond to the 'flush_all' command"
-    cache_reset_success: UI cache connection successfully reset
-    cache_reset_error: Problem resetting the UI cache connection - %{message}
     no_reset_command: The UI cache does not respond to the 'reset' command
     clear_goo_cache_success: Goo cache successfully flushed
     clear_goo_cache_error: "Problem flushing the Goo cache - %{class}: %{message}"

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -90,8 +90,6 @@ fr:
     cache_flush_success: Cache de l'interface utilisateur vidé avec succès
     cache_flush_error: "Problème lors du vidage du cache de l'interface utilisateur - %{class} : %{message}"
     no_flush_command: "Le cache de l'interface utilisateur ne répond pas à la commande 'flush_all'"
-    cache_reset_success: Connexion au cache de l'interface utilisateur réinitialisée avec succès
-    cache_reset_error: Problème lors de la réinitialisation de la connexion au cache de l'interface utilisateur - %{message}
     no_reset_command: Le cache de l'interface utilisateur ne répond pas à la commande 'reset'
     clear_goo_cache_success: Cache Goo vidé avec succès
     clear_goo_cache_error: "Problème lors du vidage du cache Goo - %{class} : %{message}"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -97,7 +97,6 @@ Rails.application.routes.draw do
   end
 
   post 'admin/clearcache', to: 'admin#clearcache'
-  post 'admin/resetcache', to: 'admin#resetcache'
   post 'admin/clear_goo_cache', to: 'admin#clear_goo_cache'
   post 'admin/clear_http_cache', to: 'admin#clear_http_cache'
   get 'admin/ontologies_report', to: 'admin#ontologies_report'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,7 +4,15 @@ Rails.application.routes.draw do
   root to: 'home#index'
   mount LetterOpenerWeb::Engine, at: '/letter_opener' if Rails.env.development?
 
-  get'/tools', to: 'home#tools'
+  constraints(lambda { |req| req.session[:user].admin? }) do
+    mount RailsPerformance::Engine, at: '/rails/performance'
+  end
+
+  constraints(lambda { |req| !req.session[:user].admin? }) do
+    get '/rails/performance', to: redirect('/login?redirect=/rails/performance')
+  end
+
+  get '/tools', to: 'home#tools'
   get 'auth/:provider/callback', to: 'login#create_omniauth'
   get 'locale/:language', to: 'language#set_locale_language'
   get 'metadata_export/index'
@@ -42,11 +50,9 @@ Rails.application.routes.draw do
 
   resources :concepts
 
-
   scope :ontologies do
     get ':ontology/concepts' => 'concepts#index'
     get ':ontology/concepts/show', to: 'concepts#show'
-
 
     get ':ontology/instances', to: 'instances#index'
     get ':ontology/instances/show', to: 'instances#show'
@@ -61,7 +67,6 @@ Rails.application.routes.draw do
     get ':ontology/collections/show', to: 'collections#show'
   end
 
-
   resources :ontologies do
     resources :submissions do
       get 'edit_properties'
@@ -71,8 +76,6 @@ Rails.application.routes.draw do
     get 'metrics_evolution'
     get 'subscriptions'
   end
-
-
 
   resources :login
 
@@ -112,7 +115,6 @@ Rails.application.routes.draw do
   get '/annotator', to: 'annotator#index'
   get '/annotatorplus', to: 'annotator#annotator_plus'
   get '/ncbo_annotatorplus', to: 'annotator#ncbo_annotator_plus'
-
 
   resources :virtual_appliance
 
@@ -164,7 +166,6 @@ Rails.application.routes.draw do
   get '/ontologies/:acronym/classes/:purl_conceptid', to: 'ontologies#show', constraints: { purl_conceptid: /[^\/]+/ }
   match '/ontologies/:acronym/submissions/:id/edit_metadata' => 'submissions#edit_metadata', via: [:get, :post]
   get '/ontologies_filter', to: 'ontologies#ontologies_filter'
-
 
   get 'ontologies_selector', to: 'ontologies#ontologies_selector'
   get 'ontologies_selector/results', to: 'ontologies#ontologies_selector_results'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -43,13 +43,11 @@ services:
       retries: 3
 
   cache:
-    image: memcached:latest
-    restart: unless-stopped
-    command: ["-m", "1024"]
-    networks:
-      - default
+    image: "redis:latest"
     ports:
-      - "11211:11211"
+      - "6379:6379"
+    volumes:
+      - redis_data:/data
   node:
     <<: *default-app
     command: "yarn build --watch"
@@ -120,3 +118,4 @@ volumes:
   assets:
   node:
   app_ui:
+  redis_data:


### PR DESCRIPTION
### Require 
- https://github.com/ontoportal-lirmm/ontologies_api_ruby_client/pull/20

### Context
This PR is another iteration of this https://github.com/agroportal/project-management/issues/308,  we don't use NewRelic as it is not free and too complex,  and the same for Bugsnag.  

Here we try a more simplistic approach not using another external provide or getting so many details, but just integrating a self-hosted tool to monitor our rails application, using https://github.com/igorkasyanchuk/rails_performance, which the only dependency required is Redis, so requiring also the migration from Memecache to Redis in the UI.

In addition, we implemented the [API Client](https://github.com/ontoportal-lirmm/ontologies_api_ruby_client/pull/20) level as a custom event to save the API call response times and cache miss or hit status. 

Finally, the rails_performance UI was added to the admin page as a new section called `Performace monitoring`, where you can get

- Current week  UI requests full history  
![image](https://github.com/user-attachments/assets/bd1deeb3-11ba-449e-a3e4-46b1d59a04de)

- Current week  UI errors
 
![image](https://github.com/user-attachments/assets/6d7d4d27-817c-4f22-adc9-cf72e3c5a3a6)

- Slow request
![image](https://github.com/user-attachments/assets/84f9b779-3d63-4123-a223-0f106147cf23)

- Add the API call details 
![image](https://github.com/user-attachments/assets/6bd553a8-c80f-45be-bd41-306c4e57f7aa)


### Changes 

- Migrate from Memcache to Redis (https://github.com/ontoportal-lirmm/bioportal_web_ui/pull/767/commits/e6de9783c149b64238d107c08db88a36b1166a26)
- Add rails_performance gem and configuration (https://github.com/ontoportal-lirmm/bioportal_web_ui/pull/767/commits/7a2db25e4bc8e7033f75c018206921f7d31a7072)
- Add the performance monitoring section to the admin page (https://github.com/ontoportal-lirmm/bioportal_web_ui/pull/767/commits/8b858f2ab75a676e1c8101518e8aef3efb0daff5)