### PR TITLE
Feature: Allow multiple parentCategories

### DIFF
--- a/app/controllers/admin/categories_controller.rb
+++ b/app/controllers/admin/categories_controller.rb
@@ -122,7 +122,7 @@ class Admin::CategoriesController < ApplicationController
   end
 
   def category_params
-    params.require(:category).permit(:acronym, :name, :description, :parentCategory, {ontologies:[]}).to_h
+    params.require(:category).permit(:acronym, :name, :description, {parentCategory: []}, {ontologies:[]}).to_h
   end
 
   def _categories

--- a/app/controllers/taxonomy_controller.rb
+++ b/app/controllers/taxonomy_controller.rb
@@ -38,7 +38,7 @@ class TaxonomyController < ApplicationController
         parent[:children] << category
       end
     end
-    categories.reject! { |category| category[:parentCategory].any? }
+    categories.reject! { |category| category[:parentCategory]&.any? }
     categories
   end
 

--- a/app/controllers/taxonomy_controller.rb
+++ b/app/controllers/taxonomy_controller.rb
@@ -8,7 +8,6 @@ class TaxonomyController < ApplicationController
   end
 
   private
-  
   def initialize_taxonomy
     @groups = LinkedData::Client::Models::Group.all
     slices = LinkedData::Client::Models::Slice.all
@@ -33,13 +32,13 @@ class TaxonomyController < ApplicationController
       category_index[category[:id]] = category
     end
     categories.each do |category|
-      if category.parentCategory
-        parent = category_index[category.parentCategory]
+      category[:parentCategory].each do |parent_id|
+        parent = category_index[parent_id]
         parent[:children] ||= []
         parent[:children] << category
       end
     end
-    categories.reject! { |category| category.parentCategory }
+    categories.reject! { |category| category[:parentCategory].any? }
     categories
   end
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -546,6 +546,6 @@ module ApplicationHelper
 
   def categories_select(id: nil, name: nil, selected: 'None')
     categories_for_select = LinkedData::Client::Models::Category.all.map{|x| ["#{x.name} (#{x.acronym})", x.id]}.unshift(["None", ''])
-    render Input::SelectComponent.new(id: id, name: name, value: categories_for_select, selected: selected)
+    render Input::SelectComponent.new(id: id, name: name, value: categories_for_select, selected: selected, multiple: true)
   end
 end

--- a/app/views/admin/categories/_form.html.haml
+++ b/app/views/admin/categories/_form.html.haml
@@ -34,7 +34,7 @@
         %th
           = t('admin.categories.form.parent_category')
         %td.top
-          = categories_select(id: 'category_parent_select', name: 'category[parentCategory]', selected: @category&.parentCategory)
+          = categories_select(id: 'category_parent_select', name: 'category[parentCategory][]', selected: @category&.parentCategory)
       - unless new_record
         %tr
           %th


### PR DESCRIPTION
Require: https://github.com/ontoportal-lirmm/ontologies_linked_data/pull/162
### Changes
- Update categories selector in the admin page to allow the selection of multiple parent categories (https://github.com/ontoportal-lirmm/bioportal_web_ui/pull/772/commits/b55e1b30d45cb335b60d93a6acfe21336b330ce6)
- Handle multiple categories in categories page (display them multiple times under each parent) (https://github.com/ontoportal-lirmm/bioportal_web_ui/pull/772/commits/81b2aee856b23c9077a71d45ac7969a233ffb428)

### Screenshots:
![image](https://github.com/user-attachments/assets/04814516-5436-4252-8614-30d7c79d0582)

![image](https://github.com/user-attachments/assets/8c633dca-3b54-4a0f-9172-731fdcd51cc7)
