### PR TITLE
Fix: Browse page links multi slashes

### DIFF
--- a/app/helpers/federation_helper.rb
+++ b/app/helpers/federation_helper.rb
@@ -3,7 +3,10 @@ module FederationHelper
 
   def federated_portals
     $FEDERATED_PORTALS ||= LinkedData::Client.settings.federated_portals
-    normalize_portals($FEDERATED_PORTALS)
+    $FEDERATED_PORTALS.each do |key, portal|
+      portal[:ui] += "/" unless portal[:ui].end_with?("/")
+      portal[:api] += "/" unless portal[:api].end_with?("/")
+    end
     $FEDERATED_PORTALS
   end
 
@@ -257,13 +260,6 @@ module FederationHelper
       end
     end
     portal_counts.max_by { |_, count| count }&.first
-  end
-
-  def normalize_portals(portals)
-    portals.each do |_, portal|
-      portal[:ui] += "/" unless portal[:ui].end_with?("/")
-      portal[:api] += "/" unless portal[:api].end_with?("/")
-    end
   end
 
 end

--- a/app/helpers/federation_helper.rb
+++ b/app/helpers/federation_helper.rb
@@ -63,7 +63,7 @@ module FederationHelper
     ui_link = config[:ui]
     api_link = config[:api]
 
-    id.gsub(api_link, "#{ui_link}/") rescue id
+    id.gsub(api_link, "#{ui_link}") rescue id
   end
 
   def internal_ontology?(id)

--- a/app/helpers/federation_helper.rb
+++ b/app/helpers/federation_helper.rb
@@ -3,6 +3,8 @@ module FederationHelper
 
   def federated_portals
     $FEDERATED_PORTALS ||= LinkedData::Client.settings.federated_portals
+    normalize_portals($FEDERATED_PORTALS)
+    $FEDERATED_PORTALS
   end
 
   def internal_portal_config(id)
@@ -255,6 +257,13 @@ module FederationHelper
       end
     end
     portal_counts.max_by { |_, count| count }&.first
+  end
+
+  def normalize_portals(portals)
+    portals.each do |_, portal|
+      portal[:ui] += "/" unless portal[:ui].end_with?("/")
+      portal[:api] += "/" unless portal[:api].end_with?("/")
+    end
   end
 
 end


### PR DESCRIPTION
### Changes
- The bug was introduced by a function that converts API links into UI links. This function added `/`each time it does. So we got double slashes in the link (https://github.com/ontoportal-lirmm/bioportal_web_ui/commit/2c1d38b2afb3c6a3103d08bd254d72eb70400a8a)
- Ensure trailing slash in federation portals ui and api links (https://github.com/ontoportal-lirmm/bioportal_web_ui/pull/873/commits/07f3c1570716084cb0c1474c9b8f154218441372)

