### PR TITLE
Feature: Add enable/disable federation option

### DIFF
--- a/app/controllers/concerns/search_aggregator.rb
+++ b/app/controllers/concerns/search_aggregator.rb
@@ -36,8 +36,8 @@ module SearchAggregator
       format_search_result(group, all_ontologies)
     end
 
-    if federation_enabled?
-      search_results = merge_sort_federated_results(query, search_results) if federation_enabled?
+    if federation_portals_enabled?
+      search_results = merge_sort_federated_results(query, search_results) if federation_portals_enabled?
       search_results = swap_canonical_portal_results_first(search_results)
     end
 
@@ -90,7 +90,7 @@ module SearchAggregator
       definition: class_object.definition,
     }
 
-    result.merge!(class_federation_configuration(class_object)) if federation_enabled?
+    result.merge!(class_federation_configuration(class_object)) if federation_portals_enabled?
 
     result
   end

--- a/app/controllers/concerns/search_aggregator.rb
+++ b/app/controllers/concerns/search_aggregator.rb
@@ -36,8 +36,8 @@ module SearchAggregator
       format_search_result(group, all_ontologies)
     end
 
-    if federation_portals_enabled?
-      search_results = merge_sort_federated_results(query, search_results) if federation_portals_enabled?
+    if federated_request?
+      search_results = merge_sort_federated_results(query, search_results)
       search_results = swap_canonical_portal_results_first(search_results)
     end
 
@@ -90,7 +90,7 @@ module SearchAggregator
       definition: class_object.definition,
     }
 
-    result.merge!(class_federation_configuration(class_object)) if federation_portals_enabled?
+    result.merge!(class_federation_configuration(class_object)) if federated_request?
 
     result
   end

--- a/app/controllers/ontologies_controller.rb
+++ b/app/controllers/ontologies_controller.rb
@@ -38,7 +38,7 @@ class OntologiesController < ApplicationController
     @groups = LinkedData::Client::Models::Group.all(display_links: false, display_context: false)
 
     @filters = ontology_filters_init(@categories, @groups)
-    @federation_enabled = federation_portals_enabled?
+    @federation_enabled = federation_enabled?
     init_filters(params)
     render 'ontologies/browser/browse'
   end

--- a/app/controllers/ontologies_controller.rb
+++ b/app/controllers/ontologies_controller.rb
@@ -38,6 +38,7 @@ class OntologiesController < ApplicationController
     @groups = LinkedData::Client::Models::Group.all(display_links: false, display_context: false)
 
     @filters = ontology_filters_init(@categories, @groups)
+    @federation_enabled = federation_portals_enabled?
     init_filters(params)
     render 'ontologies/browser/browse'
   end

--- a/app/controllers/ontologies_controller.rb
+++ b/app/controllers/ontologies_controller.rb
@@ -38,7 +38,6 @@ class OntologiesController < ApplicationController
     @groups = LinkedData::Client::Models::Group.all(display_links: false, display_context: false)
 
     @filters = ontology_filters_init(@categories, @groups)
-    @federation_enabled = federation_enabled?
     init_filters(params)
     render 'ontologies/browser/browse'
   end

--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -8,6 +8,7 @@ class SearchController < ApplicationController
   layout :determine_layout
 
   def index
+    @federation_enabled = federation_enabled?
     @search_query = params[:query] || params[:q] || ''
     params[:query] = nil
     @advanced_options_open = false
@@ -34,7 +35,6 @@ class SearchController < ApplicationController
     end
     @advanced_options_open = !search_params_empty?
     @json_url = json_link("#{rest_url}/search", params.permit!.to_h)
-    @federation_enabled = federation_enabled?
   end
 
   def json_search

--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -22,7 +22,7 @@ class SearchController < ApplicationController
 
     set_federated_portals
 
-    params[:ontologies] = nil if federation_portals_enabled?
+    params[:ontologies] = nil if federated_request?
 
     @time = Benchmark.realtime do
       results = LinkedData::Client::Models::Class.search(@search_query, params)

--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -8,7 +8,6 @@ class SearchController < ApplicationController
   layout :determine_layout
 
   def index
-    @federation_enabled = federation_enabled?
     @search_query = params[:query] || params[:q] || ''
     params[:query] = nil
     @advanced_options_open = false

--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -21,7 +21,7 @@ class SearchController < ApplicationController
 
     set_federated_portals
 
-    params[:ontologies] = nil if federation_enabled?
+    params[:ontologies] = nil if federation_portals_enabled?
 
     @time = Benchmark.realtime do
       results = LinkedData::Client::Models::Class.search(@search_query, params)
@@ -34,6 +34,7 @@ class SearchController < ApplicationController
     end
     @advanced_options_open = !search_params_empty?
     @json_url = json_link("#{rest_url}/search", params.permit!.to_h)
