### PR TITLE
Feature: Support countries as languages

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -94,6 +94,7 @@ gem 'inline_svg'
 # ISO language codes and flags
 gem 'flag-icons-rails', '~> 3.4'
 gem 'iso-639', '~> 0.3.6'
+gem 'countries', '~> 5.7'
 
 # Custom API client
 gem 'ontologies_api_client', git: 'https://github.com/ontoportal-lirmm/ontologies_api_ruby_client.git', branch: 'master'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -137,6 +137,8 @@ GEM
     coderay (1.1.3)
     color (1.8)
     concurrent-ruby (1.3.4)
+    countries (5.7.2)
+      unaccent (~> 0.3)
     crack (1.0.0)
       bigdecimal
       rexml
@@ -523,6 +525,7 @@ GEM
       railties (>= 6.0.0)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
+    unaccent (0.4.0)
     unicode-display_width (2.5.0)
     uri (0.13.1)
     version_gem (1.1.4)
@@ -568,6 +571,7 @@ DEPENDENCIES
   capybara
   chart-js-rails
   color (~> 1.8)
+  countries (~> 5.7)
   dalli
   debug
   deepl-rb

--- a/app/components/language_field_component.rb
+++ b/app/components/language_field_component.rb
@@ -3,7 +3,7 @@ require 'iso-639'
 
 class LanguageFieldComponent < ViewComponent::Base
 
-  include FlagIconsRails::Rails::ViewHelpers
+  include FlagIconsRails::Rails::ViewHelpers, MultiLanguagesHelper
 
   def initialize(value:, label: nil, auto_label: false, icon: nil)
     super
@@ -11,12 +11,9 @@ class LanguageFieldComponent < ViewComponent::Base
     @lang_code = nil
     @label = label
     @icon = icon
-
-    iso = ISO_639.find(value.to_s.split('/').last)
-    if iso
-      @lang_code = iso.alpha2
-      @label ||= iso.english_name if auto_label
-    end
+    @lang_code, label = find_language_code_name(value)
+    @label ||= label if auto_label
+    @lang_code = @lang_code.split('-').last if @lang_code
   end
 
   def lang_code

--- a/app/helpers/collections_helper.rb
+++ b/app/helpers/collections_helper.rb
@@ -4,7 +4,7 @@ module CollectionsHelper
   def get_collections(ontology, add_colors: false)
     collections = ontology.explore.collections(language: request_lang)
     generate_collections_colors(collections) if add_colors
-    collections
+    collections.sort_by{ |x| helpers.main_language_label(x.prefLabel) }
   end
 
   def get_collection(ontology, collection_uri)
@@ -64,7 +64,7 @@ module CollectionsHelper
     pref_label_lang, pref_label_html = get_collection_label(collection)
     tooltip  = pref_label_lang.to_s.eql?('@none') ? '' :  "data-controller='tooltip' data-tooltip-position-value='right' title='#{pref_label_lang.upcase}'"
     <<-EOS
-          <a id="#{collection['@id']}" href="#{collection_path(collection['@id'], request_lang)}" 
+          <a id="#{collection['@id']}" href="#{collection_path(collection['@id'], request_lang)}"
             data-turbo="true" data-turbo-frame="collection" data-collectionid="#{collection['@id']}"
            #{tooltip}
             class="#{selected_collection_id.eql?(collection['@id']) ? 'active' : nil}">
@@ -91,4 +91,3 @@ module CollectionsHelper
     end
   end
 end
-

--- a/app/helpers/multi_languages_helper.rb
+++ b/app/helpers/multi_languages_helper.rb
@@ -77,13 +77,29 @@ module MultiLanguagesHelper
 
     # Transform each language into a select option
     submission_lang = submission_lang.map do |lang|
-      lang = lang.split('/').last.upcase
-      lang = ISO_639.find(lang.to_s.downcase)
-      next nil unless lang
-      [lang.alpha2, lang.english_name]
+      code, name = find_language_code_name(lang)
+      next nil unless code
+      [code, name]
     end.compact
 
     [submission_lang, current_lang]
+  end
+
+  def find_language_code_name(language)
+    original_lang = language.to_s.split('/').last.upcase
+    lang, country = original_lang.split('-')
+
+    if country
+      lang = ISO3166::Country.find_country_by_alpha2(country)
+      return nil unless lang
+
+      [original_lang, lang.nationality]
+    else
+      lang = ISO_639.find(lang.to_s.downcase)
+      return nil unless lang
+
+      [lang.alpha2, lang.english_name]
+    end
   end
 
   def content_language_help_text


### PR DESCRIPTION
### Context 
fix https://github.com/ontoportal-lirmm/bioportal_web_ui/issues/759, by using https://github.com/countries/countries gem(dependency) to detect countries by alpha code (e.g 'br' will be 'Brazilian') 
![image](https://github.com/user-attachments/assets/900ddced-2f0e-4e2f-bfdd-b90c900ca4b4)

In addition, now support countries' flags 
![image](https://github.com/user-attachments/assets/aa7be1e9-68fa-45db-b29b-d9f44d3e7053)

### Changes 

- Add countries gem to detect countries languages by alpha code (https://github.com/ontoportal-lirmm/bioportal_web_ui/commit/9e2233441b78a58f8eff773e9e1aa128e155bac8)
- Fix collections tab labels sorting when all languages are selected (https://github.com/ontoportal-lirmm/bioportal_web_ui/commit/3c78807fb421b710664aeddaba455e8e331f31c2) related to #754 