### PR TITLE
Fix: Improve taxonomy page, fix static portal name, detect description link

### DIFF
--- a/app/assets/stylesheets/taxonomy.scss
+++ b/app/assets/stylesheets/taxonomy.scss
@@ -63,7 +63,18 @@
 }
 .taxonomy-card .description{
     color: #666666;
-    padding-bottom: 5px;
+}
+
+.taxonomy-card .descriptionlink svg{
+    margin: 0px 2px;
+    height: 19px;
+}
+
+.taxonomy-card .descriptionlink svg path{
+    fill: #666666;
+}
+.category-link{
+    color: #666666 !important;
 }
 .taxonomy-slice-svg{
     width: 35px;

--- a/app/components/display/taxonomy_card_component.rb
+++ b/app/components/display/taxonomy_card_component.rb
@@ -1,5 +1,5 @@
 class Display::TaxonomyCardComponent < ViewComponent::Base
-  require 'uri'
+  include UrlsHelper
   def initialize(taxonomy: , ontologies_names: )
     @taxonomy = taxonomy
     @ontologies_names = ontologies_names
@@ -7,10 +7,5 @@ class Display::TaxonomyCardComponent < ViewComponent::Base
 
   def reveal_id
     @taxonomy.id
-  end
-
-  def description_is_url?
-    uri_regex = URI::DEFAULT_PARSER.make_regexp
-    @taxonomy.description.match?(/\A#{uri_regex}\z/)
   end
 end

--- a/app/components/display/taxonomy_card_component.rb
+++ b/app/components/display/taxonomy_card_component.rb
@@ -1,4 +1,5 @@
 class Display::TaxonomyCardComponent < ViewComponent::Base
+  require 'uri'
   def initialize(taxonomy: , ontologies_names: )
     @taxonomy = taxonomy
     @ontologies_names = ontologies_names
@@ -6,5 +7,10 @@ class Display::TaxonomyCardComponent < ViewComponent::Base
 
   def reveal_id
     @taxonomy.id
+  end
+
+  def description_is_url?
+    uri_regex = URI::DEFAULT_PARSER.make_regexp
+    @taxonomy.description.match?(/\A#{uri_regex}\z/)
   end
 end

--- a/app/components/display/taxonomy_card_component/taxonomy_card_component.html.haml
+++ b/app/components/display/taxonomy_card_component/taxonomy_card_component.html.haml
@@ -4,12 +4,22 @@
       = "#{@taxonomy.name} (#{@taxonomy.acronym})"
     %a{href: "https://#{@taxonomy.acronym}.#{$UI_URL.sub("https://", "")}"}
       = inline_svg_tag('icons/slices.svg', class: "taxonomy-slice-svg #{@taxonomy.is_slice ? '' : 'd-none'}")
+  
+  - if description_is_url?
+    .descriptionlink
+      %a.category-link{href: @taxonomy.description, target: '_blank'}
+        = @taxonomy.description
+        = inline_svg_tag 'icons/external-link.svg'
+  
   %a.ontologies{href: "/ontologies?#{@taxonomy.id.split('/')[-2]}=#{@taxonomy.acronym}"}
     = inline_svg_tag('icons/ontology.svg')
     .number-of-ontologies
       = "#{@taxonomy.ontologies.length} ontologies"
-  .description
-    = render TextAreaFieldComponent.new(value: @taxonomy.description)
+
+  - unless description_is_url?
+    .description.mb-1
+      = render TextAreaFieldComponent.new(value: @taxonomy.description)
+
   .ontologies-cards
     - @taxonomy.ontologies.each_with_index do |ontology, index|
       - if index>10

--- a/app/components/display/taxonomy_card_component/taxonomy_card_component.html.haml
+++ b/app/components/display/taxonomy_card_component/taxonomy_card_component.html.haml
@@ -5,7 +5,7 @@
     %a{href: "https://#{@taxonomy.acronym}.#{$UI_URL.sub("https://", "")}"}
       = inline_svg_tag('icons/slices.svg', class: "taxonomy-slice-svg #{@taxonomy.is_slice ? '' : 'd-none'}")
   
-  - if description_is_url?
+  - if link?(@taxonomy.description)
     .descriptionlink
       %a.category-link{href: @taxonomy.description, target: '_blank'}
         = @taxonomy.description
@@ -16,7 +16,7 @@
     .number-of-ontologies
       = "#{@taxonomy.ontologies.length} ontologies"
 
-  - unless description_is_url?
+  - unless link?(@taxonomy.description)
     .description.mb-1
       = render TextAreaFieldComponent.new(value: @taxonomy.description)
 

--- a/app/views/taxonomy/index.html.haml
+++ b/app/views/taxonomy/index.html.haml
@@ -5,7 +5,7 @@
                 = t('taxonomy.groups_and_categories')
             .line
         .taxonomy-page-decription
-            = t('taxonomy.description')
+            = t('taxonomy.description', portal: portal_name)
 
         = render TabsContainerComponent.new do |c|
             - c.item(title: 'Groups', selected: !@category_section_active)

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1478,7 +1478,7 @@ en:
     privacy_policy_anchor: "#h-privacy-policy"
   taxonomy:
     groups_and_categories: Groups and Categories
-    description: "In %{portal}, ontologies are organized in groups and tagged with categories. Typically, groups associate ontologies from the same project or organization for better identification of the provenance. Whereas categories are about subjects/topics and enable to classify ontologies. As of 2016, AgroPortal's categories were established in cooperation with FAO AIMS. In 2024, we moved to UNESCO Thesaurus (https://vocabularies.unesco.org). Groups and categories, along with other metadata, can be used on the “Browse” page of AgroPortal to filter out the list of ontologies."
+    description: "In %{portal}, ontologies are organized in groups and tagged with categories. Typically, groups associate ontologies from the same project or organization for better identification of the provenance. Whereas categories are about subjects/topics and enable to classify ontologies. As of 2016, %{portal}'s categories were established in cooperation with FAO AIMS. In 2024, we moved to UNESCO Thesaurus (https://vocabularies.unesco.org). Groups and categories, along with other metadata, can be used on the “Browse” page of %{portal} to filter out the list of ontologies."
     show_sub_categories: Show sub categories
 
   federation:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1478,7 +1478,7 @@ en:
     privacy_policy_anchor: "#h-privacy-policy"
   taxonomy:
     groups_and_categories: Groups and Categories
-    description: In AgroPortal, ontologies are organized in groups and tagged with categories. Typically, groups associate ontologies from the same project or organization for better identification of the provenance. Whereas categories are about subjects/topics and enable to classify ontologies. As of 2016, AgroPortal's categories were established in cooperation with FAO AIMS. In 2024, we moved to UNESCO nomenclature for fields of science and technology. Groups and categories, along with other metadata, can be used on the “Browse” page of AgroPortal to filter out the list of ontologies.
+    description: "In %{portal}, ontologies are organized in groups and tagged with categories. Typically, groups associate ontologies from the same project or organization for better identification of the provenance. Whereas categories are about subjects/topics and enable to classify ontologies. As of 2016, AgroPortal's categories were established in cooperation with FAO AIMS. In 2024, we moved to UNESCO nomenclature for fields of science and technology. Groups and categories, along with other metadata, can be used on the “Browse” page of AgroPortal to filter out the list of ontologies."
     show_sub_categories: Show sub categories
 
   federation:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1478,7 +1478,7 @@ en:
     privacy_policy_anchor: "#h-privacy-policy"
   taxonomy:
     groups_and_categories: Groups and Categories
-    description: "In %{portal}, ontologies are organized in groups and tagged with categories. Typically, groups associate ontologies from the same project or organization for better identification of the provenance. Whereas categories are about subjects/topics and enable to classify ontologies. As of 2016, AgroPortal's categories were established in cooperation with FAO AIMS. In 2024, we moved to UNESCO nomenclature for fields of science and technology. Groups and categories, along with other metadata, can be used on the “Browse” page of AgroPortal to filter out the list of ontologies."
+    description: "In %{portal}, ontologies are organized in groups and tagged with categories. Typically, groups associate ontologies from the same project or organization for better identification of the provenance. Whereas categories are about subjects/topics and enable to classify ontologies. As of 2016, AgroPortal's categories were established in cooperation with FAO AIMS. In 2024, we moved to UNESCO Thesaurus (https://vocabularies.unesco.org). Groups and categories, along with other metadata, can be used on the “Browse” page of AgroPortal to filter out the list of ontologies."
     show_sub_categories: Show sub categories
 
   federation:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -1514,7 +1514,7 @@ fr:
     privacy_policy_anchor: "#h-vie-privee"
   taxonomy:
     groups_and_categories: Groupes et Catégories
-    description: "Dans %{portal}, les ontologies sont organisées en groupes et étiquetées avec des catégories. Typiquement, les groupes associent des ontologies provenant du même projet ou de la même organisation pour une meilleure identification de la provenance. Tandis que les catégories concernent des sujets/thématiques et permettent de classifier les ontologies. En 2016, les catégories d'AgroPortal ont été établies en coopération avec FAO AIMS. En 2024, nous sommes passés à la nomenclature de l'UNESCO pour les domaines des sciences et des technologies. Les groupes et les catégories, ainsi que d'autres métadonnées, peuvent être utilisés sur la page “Parcourir” d'AgroPortal pour filtrer la liste des ontologies."
+    description: "Dans %{portal}, les ontologies sont organisées en groupes et étiquetées avec des catégories. Typiquement, les groupes associent des ontologies provenant du même projet ou de la même organisation pour une meilleure identification de la provenance. Tandis que les catégories concernent des sujets/thématiques et permettent de classifier les ontologies. En 2016, les catégories d'AgroPortal ont été établies en coopération avec FAO AIMS. En 2024, nous sommes passés au Thésaurus de l'UNESCO (https://vocabularies.unesco.org). Les groupes et les catégories, ainsi que d'autres métadonnées, peuvent être utilisés sur la page “Parcourir” d'AgroPortal pour filtrer la liste des ontologies."
     show_sub_categories: Afficher les sous-catégories
   federation:
     results_from_external_portals: Résultats provenant de portails externes

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -1514,7 +1514,7 @@ fr:
     privacy_policy_anchor: "#h-vie-privee"
   taxonomy:
     groups_and_categories: Groupes et Catégories
-    description: "Dans %{portal}, les ontologies sont organisées en groupes et étiquetées avec des catégories. Typiquement, les groupes associent des ontologies provenant du même projet ou de la même organisation pour une meilleure identification de la provenance. Tandis que les catégories concernent des sujets/thématiques et permettent de classifier les ontologies. En 2016, les catégories d'AgroPortal ont été établies en coopération avec FAO AIMS. En 2024, nous sommes passés au Thésaurus de l'UNESCO (https://vocabularies.unesco.org). Les groupes et les catégories, ainsi que d'autres métadonnées, peuvent être utilisés sur la page “Parcourir” d'AgroPortal pour filtrer la liste des ontologies."
+    description: "Dans %{portal}, les ontologies sont organisées en groupes et étiquetées avec des catégories. Typiquement, les groupes associent des ontologies provenant du même projet ou de la même organisation pour une meilleure identification de la provenance. Tandis que les catégories concernent des sujets/thématiques et permettent de classifier les ontologies. En 2016, les catégories d'%{portal} ont été établies en coopération avec FAO AIMS. En 2024, nous sommes passés au Thésaurus de l'UNESCO (https://vocabularies.unesco.org). Les groupes et les catégories, ainsi que d'autres métadonnées, peuvent être utilisés sur la page “Parcourir” d'%{portal} pour filtrer la liste des ontologies."
     show_sub_categories: Afficher les sous-catégories
   federation:
     results_from_external_portals: Résultats provenant de portails externes

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -1514,7 +1514,7 @@ fr:
     privacy_policy_anchor: "#h-vie-privee"
   taxonomy:
     groups_and_categories: Groupes et Catégories
-    description: Dans AgroPortal, les ontologies sont organisées en groupes et étiquetées avec des catégories. Typiquement, les groupes associent des ontologies provenant du même projet ou de la même organisation pour une meilleure identification de la provenance. Tandis que les catégories concernent des sujets/thématiques et permettent de classifier les ontologies. En 2016, les catégories d'AgroPortal ont été établies en coopération avec FAO AIMS. En 2024, nous sommes passés à la nomenclature de l'UNESCO pour les domaines des sciences et des technologies. Les groupes et les catégories, ainsi que d'autres métadonnées, peuvent être utilisés sur la page “Parcourir” d'AgroPortal pour filtrer la liste des ontologies.
+    description: "Dans %{portal}, les ontologies sont organisées en groupes et étiquetées avec des catégories. Typiquement, les groupes associent des ontologies provenant du même projet ou de la même organisation pour une meilleure identification de la provenance. Tandis que les catégories concernent des sujets/thématiques et permettent de classifier les ontologies. En 2016, les catégories d'AgroPortal ont été établies en coopération avec FAO AIMS. En 2024, nous sommes passés à la nomenclature de l'UNESCO pour les domaines des sciences et des technologies. Les groupes et les catégories, ainsi que d'autres métadonnées, peuvent être utilisés sur la page “Parcourir” d'AgroPortal pour filtrer la liste des ontologies."
     show_sub_categories: Afficher les sous-catégories
   federation:
     results_from_external_portals: Résultats provenant de portails externes


### PR DESCRIPTION
Fix: https://github.com/ontoportal-lirmm/bioportal_web_ui/issues/788

### Changes
- Detect if the taxonomy description is a link and handle that (https://github.com/ontoportal-lirmm/bioportal_web_ui/commit/b961561ddc8d528c28f2d9eff7dbcc8d1bebd289)
<img width="1712" alt="image" src="https://github.com/user-attachments/assets/9f459d5f-37ca-4844-be4d-8e596c208f13">

If it's not a link we keep the default behavior
<img width="1712" alt="image" src="https://github.com/user-attachments/assets/c43a44f0-2187-4d22-a7c2-51de71500d3a">


- Make portal name dynamic in taxonomy page description (https://github.com/ontoportal-lirmm/bioportal_web_ui/commit/7c432791635c61154fa826d42d32974fcb623483)

- Retouch taxonomy page description to replace "In 2024, we moved to UNESCO nomenclature for fields of science and technology" by "In 2024, we moved to UNESCO Thesaurus (https://vocabularies.unesco.org/)." (https://github.com/ontoportal-lirmm/bioportal_web_ui/commit/2606cbe04a246218d6b35d1f0a56783a2791874f)
