### PR TITLE
Fix: `Tree View` Prevent word break for the  elements

### DIFF
--- a/app/assets/stylesheets/components/tree_view.scss
+++ b/app/assets/stylesheets/components/tree_view.scss
@@ -35,7 +35,6 @@ padding:0;
 a.tree-link {
     display: inline-block;
     padding: 5px;
-    word-break: break-all;
     text-wrap: wrap;
     color: var(--primary-color) !important;
 }


### PR DESCRIPTION
**Fix:** https://github.com/agroportal/project-management/issues/632

### Changes
- Prevent word break for the tree view elements (https://github.com/ontoportal-lirmm/bioportal_web_ui/commit/d366f2c8a44dfb37162a2a11ca56c359f807da8e)

### Screenshot
<img width="1263" alt="image" src="https://github.com/user-attachments/assets/6fafc214-e0c1-4b70-bf1d-f6618bb0ae4b">
