### PR TITLE
Fix: Improve concepts tree performance

### DIFF
--- a/app/controllers/concepts_controller.rb
+++ b/app/controllers/concepts_controller.rb
@@ -45,14 +45,15 @@ class ConceptsController < ApplicationController
     @ontology = LinkedData::Client::Models::Ontology.find_by_acronym(params[:ontology]).first
     @ob_instructions = helpers.ontolobridge_instructions_template(@ontology)
 
-    @submission = @ontology.explore.latest_submission(include: 'all')
+    @submission = @ontology.explore.latest_submission(include:'uriRegexPattern,preferredNamespaceUri')
 
-    @concept = @ontology.explore.single_class({full: true}, params[:id])
+    @concept = @ontology.explore.single_class({dispay: 'prefLabel'}, params[:id])
+
     concept_not_found(params[:id]) if @concept.nil?
     @schemes = params[:concept_schemes].split(',')
 
     @concept.children = @concept.explore.children(pagesize: 750, concept_schemes: Array(@schemes).join(','), language: request_lang, display: 'prefLabel,obsolete,hasChildren').collection || []
-    @concept.children.sort! { |x, y| (x.prefLabel || "").downcase <=> (y.prefLabel || "").downcase } unless @concept.children.empty?
+
     render turbo_stream: [
       replace(helpers.child_id(@concept) + '_open_link') { TreeLinkComponent.tree_close_icon },
       replace(helpers.child_id(@concept) + '_childs') do


### PR DESCRIPTION
### PR description
This PR provides partial improvements to the tree view performance. However, the primary bottleneck is in the backend, which requires specific endpoints optimized for the tree view, rather than relying on the default concept endpoints. 


### Changes

- **Optimized data retrieval in `ConceptsController#index`:**
The most time-consuming call when expanding a subtree is `@concept = @ontology.explore.single_class({full: true}, params[:id])`
In this PR, it has been updated to `@concept = @ontology.explore.single_class({display: 'prefLabel'}, params[:id])`, as only the prefLabel and id are necessary at this level.
_(Note: This change provides a slight improvement in response time but does not fully resolve the delay.)_

- **Removed redundant sorting:**
Sorting of concept children was duplicated both in the controller and in the component, adding approximately 1 second to load time.





