### PR TITLE
Fix: Put back category chip component alias to group chip component

### DIFF
--- a/app/helpers/components_helper.rb
+++ b/app/helpers/components_helper.rb
@@ -34,6 +34,7 @@ module ComponentsHelper
                     checked: checked,
                     value: value, tooltip: title, disabled: disabled, &block)
   end
+  alias  :category_chip_component :group_chip_component
 
   def rdf_highlighter_container(format, content)
     render Display::RdfHighlighterComponent.new(format: format, text: content)


### PR DESCRIPTION
Source: https://github.com/agroportal/project-management/issues/619

### PR description
Put back `category chip component` and `group chip component` that are deleted in a code cleaning activity by mistake, and this caused breaking upload ontology page that is still using them.