+    @federation_enabled = federation_enabled?
   end
 
   def json_search

--- a/app/helpers/federation_helper.rb
+++ b/app/helpers/federation_helper.rb
@@ -95,7 +95,7 @@ module FederationHelper
     "#{output} in #{sprintf("%.2f", time)}s"
   end
 
-  def federation_portals_enabled?
+  def federated_request?
     params[:portals]
   end
 

--- a/app/helpers/federation_helper.rb
+++ b/app/helpers/federation_helper.rb
@@ -190,7 +190,7 @@ module FederationHelper
     federated_portals.map do |key, config|
       turbo_frame_component = TurboFrameComponent.new(
         id: "federation_portals_status_#{key}",
-        src: "status/#{key}?name=#{name}&acronym=#{config[:name]}&checked=#{request_portals.include?(key.to_s)}"
+        src: "/status/#{key}?name=#{name}&acronym=#{config[:name]}&checked=#{request_portals.include?(key.to_s)}"
       )
 
       content_tag :div do

--- a/app/helpers/federation_helper.rb
+++ b/app/helpers/federation_helper.rb
@@ -95,9 +95,14 @@ module FederationHelper
     "#{output} in #{sprintf("%.2f", time)}s"
   end
 
-  def federation_enabled?
+  def federation_portals_enabled?
     params[:portals]
   end
+
+  def federation_enabled?
+    !federated_portals.blank?
+  end
+
 
   def federation_error?(response)
     !response[:errors].blank?

--- a/app/views/ontologies/browser/browse.html.haml
+++ b/app/views/ontologies/browser/browse.html.haml
@@ -54,7 +54,7 @@
                   - d.title { browse_filter_section_header(key: key, count: count)}
                   = browse_filter_section_body(key: key, checked_values: checked_values, objects: objects)
 
-            - if @federation_enabled
+            - if federation_enabled?
               %div{ data:{action: "change->browse-filters#federationChange"}}
                 = dropdown_component(id: "browse-portal-filter", is_open: !request_portals.empty?) do |d|
                   - d.title { browse_filter_section_header(title: t('federation.results_from_external_portals'))}

--- a/app/views/ontologies/browser/browse.html.haml
+++ b/app/views/ontologies/browser/browse.html.haml
@@ -54,11 +54,12 @@
                   - d.title { browse_filter_section_header(key: key, count: count)}
                   = browse_filter_section_body(key: key, checked_values: checked_values, objects: objects)
 
-            %div{ data:{action: "change->browse-filters#federationChange"}}
-              = dropdown_component(id: "browse-portal-filter", is_open: !request_portals.empty?) do |d|
-                - d.title { browse_filter_section_header(title: t('federation.results_from_external_portals'))}
-                .px-1.browse-federation-input-chips
-                  = federation_input_chips(name: "portals")
+            - if @federation_enabled
+              %div{ data:{action: "change->browse-filters#federationChange"}}
+                = dropdown_component(id: "browse-portal-filter", is_open: !request_portals.empty?) do |d|
+                  - d.title { browse_filter_section_header(title: t('federation.results_from_external_portals'))}
+                  .px-1.browse-federation-input-chips
+                    = federation_input_chips(name: "portals")
 
         .browse-second-row
           .browse-search-bar

--- a/app/views/search/index.html.haml
+++ b/app/views/search/index.html.haml
@@ -15,7 +15,7 @@
                 = t("search.advanced_options.ontologies")
               .field
                 = ontologies_selector(id:'search_page_ontologies' ,name: 'ontologies[]', selected:  params[:ontologies]&.split(','))
-            - if @federation_enabled
+            - if federation_enabled?
               .filter-container
                 .title 
                   = t('federation.results_from_external_portals')

--- a/app/views/search/index.html.haml
+++ b/app/views/search/index.html.haml
@@ -15,11 +15,12 @@
                 = t("search.advanced_options.ontologies")
               .field
                 = ontologies_selector(id:'search_page_ontologies' ,name: 'ontologies[]', selected:  params[:ontologies]&.split(','))
-            .filter-container
-              .title 
-                = t('federation.results_from_external_portals')
-              .field.d-flex 
-                = federation_input_chips(name: "portals[]")
+            - if @federation_enabled
+              .filter-container
+                .title 
+                  = t('federation.results_from_external_portals')
+                .field.d-flex 
+                  = federation_input_chips(name: "portals[]")
           .right
             .filter-container
               .title


### PR DESCRIPTION
### Changes
- Change the name of the function `federation_enabled?` used in the search controller, to `federation_portals_enabled?` to use the name `federation_enabled?` to specify if the federation is enabled or disabled from the config file.
- Check if there's in the config file a portal that has an `api` and an `api_key`, if no one is found then we set the federation to disabled.
- If the federation is disabled then we don't display the federation inputs in search and browser pages