### PR TITLE
Fix: Disable slices not hiding the slices section in the home page 

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -121,6 +121,9 @@ module ApplicationHelper
     onts_for_select
   end
 
+  def slices_enabled?
+    $ENABLE_SLICES.eql?(true)
+  end
 
   def at_slice?
     !@subdomain_filter.nil? && !@subdomain_filter[:active].nil? && @subdomain_filter[:active] == true

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -107,14 +107,14 @@ module ApplicationHelper
   end
 
   def onts_for_select(include_views: false)
-    ontologies ||= LinkedData::Client::Models::Ontology.all({include: "acronym,name", include_views: include_views})
+    ontologies ||= LinkedData::Client::Models::Ontology.all({include: "acronym,name,viewOf", include_views: include_views})
     onts_for_select = [['', '']]
     ontologies.each do |ont|
       next if ( ont.acronym.nil? or ont.acronym.empty? )
       acronym = ont.acronym
       name = ont.name
       abbreviation = acronym.empty? ? "" : "(#{acronym})"
-      ont_label = "#{name.strip} #{abbreviation}"
+      ont_label = "#{name.strip} #{abbreviation}#{ont.viewOf ? ' [view]' : ''}"
       onts_for_select << [ont_label, acronym]
     end
     onts_for_select.sort! { |a,b| a[0].downcase <=> b[0].downcase }

--- a/app/views/home/index.html.haml
+++ b/app/views/home/index.html.haml
@@ -176,7 +176,7 @@
       .home-statistics-link.justify-content-end{style: @analytics.empty? && "visibility: hidden"}
         = link_to t("home.see_details"),'/statistics', target: "_blank"
 
-  - if @slices
+  - if slices_enabled?
     .home-section
       .home-section-title
         .text

--- a/app/views/ontologies/ontologies_selector/ontologies_selector_results.html.haml
+++ b/app/views/ontologies/ontologies_selector/ontologies_selector_results.html.haml
@@ -2,7 +2,7 @@
     .ontologies-selector-results
         .horizontal-line                  
         .results-number
-            = t("ontologies.showing_ontologies_size", ontologies_size: @ontologies.length, analytics_size: @total_ontologies_number)
+            = t("ontologies.showing_ontologies_size", ontologies_size: @ontologies.length, analytics_size: @total_ontologies_number, portals: portal_name)
             %span.select-all{'data-action': 'click->ontologies-selector#selectall'}
                 = t('ontologies_selector.select_all')
         .ontologies


### PR DESCRIPTION
When we disable the slices using `$ENABLE_SLICES=false` in the config files we still see in the home page the slices section. This PR prevents that. 