### PR TITLE
Fix: Change portal language

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -27,7 +27,7 @@ class ApplicationController < ActionController::Base
     cookies.permanent[:locale] = I18n.locale if cookies[:locale].nil?
     logger.debug "* Locale set to '#{I18n.locale}'"
 
-    I18n.locale = portal_lang if portal_language_enabled?(I18n.locale)
+    I18n.locale = portal_lang unless portal_language_enabled?(I18n.locale)
 
     session[:locale] = I18n.locale
   end
@@ -430,7 +430,7 @@ class ApplicationController < ActionController::Base
     optional_params_str = filtered_params.map { |param, value| "#{param}=#{value}" }.join("&")
     return base_url + optional_params_str + "&apikey=#{$API_KEY}"
   end
-  
+
   def set_federated_portals
     RequestStore.store[:federated_portals] =  params[:portals]&.split(',')
   end


### PR DESCRIPTION
Related issue: https://github.com/ontoportal-lirmm/bioportal_web_ui/issues/863

Changes: 
- Fix a wrong condition done in this PR: https://github.com/ontoportal-lirmm/bioportal_web_ui/pull/748

So now the default behavior will work, while keeping the preventing of selecting a disabled language like German for example.

Screenshots:
<img width="1784" alt="image" src="https://github.com/user-attachments/assets/8a2decab-6eaf-4f64-9961-2e93d964d8e8">
<img width="1784" alt="image" src="https://github.com/user-attachments/assets/177c93a3-7e00-4346-ac1d-fda312b91102">

