### PR TITLE
Fix: ontology collections tree raising an exception

### DIFF
--- a/app/helpers/collections_helper.rb
+++ b/app/helpers/collections_helper.rb
@@ -1,4 +1,5 @@
 module CollectionsHelper
+  include MultiLanguagesHelper
 
 
   def get_collections(ontology, add_colors: false)


### PR DESCRIPTION
Related issue: https://github.com/agroportal/project-management/issues/619

**Issue screenshot**
<img width="1248" alt="image" src="https://github.com/user-attachments/assets/fe79d67e-9381-4421-91ba-05903fb96b6e">


**Issue log**
<img width="892" alt="image" src="https://github.com/user-attachments/assets/814e7d17-c968-4667-8b75-c501361d08e4">


**Changes**
- Include `MultiLanguagesHelper` in `CollectionsHelper` to make sure that `main_language_label` function that is used in `get_collections` function in `CollectionsHelper` is defined.

**Fix screenshot**
<img width="1316" alt="image" src="https://github.com/user-attachments/assets/6ac95578-52f6-486d-910e-c23248251f6c">
