### PR TITLE
Fix: browse page white page issue 

### DIFF
--- a/app/helpers/collections_helper.rb
+++ b/app/helpers/collections_helper.rb
@@ -4,7 +4,7 @@ module CollectionsHelper
   def get_collections(ontology, add_colors: false)
     collections = ontology.explore.collections(language: request_lang)
     generate_collections_colors(collections) if add_colors
-    collections.sort_by{ |x| x.prefLabel }
+    collections.sort_by{ |x| main_language_label(x.prefLabel) || ''  } if collections
   end
 
   def get_collection(ontology, collection_uri)

--- a/app/javascript/controllers/turbo_frame_controller.js
+++ b/app/javascript/controllers/turbo_frame_controller.js
@@ -32,7 +32,6 @@ export default class extends Controller {
             this.urlValue = this.#updatedPageUrl(data)
 
             this.frame.src  = this.urlValue
-
         }
     }
 
@@ -44,7 +43,7 @@ export default class extends Controller {
 
         if (currentDisplayedUrl.toString().includes(this.urlValue)){
             return true
-        } else if (currentDisplayedUrl.searchParams.get('p') === initUrl.searchParams.get('p')){
+        } else if (currentDisplayedUrl.searchParams.has('p') && currentDisplayedUrl.searchParams.get('p') === initUrl.searchParams.get('p')){
             // this is a custom fix for only the ontology viewer page,
             // that use the parameter ?p=section to tell which section is displayed
             return true


### PR DESCRIPTION
Fix https://github.com/ontoportal-lirmm/bioportal_web_ui/issues/761 by ensuring that the custom fix done in https://github.com/ontoportal-lirmm/bioportal_web_ui/pull/642 does apply only for the bug in the ontology viewer. 

[Screencast from 2024-10-11 19-49-46.webm](https://github.com/user-attachments/assets/e6f8727d-e6bb-408e-b97b-4606e2735d4c)
