### PR TITLE
Feature: Add federation results counts grouped by portal

### DIFF
--- a/app/assets/stylesheets/search.scss
+++ b/app/assets/stylesheets/search.scss
@@ -69,6 +69,7 @@
 .search-page-advanced-button .text{
   margin-left: 10px;
   color: var(--primary-color);
+  margin-top: 2px;
 }
 
 .search-page-advanced-button .icon svg path{

--- a/app/assets/stylesheets/search.scss
+++ b/app/assets/stylesheets/search.scss
@@ -77,6 +77,7 @@
 }
 .search-page-number-of-results{
   color: #888888;
+  max-width: 800px;
 }
 
 .search-page-result-element{

--- a/app/components/display/search_result_component.rb
+++ b/app/components/display/search_result_component.rb
@@ -8,13 +8,13 @@ class Display::SearchResultComponent < ViewComponent::Base
   renders_many :subresults, Display::SearchResultComponent
   renders_many :reuses, Display::SearchResultComponent
 
-  def initialize(number: 0,title: nil, ontology_acronym: nil ,uri: nil, definition: nil, link: nil,  is_sub_component: false, portal_name: nil, portal_color: nil, portal_light_color: nil, other_portals: [])
+  def initialize(number: 0,title: nil, ontology_id: nil ,uri: nil, definition: nil, link: nil,  is_sub_component: false, portal_name: nil, portal_color: nil, portal_light_color: nil, other_portals: [])
       @title = title
       @uri = uri
       @definition = definition
       @link = link
       @is_sub_component = is_sub_component
-      @ontology_acronym = ontology_acronym
+      @ontology_acronym = ontology_id&.split('/')&.last
       @number = number.to_s
       @portal_name = portal_name
       @portal_color = portal_color

--- a/app/components/ontology_browse_card_component.rb
+++ b/app/components/ontology_browse_card_component.rb
@@ -17,7 +17,7 @@ class OntologyBrowseCardComponent < ViewComponent::Base
   end
 
   def external_ontology?
-    !internal_ontology?(@ontology[:id]) || (Array(@ontology[:sources]).size > 1)
+    !internal_ontology?(@ontology[:id])
   end
 
   def onto_link

--- a/app/components/ontology_browse_card_component/ontology_browse_card_component.html.haml
+++ b/app/components/ontology_browse_card_component/ontology_browse_card_component.html.haml
@@ -79,7 +79,7 @@
           - config = ontology_portal_config(id)&.last || internal_portal_config(id) || {}
           - unless config.blank?
             %span{style: "padding: 3px 0; margin-right: 0.25rem;"}
-              = portal_button(name: config[:name], color: @text_color, light_color: @bg_light_color, link: ontoportal_ui_link(id), tooltip: "Source #{config[:name]}")
+              = portal_button(name: config[:name], color: config[:color], light_color: config[:"light-color"], link: ontoportal_ui_link(id), tooltip: "Source #{config[:name]}")
 
       - if session[:user]&.admin?
         %div.mx-1{title: content_tag(:div, debug(ontology), style: 'height: 300px; overflow: scroll'), data:{controller: 'tooltip', 'tooltip-interactive-value': 'true'}}

--- a/app/components/ontology_browse_card_component/ontology_browse_card_component.html.haml
+++ b/app/components/ontology_browse_card_component/ontology_browse_card_component.html.haml
@@ -74,12 +74,12 @@
         %span.mx-1{data:{controller:'tooltip'}, title: t('components.view_of_the_ontology', ontology: ontology[:viewOfOnt].split('/').last )}
           = render ChipButtonComponent.new(type: "clickable", text: t('components.view'), style: style_bg)
 
-      - if external_ontology?
-        - ontology[:sources].each do |id|
-          - config = ontology_portal_config(id)&.last || internal_portal_config(id) || {}
-          - unless config.blank?
-            %span{style: "padding: 3px 0; margin-right: 0.25rem;"}
-              = portal_button(name: config[:name], color: config[:color], light_color: config[:"light-color"], link: ontoportal_ui_link(id), tooltip: "Source #{config[:name]}")
+
+      - ontology[:sources]&.each do |id|
+        - config = ontology_portal_config(id)&.last || internal_portal_config(id) || {}
+        - unless config.blank?
+          %span{style: "padding: 3px 0; margin-right: 0.25rem;"}
+            = portal_button(name: config[:name], color: config[:color], light_color: config[:"light-color"], link: ontoportal_ui_link(id), tooltip: "Source #{config[:name]}")
 
       - if session[:user]&.admin?
         %div.mx-1{title: content_tag(:div, debug(ontology), style: 'height: 300px; overflow: scroll'), data:{controller: 'tooltip', 'tooltip-interactive-value': 'true'}}

--- a/app/controllers/concerns/search_aggregator.rb
+++ b/app/controllers/concerns/search_aggregator.rb
@@ -44,7 +44,7 @@ module SearchAggregator
     same_ont = result[:same_ont]
     same_cls = result[:sub_ont]
     result = same_ont.shift
-    ontology = result.links['ontology'].split('/').last
+    ontology = result.links['ontology']
     {
     root: search_result_elem(result, ontology, ontology_name_acronym(ontologies, ontology)),
     descendants: same_ont.map { |x| search_result_elem(x, ontology, '') },
@@ -74,14 +74,14 @@ module SearchAggregator
     label
   end
 
-  def search_result_elem(class_object, ontology_acronym, title)
+  def search_result_elem(class_object, ontology_id, title)
     label = search_concept_label(class_object.prefLabel)
     request_lang = helpers.request_lang&.eql?("ALL") ? '' : "&language=#{helpers.request_lang}"
-
+    ontology_acronym = link_last_part(ontology_id)
     result = {
       uri: class_object.id.to_s,
       title: title.to_s.empty? ? "#{label} - #{ontology_acronym}" : "#{label} - #{title}",
-      ontology_acronym: ontology_acronym,
+      ontology_id: ontology_id,
       link: "/ontologies/#{ontology_acronym}?p=classes&conceptid=#{escape(class_object.id)}#{request_lang}",
       definition: class_object.definition,
     }

--- a/app/controllers/concerns/submission_filter.rb
+++ b/app/controllers/concerns/submission_filter.rb
@@ -56,7 +56,9 @@ module SubmissionFilter
 
     count = @page.page.eql?(1) ? count_objects(submissions) : {}
 
-    [@page.collection, @page.totalCount, count, filter_params]
+    federation_counts = federated_browse_counts(submissions)
+
+    [@page.collection, @page.totalCount, count, filter_params, federation_counts]
   end
 
   def ontologies_with_filters_url(filters, page: 1, count: false)

--- a/app/controllers/ontologies_controller.rb
+++ b/app/controllers/ontologies_controller.rb
@@ -44,7 +44,7 @@ class OntologiesController < ApplicationController
 
   def ontologies_filter
     @time = Benchmark.realtime do
-      @ontologies, @count, @count_objects, @request_params = submissions_paginate_filter(params)
+      @ontologies, @count, @count_objects, @request_params, @federation_counts = submissions_paginate_filter(params)
     end
 
     if @page.page.eql?(1)
@@ -193,7 +193,7 @@ class OntologiesController < ApplicationController
     @schemes = get_schemes(@ontology)
     scheme_id = params[:schemeid] || @submission_latest.URI || nil
     @scheme = scheme_id ? get_scheme(@ontology, scheme_id) : @schemes.first
- 
+
 
     render partial: 'ontologies/sections/schemes', layout: 'ontology_viewer'
   end

--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -30,6 +30,7 @@ class SearchController < ApplicationController
 
 
       @search_results = aggregate_results(@search_query, results)
+      @federation_counts = federated_search_counts(@search_results)
     end
     @advanced_options_open = !search_params_empty?
     @json_url = json_link("#{rest_url}/search", params.permit!.to_h)

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -506,7 +506,7 @@ module ApplicationHelper
     end
   end
 
-  def empty_state(text)
+  def empty_state(text = t('no_result_was_found'))
     content_tag(:div, class:'browse-empty-illustration') do
       inline_svg_tag('empty-box.svg') +
       content_tag(:p, text)

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -11,11 +11,7 @@ module ApplicationHelper
 
   include ModalHelper, MultiLanguagesHelper, UrlsHelper
 
-  def url_to_endpoint(url)
-    uri = URI.parse(url)
-    endpoint = uri.path.sub(/^\//, '')
-    endpoint
-  end
+
   RESOLVE_NAMESPACE = {:omv => "http://omv.ontoware.org/2005/05/ontology#", :skos => "http://www.w3.org/2004/02/skos/core#", :owl => "http://www.w3.org/2002/07/owl#",
                        :rdf => "http://www.w3.org/1999/02/22-rdf-syntax-ns#", :rdfs => "http://www.w3.org/2000/01/rdf-schema#", :metadata => "http://data.bioontology.org/metadata/",
                        :metadata_def => "http://data.bioontology.org/metadata/def/", :dc => "http://purl.org/dc/elements/1.1/", :xsd => "http://www.w3.org/2001/XMLSchema#",
@@ -59,18 +55,6 @@ module ApplicationHelper
     end
   end
 
-  def rest_hostname
-    extract_hostname(REST_URI)
-  end
-
-  def extract_hostname(url)
-    begin
-      uri = URI.parse(url)
-      uri.hostname
-    rescue URI::InvalidURIError
-      url
-    end
-  end
 
   def omniauth_providers_info
     $OMNIAUTH_PROVIDERS
@@ -83,11 +67,6 @@ module ApplicationHelper
   def omniauth_token_provider(strategy)
     omniauth_provider_info(strategy.to_sym).keys.first
   end
-
-  def encode_param(string)
-    CGI.escape(string)
-  end
-
 
   def current_user
     session[:user]
@@ -102,9 +81,6 @@ module ApplicationHelper
     child.id.to_s.split('/').last
   end
 
-
-
-  # Create a popup button with a ? inside to display help when hovered
   def help_tooltip(content, html_attribs = {}, icon = 'fas fa-question-circle', css_class = nil, text = nil)
     html_attribs["title"] = content
     attribs = []
@@ -145,15 +121,6 @@ module ApplicationHelper
     onts_for_select
   end
 
-  def link_last_part(url)
-    return "" if url.nil?
-
-    if url.include?('#')
-      url.split('#').last
-    else
-      url.split('/').last
-    end
-  end
 
   def at_slice?
     !@subdomain_filter.nil? && !@subdomain_filter[:active].nil? && @subdomain_filter[:active] == true
@@ -185,14 +152,6 @@ module ApplicationHelper
     end
   end
 
-
-  def link?(str)
-    # Regular expression to match strings starting with "http://" or "https://"
-    link_pattern = /\Ahttps?:\/\//
-    str = str&.strip
-    # Check if the string matches the pattern
-    !!(str =~ link_pattern)
-  end
 
   def subscribe_button(ontology_id)
     return if ontology_id.nil?
@@ -361,10 +320,6 @@ module ApplicationHelper
 
   def help_path(anchor: nil)
     "#{Rails.configuration.settings.links[:help]}##{anchor}"
-  end
-
-  def uri?(url)
-    url =~ /\A#{URI::DEFAULT_PARSER.make_regexp(%w[http https])}\z/
   end
 
   def extract_label_from(uri)

--- a/app/helpers/components_helper.rb
+++ b/app/helpers/components_helper.rb
@@ -286,7 +286,7 @@ module ComponentsHelper
   end
 
   def text_with_icon(text:, icon:)
-    content_tag(:div, class: 'icon') do
+    content_tag(:div, class: 'd-flex align-items-center icon') do
       inline_svg_tag(icon, height: '18', weight: '18') + content_tag(:div, class: 'text') {text}
     end
   end

--- a/app/helpers/components_helper.rb
+++ b/app/helpers/components_helper.rb
@@ -28,8 +28,6 @@ module ComponentsHelper
                     checked: checked,
                     value: value, tooltip: title, &block)
   end
-  alias  :category_chip_component :group_chip_component
-
 
   def rdf_highlighter_container(format, content)
     render Display::RdfHighlighterComponent.new(format: format, text: content)
@@ -101,7 +99,6 @@ module ComponentsHelper
     end
   end
 
-
   def resolvability_check_tag(url)
     content_tag(:span, check_resolvability_container(url), style: 'display: inline-block;', onClick: "window.open('#{check_resolvability_url(url: url)}', '_blank');")
   end
@@ -115,7 +112,6 @@ module ComponentsHelper
       render ClipboardComponent.new(title: t("components.copy_original_uri"), message: url, show_content: show_content)
     end
   end
-
 
   def generated_link_to_clipboard(url, acronym)
     url = "#{$UI_URL}/ontologies/#{acronym}/#{link_last_part(url)}"
@@ -131,7 +127,6 @@ module ComponentsHelper
       end
     end
   end
-
 
   def link_to_with_actions(link_to_tag, acronym: nil, url: nil, copy: true, check_resolvability: true, generate_link: true, generate_htaccess: false)
     tag = link_to_tag
@@ -268,13 +263,11 @@ module ComponentsHelper
     end
   end
 
-
   def regular_button(id, value, variant: "secondary", state: "regular", size: "slim", &block)
     render Buttons::RegularButtonComponent.new(id:id, value: value, variant: variant, state: state, size: size) do |btn|
       capture(btn, &block) if block_given?
     end
   end
-
 
   def form_save_button
     render Buttons::RegularButtonComponent.new(id: 'save-button', value: t('components.save_button'), variant: "primary", size: "slim", type: "submit") do |btn|
@@ -292,4 +285,9 @@ module ComponentsHelper
     end
   end
 
+  def text_with_icon(text:, icon:)
+    content_tag(:div, class: 'icon') do
+      inline_svg_tag(icon, height: '18', weight: '18') + content_tag(:div, class: 'text') {text}
+    end
+  end
 end

--- a/app/helpers/federation_helper.rb
+++ b/app/helpers/federation_helper.rb
@@ -123,5 +123,15 @@ module FederationHelper
     !class_object.links['self'].include?($REST_URL)
   end
 
+  def federated_search_counts(search_results)
+    counts = Hash.new(0)
+
+    search_results.each do |result|
+      portal_name = result.dig(:root, :portal_name) || $SITE
+      counts[portal_name] += 1
+    end
+
+    counts
+  end
 
 end

--- a/app/helpers/federation_helper.rb
+++ b/app/helpers/federation_helper.rb
@@ -134,31 +134,33 @@ module FederationHelper
     !class_object.links['self'].include?($REST_URL)
   end
 
+
   def federated_search_counts(search_results)
-    counts = Hash.new(0)
-
-    search_results.each do |result|
-      portal_name = result.dig(:root, :portal_name) || $SITE.downcase
-      counts[portal_name] += 1
+    ids = search_results.map do |result|
+      result.dig(:root, :ontology_id) || rest_url
     end
-
-    counts
+    counts_ontology_ids_by_portal_name(ids)
   end
 
   def federated_browse_counts(ontologies)
+    ids = ontologies.map { |ontology| ontology[:id] }
+    counts_ontology_ids_by_portal_name(ids)
+  end
+
+  private
+
+  def counts_ontology_ids_by_portal_name(portals_ids)
     counts = Hash.new(0)
-
-    ontologies.each do |ontology|
-      current_portal, *federation_portals = request_portals
-
-      counts[current_portal.downcase] += 1 if ontology[:id].include?(current_portal.to_s.downcase)
+    current_portal, *federation_portals = request_portals
+    portals_ids.each do |id|
+      counts[current_portal.downcase] += 1 if id.include?(current_portal.to_s.downcase)
 
       federation_portals.each do |portal|
-        counts[portal.downcase] += 1 if ontology[:id].include?(federated_portals[portal.downcase.to_sym][:api])
+        portal_api = federated_portals[portal.downcase.to_sym][:api]
+        counts[portal.downcase] += 1 if id.include?(portal_api)
       end
     end
 
     counts
   end
-
 end

--- a/app/helpers/federation_helper.rb
+++ b/app/helpers/federation_helper.rb
@@ -106,6 +106,16 @@ module FederationHelper
     federation_errors.map{ |p| "#{p} #{t('federation.not_responding')} " }.join(' ')
   end
 
+  def alert_message_if_federation_error(errors, &block)
+    return if errors.blank?
+
+    content_tag(:div, class: 'my-1') do
+      render Display::AlertComponent.new(type: 'warning') do
+        capture(&block)
+      end
+    end
+  end
+
   def class_federation_configuration(class_object)
     is_external = federation_external_class?(class_object)
     portal_name = is_external ? helpers.portal_name_from_uri(class_object.links['ui']) : nil

--- a/app/helpers/federation_helper.rb
+++ b/app/helpers/federation_helper.rb
@@ -75,8 +75,8 @@ module FederationHelper
     [portal_name] + portals
   end
 
-  def request_portals_names(counts)
-    request_portals.map do |x|
+  def request_portals_names(counts, time)
+    output = request_portals.map do |x|
       config = federated_portal_config(x)
 
       if config
@@ -89,8 +89,10 @@ module FederationHelper
         next nil
       end
 
-      content_tag(:span, "#{federated_portal_name(name)} (#{counts[federated_portal_name(name).downcase]})", style: color ? "color: #{color}" :  "", class: color ? "" : "text-primary")
-    end.compact
+      content_tag(:span, "#{federated_portal_name(name)} (#{counts[federated_portal_name(name).downcase]})", style: color ? "color: #{color}" : "", class: color ? "" : "text-primary")
+    end.compact.join(", ")
+
+    "#{output} in #{sprintf("%.2f", time)}s"
   end
 
   def federation_enabled?

--- a/app/helpers/federation_helper.rb
+++ b/app/helpers/federation_helper.rb
@@ -134,4 +134,16 @@ module FederationHelper
     counts
   end
 
+  def federated_browse_counts(ontologies)
+    counts = Hash.new(0)
+
+    ontologies.each do |ontology|
+      request_portals.each do |portal|
+        counts[portal.to_s.downcase] += 1 if ontology[:id].include?(portal.to_s.downcase)
+      end
+    end
+
+    counts
+  end
+
 end

--- a/app/helpers/federation_helper.rb
+++ b/app/helpers/federation_helper.rb
@@ -138,8 +138,12 @@ module FederationHelper
     counts = Hash.new(0)
 
     ontologies.each do |ontology|
-      request_portals.each do |portal|
-        counts[portal.to_s.downcase] += 1 if ontology[:id].include?(portal.to_s.downcase)
+      current_portal, *federation_portals = request_portals
+
+      counts[current_portal.downcase] += 1 if ontology[:id].include?(current_portal.to_s.downcase)
+
+      federation_portals.each do |portal|
+        counts[portal.downcase] += 1 if ontology[:id].include?(federated_portals[portal.downcase.to_sym][:api])
       end
     end
 

--- a/app/helpers/federation_helper.rb
+++ b/app/helpers/federation_helper.rb
@@ -36,25 +36,24 @@ module FederationHelper
     config[:'light-color'] if config
   end
 
-
   def ontology_portal_config(id)
     rest_url = id.split('/')[0..-3].join('/')
-    federated_portals.select{|_, config| config[:api].start_with?(rest_url)}.first
+    federated_portals.select { |_, config| config[:api].start_with?(rest_url) }.first
   end
 
   def ontology_portal_name(id)
-    portal_key, _ =  ontology_portal_config(id)
+    portal_key, _ = ontology_portal_config(id)
     portal_key ? federated_portal_name(portal_key) : nil
   end
 
   def ontology_portal_color(id)
-    portal_key, _ =  ontology_portal_config(id)
+    portal_key, _ = ontology_portal_config(id)
     federated_portal_color(portal_key) if portal_key
   end
 
   def ontoportal_ui_link(id)
-    portal_key, config =  ontology_portal_config(id)
-    return nil  unless portal_key
+    portal_key, config = ontology_portal_config(id)
+    return nil unless portal_key
 
     ui_link = config[:ui]
     api_link = config[:api]
@@ -104,8 +103,8 @@ module FederationHelper
   end
 
   def federation_error(response)
-    federation_errors = response[:errors].map{|e| ontology_portal_name(e.split(' ').last.gsub('search', ''))}
-    federation_errors.map{ |p| "#{p} #{t('federation.not_responding')} " }.join(' ')
+    federation_errors = response[:errors].map { |e| ontology_portal_name(e.split(' ').last.gsub('search', '')) }
+    federation_errors.map { |p| "#{p} #{t('federation.not_responding')} " }.join(' ')
   end
 
   def alert_message_if_federation_error(errors, &block)

--- a/app/helpers/federation_helper.rb
+++ b/app/helpers/federation_helper.rb
@@ -75,7 +75,7 @@ module FederationHelper
     [portal_name] + portals
   end
 
-  def request_portals_names
+  def request_portals_names(counts)
     request_portals.map do |x|
       config = federated_portal_config(x)
 
@@ -89,7 +89,7 @@ module FederationHelper
         next nil
       end
 
-      content_tag(:span, federated_portal_name(name), style: color ? "color: #{color}" :  "", class: color ? "" : "text-primary")
+      content_tag(:span, "#{federated_portal_name(name)} (#{counts[federated_portal_name(name).downcase]})", style: color ? "color: #{color}" :  "", class: color ? "" : "text-primary")
     end.compact
   end
 
@@ -127,7 +127,7 @@ module FederationHelper
     counts = Hash.new(0)
 
     search_results.each do |result|
-      portal_name = result.dig(:root, :portal_name) || $SITE
+      portal_name = result.dig(:root, :portal_name) || $SITE.downcase
       counts[portal_name] += 1
     end
 

--- a/app/helpers/instances_helper.rb
+++ b/app/helpers/instances_helper.rb
@@ -57,7 +57,7 @@ module InstancesHelper
   end
 
   def instance_property_value(property, ontology_acronym)
-    if uri?(property)
+    if link?(property)
       instance, types = get_instance_and_type(property, ontology_acronym)
       return link_to_instance(instance, ontology_acronym) unless instance.empty?
     end

--- a/app/helpers/mappings_helper.rb
+++ b/app/helpers/mappings_helper.rb
@@ -141,7 +141,7 @@ module MappingsHelper
       target_ontology = ontology_to
       target = concept_to_id
     else
-      if helpers.uri?(ontology_to)
+      if helpers.link?(ontology_to)
         target_ontology = LinkedData::Client::Models::Ontology.find(ontology_to)
       else
         target_ontology = LinkedData::Client::Models::Ontology.find_by_acronym(ontology_to).first

--- a/app/helpers/urls_helper.rb
+++ b/app/helpers/urls_helper.rb
@@ -25,14 +25,6 @@ module UrlsHelper
         !!(str =~ link_pattern)
     end
 
-    def uri?(url)
-        url =~ /\A#{URI::DEFAULT_PARSER.make_regexp(%w[http https])}\z/
-    end
-
-    def encode_param(string)
-        CGI.escape(string)
-    end
-
     def link_last_part(url)
         return "" if url.nil?
 
@@ -49,5 +41,9 @@ module UrlsHelper
 
     def unescape(string)
         CGI.unescape(string) if string
+    end
+
+    def encode_param(string)
+        escape(string)
     end
 end

--- a/app/helpers/urls_helper.rb
+++ b/app/helpers/urls_helper.rb
@@ -1,4 +1,48 @@
 module UrlsHelper
+    def url_to_endpoint(url)
+        uri = URI.parse(url)
+        endpoint = uri.path.sub(/^\//, '')
+        endpoint
+    end
+    def rest_hostname
+        extract_hostname(REST_URI)
+    end
+
+    def extract_hostname(url)
+        begin
+            uri = URI.parse(url)
+            uri.hostname
+        rescue URI::InvalidURIError
+            url
+        end
+    end
+
+    def link?(str)
+        # Regular expression to match strings starting with "http://" or "https://"
+        link_pattern = /\Ahttps?:\/\//
+        str = str&.strip
+        # Check if the string matches the pattern
+        !!(str =~ link_pattern)
+    end
+
+    def uri?(url)
+        url =~ /\A#{URI::DEFAULT_PARSER.make_regexp(%w[http https])}\z/
+    end
+
+    def encode_param(string)
+        CGI.escape(string)
+    end
+
+    def link_last_part(url)
+        return "" if url.nil?
+
+        if url.include?('#')
+            url.split('#').last
+        else
+            url.split('/').last
+        end
+    end
+
     def escape(string)
         CGI.escape(string) if string
     end

--- a/app/views/ontologies/browser/_ontologies.html.haml
+++ b/app/views/ontologies/browser/_ontologies.html.haml
@@ -6,12 +6,12 @@
   - if @page.page.eql?(1)
     = content_tag(:p, class: "browse-desc-text", style: "margin-bottom: 12px !important;") do
       #{t("ontologies.showing_ontologies_size", ontologies_size: @count, analytics_size: @total_ontologies, portals: request_portals_names(@federation_counts).join(', ').html_safe).html_safe} in #{sprintf("%.2f", @time)}s
-    - unless @errors.blank?
-      %div.my-1
-        = render Display::AlertComponent.new(type: 'warning') do
-          -  @errors.each do |e|
-            %div
-              = e.errors || e
+
+    = alert_message_if_federation_error(@errors) do
+      -  @errors.each do |e|
+        %div
+          = e.errors || e
+
   - ontologies = c.collection
   - ontologies.each do |ontology|
     - config = ontology_portal_config(ontology[:id])&.last || {}
@@ -24,6 +24,4 @@
   - c.loader do
     - ontologies_browse_skeleton
   - c.error do
-    .browse-empty-illustration
-      %img{:src => "#{asset_path("empty-box.svg")}"}
-      %p No result was found
+    = empty_state

--- a/app/views/ontologies/browser/_ontologies.html.haml
+++ b/app/views/ontologies/browser/_ontologies.html.haml
@@ -5,7 +5,7 @@
 
   - if @page.page.eql?(1)
     = content_tag(:p, class: "browse-desc-text", style: "margin-bottom: 12px !important;") do
-      #{t("ontologies.showing_ontologies_size", ontologies_size: @count, analytics_size: @total_ontologies, portals: request_portals_names(@federation_counts).join(', ').html_safe).html_safe} in #{sprintf("%.2f", @time)}s
+      = t("ontologies.showing_ontologies_size", ontologies_size: @count, analytics_size: @total_ontologies, portals: request_portals_names(@federation_counts, @time)).html_safe
 
     = alert_message_if_federation_error(@errors) do
       -  @errors.each do |e|

--- a/app/views/ontologies/browser/_ontologies.html.haml
+++ b/app/views/ontologies/browser/_ontologies.html.haml
@@ -5,7 +5,7 @@
 
   - if @page.page.eql?(1)
     = content_tag(:p, class: "browse-desc-text", style: "margin-bottom: 12px !important;") do
-      #{t("ontologies.showing_ontologies_size", ontologies_size: @count, analytics_size: @total_ontologies, portals: request_portals_names.join(', ').html_safe).html_safe} (#{sprintf("%.2f", @time)}s)
+      #{t("ontologies.showing_ontologies_size", ontologies_size: @count, analytics_size: @total_ontologies, portals: request_portals_names(@federation_counts).join(', ').html_safe).html_safe} in #{sprintf("%.2f", @time)}s
     - unless @errors.blank?
       %div.my-1
         = render Display::AlertComponent.new(type: 'warning') do

--- a/app/views/ontologies/browser/browse.html.haml
+++ b/app/views/ontologies/browser/browse.html.haml
@@ -1,7 +1,7 @@
 .browse-center
   .browse-container
     .container.align-alert
-      - if session[:user]&.admin?
+      - if current_user_admin?
         %div{style:'width: 70%;'}
           = render Display::AlertComponent.new(type: 'info') do
             %span.d-flex.align-items-center

--- a/app/views/recommender/index.html.haml
+++ b/app/views/recommender/index.html.haml
@@ -78,7 +78,7 @@
             - btn.icon_left do
               = inline_svg_tag "edit.svg"
     - if @results && @results.empty?
-      = empty_state(t('no_result_was_found'))
+      = empty_state
     - unless @results.nil? || @results.empty?
       .recommender-page-results 
         .title
@@ -122,5 +122,3 @@
             = render Buttons::RegularButtonComponent.new(id:'recommender_go_annotator', value: t('recommender.call_annotator'), variant: "secondary", href: "/annotator?text=#{params[:input]}&ontologies=#{params[:ontologies]}", size: "slim", target: '_blank', state: "regular") do |btn|
               - btn.icon_right do
                 = inline_svg_tag "arrow-right-outlined.svg"
-
-  

--- a/app/views/search/index.html.haml
+++ b/app/views/search/index.html.haml
@@ -44,20 +44,15 @@
           %div.d-flex
             .search-page-advanced-button.mr-4{class: @search_results.blank? ? 'd-none' : ''}
               %a.d-flex{href: @json_url, target: '_blank'}
-                .icon
-                  = inline_svg_tag 'json.svg', height: '18', weight: '18'
-                .text
-                  API JSON
+                = text_with_icon(text: "API JSON", icon: 'json.svg')
+
             .search-page-advanced-button.show-options{class: "#{@advanced_options_open ? 'd-none' : ''}",'data': {'action': 'click->reveal-component#show', 'reveal-component-target': 'showButton'}}
-              .icon
-                =inline_svg_tag 'icons/settings.svg'
-              .text
-                = t('search.show_advanced_options')
+              = text_with_icon(text: t('search.show_advanced_options'), icon: 'icons/settings.svg')
+
             .search-page-advanced-button.hide-options{class: "#{@advanced_options_open ? '' : 'd-none'}", 'data': {'action': 'click->reveal-component#hide', 'reveal-component-target': 'hideButton'}}
-              .icon
-                =inline_svg_tag 'icons/hide.svg'
-              .text
-                = t('search.hide_advanced_options')
+              = text_with_icon(text: t('search.hide_advanced_options'), icon: 'icons/hide.svg')
+
+
     - unless @federation_errors.blank?
       = render Display::AlertComponent.new(message: @federation_errors, type: "warning")
 
@@ -77,6 +72,4 @@
                 - r[:descendants].each { |dd|  b.subresult(dd.merge(is_sub_component: true))}
 
     - if @search_results.empty? && !@search_query.empty?
-      .browse-empty-illustration
-        %img{:src => "#{asset_path("empty-box.svg")}"}
-        %p No result was found
+      = empty_state(t('no_result_was_found'))

--- a/app/views/search/index.html.haml
+++ b/app/views/search/index.html.haml
@@ -40,7 +40,7 @@
         .search-page-options{class:  @search_results.empty? ? 'justify-content-end': ''}
           - unless @search_results.empty?
             .search-page-number-of-results
-              = "#{t('search.match_in')} #{@search_results.length} #{t('search.ontologies')} #{t('federation.from')} #{request_portals_names.join(', ').html_safe} (#{sprintf("%.2f", @time)}s)".html_safe
+              = "#{t('search.match_in')} #{@search_results.length} #{t('search.ontologies')} #{t('federation.from')} #{request_portals_names(@federation_counts).join(', ').html_safe} in #{sprintf("%.2f", @time)}s".html_safe
           %div.d-flex
             .search-page-advanced-button.mr-4{class: @search_results.blank? ? 'd-none' : ''}
               %a.icon{href: @json_url}

--- a/app/views/search/index.html.haml
+++ b/app/views/search/index.html.haml
@@ -40,7 +40,7 @@
         .search-page-options{class:  @search_results.empty? ? 'justify-content-end': ''}
           - unless @search_results.empty?
             .search-page-number-of-results
-              = "#{t('search.match_in')} #{@search_results.length} #{t('search.ontologies')} #{t('federation.from')} #{request_portals_names(@federation_counts).join(', ').html_safe} in #{sprintf("%.2f", @time)}s".html_safe
+              = t('search.match_in', results_size: @search_results.length, portals: request_portals_names(@federation_counts, @time)).html_safe
           %div.d-flex
             .search-page-advanced-button.mr-4{class: @search_results.blank? ? 'd-none' : ''}
               %a.d-flex{href: @json_url, target: '_blank'}

--- a/app/views/search/index.html.haml
+++ b/app/views/search/index.html.haml
@@ -53,8 +53,9 @@
               = text_with_icon(text: t('search.hide_advanced_options'), icon: 'icons/hide.svg')
 
 
-    - unless @federation_errors.blank?
-      = render Display::AlertComponent.new(message: @federation_errors, type: "warning")
+
+
+    = alert_message_if_federation_error(@federation_errors) {@federation_errors}
 
     .search-page-results-container
       - number = 0
@@ -72,4 +73,4 @@
                 - r[:descendants].each { |dd|  b.subresult(dd.merge(is_sub_component: true))}
 
     - if @search_results.empty? && !@search_query.empty?
-      = empty_state(t('no_result_was_found'))
+      = empty_state

--- a/app/views/search/index.html.haml
+++ b/app/views/search/index.html.haml
@@ -42,8 +42,11 @@
             .search-page-number-of-results
               = "#{t('search.match_in')} #{@search_results.length} #{t('search.ontologies')} #{t('federation.from')} #{request_portals_names.join(', ').html_safe} (#{sprintf("%.2f", @time)}s)".html_safe
           %div.d-flex
-            .search-page-json.mx-4.mt-1
-              = search_json_link
+            .search-page-advanced-button.mr-4{class: @search_results.blank? ? 'd-none' : ''}
+              %a.icon{href: @json_url}
+                = inline_svg_tag 'json.svg', height: '18', weight: '18'
+              .text
+                API JSON
             .search-page-advanced-button.show-options{class: "#{@advanced_options_open ? 'd-none' : ''}",'data': {'action': 'click->reveal-component#show', 'reveal-component-target': 'showButton'}}
               .icon
                 =inline_svg_tag 'icons/settings.svg'
@@ -56,21 +59,21 @@
                 = t('search.hide_advanced_options')
     - unless @federation_errors.blank?
       = render Display::AlertComponent.new(message: @federation_errors, type: "warning")
-    - if @search_results
-      .search-page-results-container
-        - number = 0
-        - @search_results.each do |result|
-          .search-page-result-element
-            - number = number + 1
-            - descendants = result[:descendants]
-            - reuses = result[:reuses]
-            - result[:root][:number] = number
-            = render Display::SearchResultComponent.new(result[:root]) do |c|
-              - descendants.each { |d| c.subresult(d.merge(is_sub_component: true))}
-              - reuses.each do |r|
-                - number = number + 1
-                - c.reuse(r[:root].merge(is_sub_component: true, number: number)) do |b|
-                  - r[:descendants].each { |dd|  b.subresult(dd.merge(is_sub_component: true))}
+
+    .search-page-results-container
+      - number = 0
+      - @search_results.each do |result|
+        .search-page-result-element
+          - number = number + 1
+          - descendants = result[:descendants]
+          - reuses = result[:reuses]
+          - result[:root][:number] = number
+          = render Display::SearchResultComponent.new(result[:root]) do |c|
+            - descendants.each { |d| c.subresult(d.merge(is_sub_component: true))}
+            - reuses.each do |r|
+              - number = number + 1
+              - c.reuse(r[:root].merge(is_sub_component: true, number: number)) do |b|
+                - r[:descendants].each { |dd|  b.subresult(dd.merge(is_sub_component: true))}
 
     - if @search_results.empty? && !@search_query.empty?
       .browse-empty-illustration

--- a/app/views/search/index.html.haml
+++ b/app/views/search/index.html.haml
@@ -43,10 +43,11 @@
               = "#{t('search.match_in')} #{@search_results.length} #{t('search.ontologies')} #{t('federation.from')} #{request_portals_names(@federation_counts).join(', ').html_safe} in #{sprintf("%.2f", @time)}s".html_safe
           %div.d-flex
             .search-page-advanced-button.mr-4{class: @search_results.blank? ? 'd-none' : ''}
-              %a.icon{href: @json_url}
-                = inline_svg_tag 'json.svg', height: '18', weight: '18'
-              .text
-                API JSON
+              %a.d-flex{href: @json_url, target: '_blank'}
+                .icon
+                  = inline_svg_tag 'json.svg', height: '18', weight: '18'
+                .text
+                  API JSON
             .search-page-advanced-button.show-options{class: "#{@advanced_options_open ? 'd-none' : ''}",'data': {'action': 'click->reveal-component#show', 'reveal-component-target': 'showButton'}}
               .icon
                 =inline_svg_tag 'icons/settings.svg'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -921,8 +921,7 @@ en:
         classes_with_definitions: Classes with definitions
     show_advanced_options: Show options
     hide_advanced_options: Hide options
-    match_in: Match in
-    ontologies: ontologies
+    match_in: Match in %{results_size} from %{portals}
     result_component:
       details: Details
       visualize: Vizualize

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -921,7 +921,7 @@ en:
         classes_with_definitions: Classes with definitions
     show_advanced_options: Show options
     hide_advanced_options: Hide options
-    match_in: Match in %{results_size} from %{portals}
+    match_in: Match in %{results_size} ontologies from %{portals}
     result_component:
       details: Details
       visualize: Vizualize
@@ -1504,5 +1504,4 @@ en:
 
   federation:
     results_from_external_portals: Results from external portals
-    from: from
     not_responding: is not responding.

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -937,8 +937,7 @@ fr:
         classes_with_definitions: Classes avec définitions
     show_advanced_options: Afficher les options
     hide_advanced_options: Cacher les options
-    match_in: Correspondance dans
-    ontologies: ontologies
+    match_in: Correspondance dans %{results_size} ontologies de %{portals}
     result_component:
       details: Détails
       visualize: Visualiser
@@ -1542,6 +1541,4 @@ fr:
     show_sub_categories: Afficher les sous-catégories
   federation:
     results_from_external_portals: Résultats provenant de portails externes
-    from: de
     not_responding: ne répond pas.
-


### PR DESCRIPTION
### Changes
- Add text for api json button in search page and show it only when the search is performed (https://github.com/ontoportal-lirmm/bioportal_web_ui/commit/f3aa7b4cef8cca09f826fc64e4e5801743537d2d)
<img width="1174" alt="Capture d’écran 2024-10-16 à 19 34 03" src="https://github.com/user-attachments/assets/5d6aaff3-209b-4f7c-ae27-18eabd8fe26f">
- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -- - - - - - - - - -
<img width="1179" alt="Capture d’écran 2024-10-16 à 19 37 49" src="https://github.com/user-attachments/assets/742aea62-ea64-4e98-afc7-5cc882664999">

-----

- Show results count separately for every portal in federated search and browse (https://github.com/ontoportal-lirmm/bioportal_web_ui/commit/20d85ec46637f25fc9a233ae3351ba49b35e562d) (https://github.com/ontoportal-lirmm/bioportal_web_ui/commit/63f27eea2a129752e24b8e978f400684cef9f968) (https://github.com/ontoportal-lirmm/bioportal_web_ui/commit/76c1db5811ebf6e5134045b0b682ad5a903858ad) (https://github.com/ontoportal-lirmm/bioportal_web_ui/commit/caf73538976a163114a461f782f06a544e52f50d)
<img width="1184" alt="image" src="https://github.com/user-attachments/assets/e6025c83-c519-4b3f-b50e-f5297237ccf2">
- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -- - - - - - - - - -
<img width="1213" alt="image" src="https://github.com/user-attachments/assets/1cdecb4d-eee9-45c2-9bdf-ea495a3cc1b1">

-----

- Fix browse page federation portals button colors issue (https://github.com/ontoportal-lirmm/bioportal_web_ui/commit/e2074c72e4e05dcc560dd03afadfe37ac8f91542)
<img width="853" alt="image" src="https://github.com/user-attachments/assets/6afb90ca-6cc0-4b71-8d39-357df9569a91">

