### PR TITLE
Fix: Prevent display home portal tooltip if we get a non complete response

### DIFF
--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -48,10 +48,10 @@ class HomeController < ApplicationController
     @config = $PORTALS_INSTANCES.select { |x| x[:name].downcase.eql?((params[:portal] || helpers.portal_name).downcase) }.first
     if @config && @config[:api]
       @portal_config = LinkedData::Client::Models::Ontology.top_level_links(@config[:api]).to_h
-      return @portal_config = {} if @portal_config.any?{|_, value| value.blank?}
-      return @portal_config
+      @color = @portal_config[:color].present? ? @portal_config[:color] : @config[:color]
+      @name = @portal_config[:title].present? ? @portal_config[:title] : @config[:name]
     else
-      return @portal_config = {}
+      @portal_config = {}
     end
   end
 

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -48,8 +48,10 @@ class HomeController < ApplicationController
     @config = $PORTALS_INSTANCES.select { |x| x[:name].downcase.eql?((params[:portal] || helpers.portal_name).downcase) }.first
     if @config && @config[:api]
       @portal_config = LinkedData::Client::Models::Ontology.top_level_links(@config[:api]).to_h
+      return @portal_config = {} if @portal_config.any?{|_, value| value.blank?}
+      return @portal_config
     else
-      @portal_config = {}
+      return @portal_config = {}
     end
   end
 

--- a/app/views/home/portal_config.html.haml
+++ b/app/views/home/portal_config.html.haml
@@ -4,21 +4,21 @@
       .div.d-flex.align-items-center
         %div
           %div.text-center
-            = link_to @portal_config[:ui] || @config[:ui], target: '_blank', class: 'home-logo-instances mr-1 m-0', style: "background-color: #{@portal_config[:color] || @config[:color]}" do
+            = link_to @portal_config[:ui] || @config[:ui], target: '_blank', class: 'home-logo-instances mr-1 m-0', style: "background-color: #{@color}" do
               = inline_svg 'logo-white.svg', width: "35", height: "26"
         %div
-          %div.portal-configuration-title{style: "color: #{@portal_config[:color] || @config[:color]}"}
+          %div.portal-configuration-title{style: "color: #{@color}"}
             %h3
-              = @portal_config[:title] || @config[:name]
+              = @name
             - if  @portal_config[:numberOfArtefacts]
               .portal-config-ontologies
                 = inline_svg_tag 'icons/ontology.svg'
                 %span
                   = "#{@portal_config[:numberOfArtefacts]} ontologies"
-    - if @portal_config[:description]
+    - if @portal_config[:description].present?
       .portal-description
         = @portal_config[:description]
-    - if @portal_config[:federated_portals]
+    - if @portal_config[:federated_portals].present?
       %div.mb-1
         .home-section-title
           .text
@@ -31,7 +31,7 @@
               %p{style: "color: #{portal[:color]}"}
                 = portal[:name]
 
-    - if @portal_config[:fundedBy]
+    - if @portal_config[:fundedBy].present?
       %div.mb-1
         .home-section-title
           .portal-config-title-text


### PR DESCRIPTION
Fix: https://github.com/ontoportal-lirmm/bioportal_web_ui/issues/835

Before:
![image](https://github.com/user-attachments/assets/1ef800a0-2857-479f-a37b-ba86d10b51d2)


After:
![image](https://github.com/user-attachments/assets/4650f8c6-6ba3-488d-a436-fcedc1de11d7)
