### PR TITLE
Fix: Taxonomy empty list

### DIFF
--- a/app/assets/stylesheets/taxonomy.scss
+++ b/app/assets/stylesheets/taxonomy.scss
@@ -109,4 +109,21 @@
     background-color: var(--primary-color);
 }
 
+.taxonomy-empty-illustration{
+    display: flex;
+    gap: 15px;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    width: 100%;
+    margin-top: 40px;
+}
+
+.taxonomy-empty-illustration-text{
+    color: var(--gray-color);
+
+}
+.taxonomy-empty-illustration-button{
+    width: 168px;
+}
 

--- a/app/assets/stylesheets/taxonomy.scss
+++ b/app/assets/stylesheets/taxonomy.scss
@@ -111,13 +111,15 @@
 
 .taxonomy-empty-illustration{
     display: flex;
-    gap: 15px;
     flex-direction: column;
     align-items: center;
     justify-content: center;
     width: 100%;
-    margin-top: 40px;
+    .browse-empty-illustration {
+        margin-top: 40px;
+    }
 }
+
 
 .taxonomy-empty-illustration-text{
     color: var(--gray-color);

--- a/app/controllers/taxonomy_controller.rb
+++ b/app/controllers/taxonomy_controller.rb
@@ -32,7 +32,7 @@ class TaxonomyController < ApplicationController
       category_index[category[:id]] = category
     end
     categories.each do |category|
-      category[:parentCategory].each do |parent_id|
+      category[:parentCategory]&.each do |parent_id|
         parent = category_index[parent_id]
         parent[:children] ||= []
         parent[:children] << category

--- a/app/controllers/taxonomy_controller.rb
+++ b/app/controllers/taxonomy_controller.rb
@@ -34,6 +34,7 @@ class TaxonomyController < ApplicationController
     categories.each do |category|
       category[:parentCategory]&.each do |parent_id|
         parent = category_index[parent_id]
+        next if parent.nil?
         parent[:children] ||= []
         parent[:children] << category
       end

--- a/app/helpers/components_helper.rb
+++ b/app/helpers/components_helper.rb
@@ -274,8 +274,8 @@ module ComponentsHelper
     end
   end
 
-  def regular_button(id, value, variant: "secondary", state: "regular", size: "slim", &block)
-    render Buttons::RegularButtonComponent.new(id:id, value: value, variant: variant, state: state, size: size) do |btn|
+  def regular_button(id, value, variant: "secondary", state: "regular", size: "slim", href: nil, &block)
+    render Buttons::RegularButtonComponent.new(id:id, value: value, variant: variant, state: state, size: size, href: href) do |btn|
       capture(btn, &block) if block_given?
     end
   end

--- a/app/views/taxonomy/_taxonomies.html.haml
+++ b/app/views/taxonomy/_taxonomies.html.haml
@@ -2,7 +2,7 @@
     - taxonomies = []
     - if taxonomies.blank?
         .taxonomy-empty-illustration
-            = empty_state("No #{type} is created yet")
+            = empty_state(t('taxonomy.no_taxonomy_created', type: type))
             - if true
                 .taxonomy-empty-illustration-button
                     = render Buttons::RegularButtonComponent.new(id:'create-taxonomy', value: "Create #{type}", variant: "secondary", size: "slim", href: "/admin?section=#{type}")

--- a/app/views/taxonomy/_taxonomies.html.haml
+++ b/app/views/taxonomy/_taxonomies.html.haml
@@ -1,5 +1,4 @@
 .taxonomy-section
-    - taxonomies = []
     - if taxonomies.blank?
         .taxonomy-empty-illustration
             = empty_state(t('taxonomy.no_taxonomy_created', type: type))

--- a/app/views/taxonomy/_taxonomies.html.haml
+++ b/app/views/taxonomy/_taxonomies.html.haml
@@ -1,10 +1,9 @@
 .taxonomy-section
+    - taxonomies = []
     - if taxonomies.blank?
         .taxonomy-empty-illustration
-            = inline_svg_tag 'empty-box.svg'
-            .taxonomy-empty-illustration-text
-                No group is created yet
-            - if session[:user]&.admin?
+            = empty_state("No #{type} is created yet")
+            - if true
                 .taxonomy-empty-illustration-button
                     = render Buttons::RegularButtonComponent.new(id:'create-taxonomy', value: "Create #{type}", variant: "secondary", size: "slim", href: "/admin?section=#{type}")
     - else

--- a/app/views/taxonomy/_taxonomies.html.haml
+++ b/app/views/taxonomy/_taxonomies.html.haml
@@ -1,9 +1,8 @@
 .taxonomy-section
-    - taxonomies = []
     - if taxonomies.blank?
         .taxonomy-empty-illustration
             = empty_state(t('taxonomy.no_taxonomy_created', type: type))
-            - if true
+            - if current_user_admin?
                 .taxonomy-empty-illustration-button
                     = render Buttons::RegularButtonComponent.new(id:'create-taxonomy', value: "Create #{type}", variant: "secondary", size: "slim", href: "/admin?section=#{type}")
     - else

--- a/app/views/taxonomy/_taxonomies.html.haml
+++ b/app/views/taxonomy/_taxonomies.html.haml
@@ -1,10 +1,11 @@
 .taxonomy-section
+    - taxonomies = []
     - if taxonomies.blank?
         .taxonomy-empty-illustration
             = empty_state(t('taxonomy.no_taxonomy_created', type: type))
             - if current_user_admin?
                 .taxonomy-empty-illustration-button
-                    = render Buttons::RegularButtonComponent.new(id:'create-taxonomy', value: "Create #{type}", variant: "secondary", size: "slim", href: "/admin?section=#{type}")
+                    = regular_button('create-taxonomy', "Create #{type}", variant: "secondary", size: "slim", href: "/admin?section=#{type}")
     - else
         - pairs, impairs = taxonomies.each_with_index.partition { |_, index| index.even? }
         - taxonomies_first_row = pairs.map(&:first)

--- a/app/views/taxonomy/_taxonomies.html.haml
+++ b/app/views/taxonomy/_taxonomies.html.haml
@@ -1,10 +1,19 @@
 .taxonomy-section
-    - pairs, impairs = taxonomies.each_with_index.partition { |_, index| index.even? }
-    - taxonomies_first_row = pairs.map(&:first)
-    - taxonomies_second_row = impairs.map(&:first)
-    .first-row
-        - taxonomies_first_row.each do |taxonomy|
-            = render Display::TaxonomyCardComponent.new(taxonomy: taxonomy, ontologies_names: @ontologies_names)
-    .second-row
-        - taxonomies_second_row.each do |taxonomy|
-            = render Display::TaxonomyCardComponent.new(taxonomy: taxonomy, ontologies_names: @ontologies_names)
+    - if taxonomies.blank?
+        .taxonomy-empty-illustration
+            = inline_svg_tag 'empty-box.svg'
+            .taxonomy-empty-illustration-text
+                No group is created yet
+            - if session[:user]&.admin?
+                .taxonomy-empty-illustration-button
+                    = render Buttons::RegularButtonComponent.new(id:'create-taxonomy', value: "Create #{type}", variant: "secondary", size: "slim", href: "/admin?section=#{type}")
+    - else
+        - pairs, impairs = taxonomies.each_with_index.partition { |_, index| index.even? }
+        - taxonomies_first_row = pairs.map(&:first)
+        - taxonomies_second_row = impairs.map(&:first)
+        .first-row
+            - taxonomies_first_row.each do |taxonomy|
+                = render Display::TaxonomyCardComponent.new(taxonomy: taxonomy, ontologies_names: @ontologies_names)
+        .second-row
+            - taxonomies_second_row.each do |taxonomy|
+                = render Display::TaxonomyCardComponent.new(taxonomy: taxonomy, ontologies_names: @ontologies_names)

--- a/app/views/taxonomy/index.html.haml
+++ b/app/views/taxonomy/index.html.haml
@@ -22,10 +22,3 @@
     document.getElementById('groups_tab').addEventListener('click', function(event) {
         window.history.pushState({ path: '/groups' }, '', '/groups');
     })
-
-
-
-    <div class="blabla"> qsdfqdsfqds </div>
-
-    .blabla
-        qqsdfqdsf

--- a/app/views/taxonomy/index.html.haml
+++ b/app/views/taxonomy/index.html.haml
@@ -10,11 +10,11 @@
         = render TabsContainerComponent.new do |c|
             - c.item(title: 'Groups', selected: !@category_section_active)
             - c.item_content do
-                = render partial: '/taxonomy/taxonomies', locals: { taxonomies: @groups }
+                = render partial: '/taxonomy/taxonomies', locals: { taxonomies: @groups, type: 'groups' }
 
             - c.item(title: 'Categories', selected: @category_section_active)
             - c.item_content do
-                = render partial: '/taxonomy/taxonomies', locals: { taxonomies: @categories }
+                = render partial: '/taxonomy/taxonomies', locals: { taxonomies: @categories, type: 'categories' }
 :javascript
     document.getElementById('categories_tab').addEventListener('click', function(event) {
         window.history.pushState({ path: '/categories' }, '', '/categories');
@@ -22,3 +22,10 @@
     document.getElementById('groups_tab').addEventListener('click', function(event) {
         window.history.pushState({ path: '/groups' }, '', '/groups');
     })
+
+
+
+    <div class="blabla"> qsdfqdsfqds </div>
+
+    .blabla
+        qqsdfqdsf

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1480,7 +1480,7 @@ en:
     groups_and_categories: Groups and Categories
     description: "In %{portal}, ontologies are organized in groups and tagged with categories. Typically, groups associate ontologies from the same project or organization for better identification of the provenance. Whereas categories are about subjects/topics and enable to classify ontologies. As of 2016, %{portal}'s categories were established in cooperation with FAO AIMS. In 2024, we moved to UNESCO Thesaurus (https://vocabularies.unesco.org). Groups and categories, along with other metadata, can be used on the “Browse” page of %{portal} to filter out the list of ontologies."
     show_sub_categories: Show sub categories
-
+    no_taxonomy_created: "No %{type} are created yet"
   federation:
     results_from_external_portals: Results from external portals
     not_responding: is not responding.

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -1516,6 +1516,8 @@ fr:
     groups_and_categories: Groupes et Catégories
     description: "Dans %{portal}, les ontologies sont organisées en groupes et étiquetées avec des catégories. Typiquement, les groupes associent des ontologies provenant du même projet ou de la même organisation pour une meilleure identification de la provenance. Tandis que les catégories concernent des sujets/thématiques et permettent de classifier les ontologies. En 2016, les catégories d'%{portal} ont été établies en coopération avec FAO AIMS. En 2024, nous sommes passés au Thésaurus de l'UNESCO (https://vocabularies.unesco.org). Les groupes et les catégories, ainsi que d'autres métadonnées, peuvent être utilisés sur la page “Parcourir” d'%{portal} pour filtrer la liste des ontologies."
     show_sub_categories: Afficher les sous-catégories
+    no_taxonomy_created: "Aucun %{type} n'a encore été créé"
+
   federation:
     results_from_external_portals: Résultats provenant de portails externes
     not_responding: ne répond pas.


### PR DESCRIPTION
### Changes
- Add null safety for parent categories list.
- Add empty illustration for categories/groups. And display a button to create groups/categories if the user is an admin.

### Screenshots
**Non admin users**
<img width="1461" alt="image" src="https://github.com/user-attachments/assets/dc05e058-7152-49b7-9cfa-a70bd1b08e5b">


**Admins**
<img width="1461" alt="image" src="https://github.com/user-attachments/assets/f718d41f-ac45-4373-be4a-5ae41042b13d">
