### PR TITLE
Fix: Jump to infinit loading

### DIFF
--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -48,7 +48,8 @@ class SearchController < ApplicationController
       params.delete("ontologies")
     end
     search_page = LinkedData::Client::Models::Class.search(params[:q], params)
-    @results = search_page.collection
+
+    @results = search_page[:collection]
 
     response = ""
     obsolete_response = ""

--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -26,7 +26,7 @@ class SearchController < ApplicationController
     @time = Benchmark.realtime do
       results = LinkedData::Client::Models::Class.search(@search_query, params)
       @federation_errors = federation_error(results) if federation_error?(results)
-      results = results[:collection]
+      results = results.collection
 
 
       @search_results = aggregate_results(@search_query, results)
@@ -49,7 +49,7 @@ class SearchController < ApplicationController
     end
     search_page = LinkedData::Client::Models::Class.search(params[:q], params)
 
-    @results = search_page[:collection]
+    @results = search_page.collection
 
     response = ""
     obsolete_response = ""


### PR DESCRIPTION
Require: https://github.com/ontoportal-lirmm/ontologies_api_ruby_client/pull/21

Source: https://github.com/agroportal/project-management/issues/619

**PR description**
After adding the federation to the search, the search results are now returned as a hash instead of an object, so to access to the collection key of the results we need to use `[:collection]` instead of `.collection`