### PR TITLE
Feature: Keep only top level categories in federated browse page

### DIFF
--- a/app/controllers/ontologies_controller.rb
+++ b/app/controllers/ontologies_controller.rb
@@ -60,11 +60,12 @@ class OntologiesController < ApplicationController
         end
       end.flatten
 
-      unless request_portals.empty?
+      unless request_portals.length == 1
         streams += [
           replace('categories_refresh_for_federation') do
             key = "categories"
             objects, checked_values, _ = @filters[key.to_sym]
+            objects = keep_only_root_categories(objects)
             helpers.browse_filter_section_body(checked_values: checked_values,
                                                key: key, objects: objects,
                                                counts: @count_objects[key.to_sym])
@@ -583,4 +584,9 @@ class OntologiesController < ApplicationController
     return !results.blank? ? results.first[:name] : nil
   end
 
+  def keep_only_root_categories(categories)
+    categories.select do |category|
+      category.id.start_with?(rest_url) || category.parentCategory.blank?
+    end
+  end
 end


### PR DESCRIPTION
Related issue: https://github.com/ontoportal-lirmm/bioportal_web_ui/issues/862

### Changes
- On the federated browse page, only root categories (categories without parents) from other federation portals are displayed (https://github.com/ontoportal-lirmm/bioportal_web_ui/pull/877/commits/82cc2cc8bd33dc94470f9cbba32d42d7f091936f)