### PR TITLE
Fix: Refresh concepts page on jump to

### DIFF
--- a/app/javascript/controllers/class_search_auto_complete_controller.js
+++ b/app/javascript/controllers/class_search_auto_complete_controller.js
@@ -18,8 +18,10 @@ export default class extends OntoportalAutocompleteController {
 
         // Appropriate value selected
         if (li.extra) {
-            let sValue = jQuery("#jump_to_concept_id").val()
-            Turbo.visit("/ontologies/" + jQuery(document).data().bp.ontology.acronym + "/?p=classes&conceptid=" + encodeURIComponent(sValue) + "&jump_to_nav=true")
+            let sValue = jQuery("#jump_to_concept_id").val();
+            let acronym = jQuery(document).data().bp.ontology.acronym;
+            let newUrl = "/ontologies/" + acronym + "/?p=classes&conceptid=" + encodeURIComponent(sValue) + "&jump_to_nav=true";
+            window.location.href = newUrl
         }
     }
 


### PR DESCRIPTION
Issues fixed:
https://github.com/ontoportal-lirmm/bioportal_web_ui/issues/860
https://github.com/ontoportal-lirmm/bioportal_web_ui/issues/845

### Changes
- Replace reloading the page using `Turbo.visit` when performing a `jump_to`, by reloading the whole page (https://github.com/ontoportal-lirmm/bioportal_web_ui/commit/fb06a1a3a4ccc3fb480267b6e7c2ca1fcab30329)

