### PR TITLE
Fix: Prevent delete category if still used as parent category

### DIFF
--- a/app/controllers/admin/categories_controller.rb
+++ b/app/controllers/admin/categories_controller.rb
@@ -11,6 +11,15 @@ class Admin::CategoriesController < ApplicationController
 
   def index
     @categories = _categories
+
+    @parents_list = Hash.new { |hash, key| hash[key] = [] }
+    @categories.each do |category|
+      category.parentCategory.each do |parent|
+        @parents_list[parent] << category.acronym
+      end
+    end
+
+
   end
 
   def new

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -451,7 +451,7 @@ module ApplicationHelper
     render Input::SelectComponent.new(id: id, name: name, value: categories_for_select, selected: selected, multiple: true)
   end
 
-  def is_parent?(parents_list, category)
+  def category_is_parent?(parents_list, category)
     is_parent = parents_list.keys.include?(category.id)
     parent_error_message = t('admin.categories.category_used_parent')
     parents_list[category.id].each do |c|

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -451,4 +451,13 @@ module ApplicationHelper
     render Input::SelectComponent.new(id: id, name: name, value: categories_for_select, selected: selected, multiple: true)
   end
 
+  def is_parent?(parents_list, category)
+    is_parent = parents_list.keys.include?(category.id)
+    parent_error_message = t('admin.categories.category_used_parent')
+    parents_list[category.id].each do |c|
+      parent_error_message = "#{parent_error_message} #{c}"
+    end
+    [is_parent,parent_error_message]
+  end
+
 end

--- a/app/views/admin/categories/_category.html.haml
+++ b/app/views/admin/categories/_category.html.haml
@@ -1,7 +1,7 @@
 %tr.human{:id => category.id.split('/').last}
   - count = category.ontologies&.size || 0
   - is_parent = @parents_list.keys.include?(category.id)
-  - parent_error_message = "Can't delete category, used as a parent category for: "
+  - parent_error_message = t('admin.categories.category_used_parent')
   - @parents_list[category.id].each do |c|
     - parent_error_message = "#{parent_error_message} #{c}"
   %td

--- a/app/views/admin/categories/_category.html.haml
+++ b/app/views/admin/categories/_category.html.haml
@@ -1,9 +1,6 @@
 %tr.human{:id => category.id.split('/').last}
-  - count = category.ontologies&.size || 0
-  - is_parent = @parents_list.keys.include?(category.id)
-  - parent_error_message = t('admin.categories.category_used_parent')
-  - @parents_list[category.id].each do |c|
-    - parent_error_message = "#{parent_error_message} #{c}"
+  - count = category.ontologies&.size || 0 
+  - is_parent, parent_error_message = is_parent?(@parents_list, category)
   %td
     %div{style: 'width: 250px'}
       %div.text-truncate{title: category.name}

--- a/app/views/admin/categories/_category.html.haml
+++ b/app/views/admin/categories/_category.html.haml
@@ -1,6 +1,6 @@
 %tr.human{:id => category.id.split('/').last}
   - count = category.ontologies&.size || 0 
-  - is_parent, parent_error_message = is_parent?(@parents_list, category)
+  - is_parent, parent_error_message = category_is_parent?(@parents_list, category)
   %td
     %div{style: 'width: 250px'}
       %div.text-truncate{title: category.name}
@@ -27,4 +27,3 @@
             = link_to t('admin.categories.delete'), "", class: 'btn btn-link disabled'
         - else
           = button_to t('admin.categories.delete'), CGI.unescape(admin_category_path(category.id.split('/').last)), method: :delete, class: 'btn btn-link',  form: {data: { turbo: true, turbo_confirm: t('admin.categories.turbo_confirm'), turbo_frame: '_top'}}
-          

--- a/app/views/admin/categories/_category.html.haml
+++ b/app/views/admin/categories/_category.html.haml
@@ -1,5 +1,9 @@
 %tr.human{:id => category.id.split('/').last}
   - count = category.ontologies&.size || 0
+  - is_parent = @parents_list.keys.include?(category.id)
+  - parent_error_message = "Can't delete category, used as a parent category for: "
+  - @parents_list[category.id].each do |c|
+    - parent_error_message = "#{parent_error_message} #{c}"
   %td
     %div{style: 'width: 250px'}
       %div.text-truncate{title: category.name}
@@ -18,8 +22,12 @@
         = link_to_modal(nil, edit_admin_category_path(category.id.split('/').last), data: {show_modal_title_value:  category.name}) do
           = t('admin.categories.edit_button')
       %span
-        - if count.zero?
-          = button_to t('admin.categories.delete'), CGI.unescape(admin_category_path(category.id.split('/').last)), method: :delete, class: 'btn btn-link',  form: {data: { turbo: true, turbo_confirm: t('admin.categories.turbo_confirm'), turbo_frame: '_top'}}
-        - else
+        - if !count.zero?
           %span{data: { controller: 'tooltip' }, title: t('admin.categories.info_error_delete')}
             = link_to t('admin.categories.delete'), "", class: 'btn btn-link disabled'
+        - elsif is_parent
+          %span{data: { controller: 'tooltip' }, title: parent_error_message}
+            = link_to t('admin.categories.delete'), "", class: 'btn btn-link disabled'
+        - else
+          = button_to t('admin.categories.delete'), CGI.unescape(admin_category_path(category.id.split('/').last)), method: :delete, class: 'btn btn-link',  form: {data: { turbo: true, turbo_confirm: t('admin.categories.turbo_confirm'), turbo_frame: '_top'}}
+          

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -193,6 +193,7 @@ en:
       problem_of_updating: Problem updating the category - %{message}
       category_deleted_successfully: Category successfully deleted in %{time}s
       problem_of_deleting: Problem deleting the category - %{message}
+      category_used_parent: "Can't delete category, used as a parent category for:"
       edit_button: "Edit"
       delete: Delete
       info_error_delete: Can't delete this category because still used

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -199,6 +199,7 @@ fr:
       problem_of_updating: Problème lors de la mise à jour de la catégorie - %{message}
       category_deleted_successfully: Catégorie supprimée avec succès en %{time}s
       problem_of_deleting: Problème lors de la suppression de la catégorie - %{message}
+      category_used_parent: "Impossible de supprimer la catégorie, utilisée comme catégorie parente pour:"
       edit_button: Éditer
       delete: Supprimer
       info_error_delete: Impossible de supprimer cette catégorie car elle est encore utilisée


### PR DESCRIPTION
### Changes
- Prevent delete category if still used as parent category (https://github.com/ontoportal-lirmm/bioportal_web_ui/commit/357a86ecd3db857baacf89f18a22a585bf19de20)
![image](https://github.com/user-attachments/assets/674dbdba-90e6-43d1-bbed-b6a49b32a81e)
