### PR TITLE
Fix: Watch button count and state

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -175,10 +175,9 @@ module ApplicationHelper
   end
 
   def subscribed_to_ontology?(ontology_acronym, user)
-    user = LinkedData::Client::Models::User.find(user.username, {include: 'subscription'}) if user.subscription.nil?
+    user = LinkedData::Client::Models::User.find(user.username, {include: 'all'}) if user.subscription.nil?
     return false if user.subscription.nil? or user.subscription.empty?
     user.subscription.each do |sub|
-      #sub = {ontology: ontology_acronym, notification_type: "NOTES"}
       sub_ont_acronym = sub[:ontology] ?  sub[:ontology].split('/').last : nil #  make sure we get the acronym, even if it's a full URI
       return true if sub_ont_acronym == ontology_acronym
     end

--- a/app/helpers/ontologies_helper.rb
+++ b/app/helpers/ontologies_helper.rb
@@ -627,7 +627,7 @@ module OntologiesHelper
 
   def count_subscriptions(ontology_id)
     ontology_id = ontology_id.split('/').last
-    users = LinkedData::Client::Models::User.all(include: 'subscription', display_context: false, display_links: false)
+    users = LinkedData::Client::Models::User.all(include: 'all', display_context: false, display_links: false)
     users.select { |u| u.subscription.find { |s| s.ontology && s.ontology.split('/').last.eql?(ontology_id) } }.count
   end
 


### PR DESCRIPTION
Related issue: https://github.com/ontoportal-lirmm/bioportal_web_ui/issues/819


**Source of issue**
To get the subscriptions of a user we used to the the call with the param `?include=subscription` which used to display the users with their subscription list that includes ontologies acronyms, but after idk what we did in the back side the same call gives us a result like this one

<img width="1344" alt="image" src="https://github.com/user-attachments/assets/1946ed8e-4d67-4b93-8b76-c258f7582e27">

**The solution is** to do `include=all` and this is the result of it
<img width="1344" alt="image" src="https://github.com/user-attachments/assets/53274916-1d34-46b6-91f9-733c715f5acc">


### Demo

https://github.com/user-attachments/assets/618f2f88-4a06-4e1a-b40d-932540b5ecc1



