### PR TITLE
Fix: `Federated search/browse` results count by portal

### DIFF
--- a/app/helpers/federation_helper.rb
+++ b/app/helpers/federation_helper.rb
@@ -214,9 +214,11 @@ module FederationHelper
   end
 
   def federated_search_counts(search_results)
-    ids = search_results.map do |result|
-      result.dig(:root, :ontology_id) || rest_url
-    end
+    ids = search_results.flat_map do |result|
+      ontology_id = result.dig(:root, :ontology_id) || rest_url
+      other_portal_ids = result.dig(:root, :other_portals)&.map { |portal| portal[:link].split('?').first } || []
+      [ontology_id] + other_portal_ids
+    end.uniq
     counts_ontology_ids_by_portal_name(ids)
   end
 
@@ -236,7 +238,7 @@ module FederationHelper
       counts[current_portal.downcase] += 1 if id.include?(current_portal.to_s.downcase)
 
       federation_portals.each do |portal|
-        portal_api = federated_portals[portal.downcase.to_sym][:api]
+        portal_api = federated_portals[portal.downcase.to_sym][:name].downcase
         counts[portal.downcase] += 1 if id.include?(portal_api)
       end
     end

--- a/app/helpers/federation_helper.rb
+++ b/app/helpers/federation_helper.rb
@@ -221,7 +221,9 @@ module FederationHelper
   end
 
   def federated_browse_counts(ontologies)
-    ids = ontologies.map { |ontology| ontology[:id] }
+    ids = ontologies.flat_map do |ontology|
+      [ontology[:id]] + (ontology[:sources] || [])
+    end.uniq
     counts_ontology_ids_by_portal_name(ids)
   end
 

--- a/app/helpers/federation_helper.rb
+++ b/app/helpers/federation_helper.rb
@@ -238,8 +238,9 @@ module FederationHelper
       counts[current_portal.downcase] += 1 if id.include?(current_portal.to_s.downcase)
 
       federation_portals.each do |portal|
-        portal_api = federated_portals[portal.downcase.to_sym][:name].downcase
-        counts[portal.downcase] += 1 if id.include?(portal_api)
+        portal_api = federated_portals[portal.downcase.to_sym][:api].sub(/^https?:\/\//, '')
+        portal_ui = federated_portals[portal.downcase.to_sym][:ui].sub(/^https?:\/\//, '')
+        counts[portal.downcase] += 1 if (id.include?(portal_api) || id.include?(portal_ui))
       end
     end
 


### PR DESCRIPTION
Related issue: https://github.com/ontoportal-lirmm/bioportal_web_ui/issues/859

### Changes
- Include counting duplicated results for each portal (not only the canonical) in both federated browse and search
(https://github.com/ontoportal-lirmm/bioportal_web_ui/pull/870/commits/9f0fee89da72ef8a9b0304a483039d10a62e6197) (https://github.com/ontoportal-lirmm/bioportal_web_ui/pull/870/commits/5f460ffc76249688fb4b0397e2997dc31cc2d2ec)

### Screenshots:
**Federated browse**
<img width="1248" alt="image" src="https://github.com/user-attachments/assets/f5cd1519-6591-469b-8052-ae0cb7b5d96d">


**Federated search**
<img width="1086" alt="image" src="https://github.com/user-attachments/assets/446c8554-4c3b-4308-81a7-84cbac3ed218">