### PR TITLE
Fix: Browse page switch style, and don't display current portal name button in browse results

### DIFF
--- a/app/assets/stylesheets/browse.scss
+++ b/app/assets/stylesheets/browse.scss
@@ -266,6 +266,9 @@
   z-index: 1;
 
 }
+.browse-filter .switch-filter > p, .switch-filter > div{
+  max-width: 207px;
+}
 
 .browse-search-bar input:focus {
   box-shadow: rgba(100, 100, 111, 0.2) 0px 7px 29px 0px;

--- a/app/assets/stylesheets/components/switch.scss
+++ b/app/assets/stylesheets/components/switch.scss
@@ -9,6 +9,7 @@
   color: #666666;
   margin-bottom: 0;
   margin-right: 10px;
+  max-width: 207px;
 }
 
 

--- a/app/assets/stylesheets/components/switch.scss
+++ b/app/assets/stylesheets/components/switch.scss
@@ -9,7 +9,6 @@
   color: #666666;
   margin-bottom: 0;
   margin-right: 10px;
-  max-width: 207px;
 }
 
 

--- a/app/controllers/concerns/submission_filter.rb
+++ b/app/controllers/concerns/submission_filter.rb
@@ -72,7 +72,7 @@ module SubmissionFilter
     submissions.group_by { |x| x[:ontology]&.acronym }.each do |acronym, ontologies|
       ontology = canonical_ontology(ontologies)
       ontology[:sources] = ontologies.map { |x| x[:id] }
-      ontology[:sources].reject! { |id| id.include?(portal_name.downcase) }
+      ontology[:sources].reject! { |id| id.include?(portal_name.downcase) } if ontology[:sources].size.eql?(1)
       merged_submissions << ontology
     end
     merged_submissions

--- a/app/controllers/concerns/submission_filter.rb
+++ b/app/controllers/concerns/submission_filter.rb
@@ -72,6 +72,7 @@ module SubmissionFilter
     submissions.group_by { |x| x[:ontology]&.acronym }.each do |acronym, ontologies|
       ontology = canonical_ontology(ontologies)
       ontology[:sources] = ontologies.map { |x| x[:id] }
+      ontology[:sources].reject! { |id| id.include?(portal_name.downcase) }
       merged_submissions << ontology
     end
     merged_submissions


### PR DESCRIPTION
Related issue: https://github.com/ontoportal-lirmm/bioportal_web_ui/issues/827

### Changes
- Fix broken switch style when using a long text beside it (https://github.com/ontoportal-lirmm/bioportal_web_ui/commit/39a93873f41fcc8150a8ed0531bf45c79ef816cf)
<img width="850" alt="image" src="https://github.com/user-attachments/assets/ff27fa4e-e430-4179-ad16-416f49096fb1">

- Don't display current portal button in browse page results (https://github.com/ontoportal-lirmm/bioportal_web_ui/commit/c8ad07ae28fed1d76cf44c681f6a82838d3d4a22)

**Before**
<img width="835" alt="image" src="https://github.com/user-attachments/assets/70ef3c56-7b6d-46b1-a0fe-9d36214bf36e">

**After**
<img width="835" alt="image" src="https://github.com/user-attachments/assets/6222fdfe-f32d-45de-a54f-fe1e2934de25">
