### PR TITLE
Fix: Notes buttons showing, some properties details, and no collection selection  showing content missing or an error alert

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -129,7 +129,7 @@ module ApplicationHelper
 
   def add_comment_button(parent_id, parent_type)
     if session[:user].nil?
-      link_to t('application.add_comment'),  login_index_path(redirect: request.url), class: "secondary-button regular-button slim"
+      link_to t('application.add_comment'),  login_index_path(redirect: request.url), class: "secondary-button regular-button slim", data: {'turbo-frame': '_top'}
     else
       link_to_modal t('application.add_comment'), notes_new_comment_path(parent_id: parent_id, parent_type: parent_type, ontology_id: @ontology.acronym),
                     class: "secondary-button regular-button slim", data: { show_modal_title_value: t('application.add_new_comment')}
@@ -146,7 +146,7 @@ module ApplicationHelper
 
   def add_proposal_button(parent_id, parent_type)
     if session[:user].nil?
-      link_to t('application.add_proposal'),  login_index_path(redirect: request.url), class: "secondary-button regular-button slim"
+      link_to t('application.add_proposal'),  login_index_path(redirect: request.url), class: "secondary-button regular-button slim",  data: {'turbo-frame': '_top'}
     else
       link_to_modal t('application.add_proposal'), notes_new_proposal_path(parent_id: parent_id, parent_type: parent_type, ontology_id: @ontology.acronym),
                     class: "secondary-button regular-button slim", data: { show_modal_title_value: t('application.add_new_proposal')}

--- a/app/helpers/components_helper.rb
+++ b/app/helpers/components_helper.rb
@@ -280,8 +280,8 @@ module ComponentsHelper
     end
   end
 
-  def form_save_button
-    render Buttons::RegularButtonComponent.new(id: 'save-button', value: t('components.save_button'), variant: "primary", size: "slim", type: "submit") do |btn|
+  def form_save_button(enable_loading: true)
+    render Buttons::RegularButtonComponent.new(id: 'save-button', value: t('components.save_button'), variant: "primary", size: "slim", type: "submit", state: enable_loading ? 'animate' : '') do |btn|
       btn.icon_left do
         inline_svg_tag "check.svg"
       end

--- a/app/helpers/ontologies_helper.rb
+++ b/app/helpers/ontologies_helper.rb
@@ -529,12 +529,15 @@ module OntologiesHelper
 
   def ontology_object_details_component(frame_id: , ontology_id:, objects_title:, object:, &block)
     render TurboFrameComponent.new(id: frame_id, data: {"turbo-frame-target": "frame"}) do
-      return if !object.present?
-      return alert_component(object.errors.join) if object.errors
+      return unless object.present?
 
-      ontology_object_tabs_component(ontology_id: ontology_id, objects_title: objects_title, object_id: object["@id"]) do |tabs|
-        tab_item_component(container_tabs: tabs, title: t('concepts.details'), path: '#details', selected: true) do
-          capture(&block)
+      if object.errors
+        alert_component(object.errors.join)
+      else
+        ontology_object_tabs_component(ontology_id: ontology_id, objects_title: objects_title, object_id: object["@id"]) do |tabs|
+          tab_item_component(container_tabs: tabs, title: t('concepts.details'), path: '#details', selected: true) do
+            capture(&block)
+          end
         end
       end
     end

--- a/app/views/concepts/_list.html.haml
+++ b/app/views/concepts/_list.html.haml
@@ -10,6 +10,9 @@
       = render TreeLinkComponent.new(child: concept, href: href,
           children_href: '#', selected: concept.id.eql?(concepts.first.id) && c.auto_click?,
           target_frame: 'concept_show', data: data, is_reused: concept_reused?(submission: @submission, concept_id: concept.id))
-  - c.error do
-    = t('concepts.list_error')
 
+  - c.error do
+    - if @collection.nil?
+      = t("ontologies.concepts_browsers.select_collection")
+    - else
+      = t('concepts.list_error')

--- a/app/views/notes/_new_comment.html.haml
+++ b/app/views/notes/_new_comment.html.haml
@@ -11,4 +11,4 @@
       %div.form-group
         %textarea.form-control.reply_body{cols: "1", name: "body", required: true, placeholder: t('notes.new_comment.comment'), rows: "1", style: "height: 100px;", tabindex: "0"}
 
-      = submit_tag t('notes.new_comment.save') , class:'btn btn-success btn-block'
+      = form_save_button(enable_loading: false)

--- a/app/views/notes/_new_proposal.html.haml
+++ b/app/views/notes/_new_proposal.html.haml
@@ -50,4 +50,4 @@
       .form-group
         = text_field_tag 'proposal[parent]','', placeholder: t('notes.new_proposal.parent'), class: "form-control", required: true
 
-    = submit_tag t('notes.new_proposal.save') , class:'btn btn-success btn-block'
+    = form_save_button(enable_loading: false)


### PR DESCRIPTION
Fix https://github.com/ontoportal-lirmm/bioportal_web_ui/issues/817, https://github.com/ontoportal-lirmm/bioportal_web_ui/issues/813, https://github.com/ontoportal-lirmm/bioportal_web_ui/issues/818 and https://github.com/ontoportal-lirmm/bioportal_web_ui/issues/796

### Changes

- Enforce add comment and proposal buttons to use turbo top frame (https://github.com/ontoportal-lirmm/bioportal_web_ui/commit/8a4b78f8050e1193aa966b912c59841bcb5f80c1) to resolve https://github.com/ontoportal-lirmm/bioportal_web_ui/issues/817

- Fix property content missing message (https://github.com/ontoportal-lirmm/bioportal_web_ui/pull/846/commits/ce948aaceff4f179182787e37e082f797129518e) to resolve https://github.com/ontoportal-lirmm/bioportal_web_ui/issues/796

![image](https://github.com/user-attachments/assets/4c68e049-7371-40b3-bc06-2b377841d02a)


- Make the notes form use the correct button components (https://github.com/ontoportal-lirmm/bioportal_web_ui/commit/3983accdd83211aff9706142ee12698f7b2ca2bf)   to resolve https://github.com/ontoportal-lirmm/bioportal_web_ui/issues/813
![image](https://github.com/user-attachments/assets/18b98ee3-8e5d-4af5-a3b7-9a4bfa6a4295)

- Fix not selecting a collection message error (https://github.com/ontoportal-lirmm/bioportal_web_ui/pull/846/commits/ae4a92b4de97401bee922996d3e39e21c1f99b8a) to resolve https://github.com/ontoportal-lirmm/bioportal_web_ui/issues/818
![image](https://github.com/user-attachments/assets/e609e365-8c9b-4925-a413-94721509c336)
