### PR TITLE
Fix: Agent search not working well 

### DIFF
--- a/app/controllers/agents_controller.rb
+++ b/app/controllers/agents_controller.rb
@@ -18,7 +18,7 @@ class AgentsController < ApplicationController
   end
 
   def ajax_agents
-    filters = { query: params[:query], qf: "identifiers_texts^20 acronym_text^15 name_text^10 email_text^10"}
+    filters = { query: "#{params[:query]}*", qf: "identifiers_texts^20 acronym_text^15 name_text^10 email_text^10"}
     @agents = LinkedData::Client::HTTP.get('/search/agents', filters)
     agents_json = @agents.collection.map do |x|
       {


### PR DESCRIPTION
Related issue: https://github.com/ontoportal-lirmm/bioportal_web_ui/issues/799

### Changes
- Add `*` to the agents search query (https://github.com/ontoportal-lirmm/bioportal_web_ui/commit/688466f37eb82f3082dbf3424481d9d29b92baed)