### PR TITLE
Fix: Handle invalid `propertyid` in the `Properties` subtab 

### DIFF
--- a/app/controllers/properties_controller.rb
+++ b/app/controllers/properties_controller.rb
@@ -77,12 +77,10 @@ class PropertiesController < ApplicationController
   private
 
   def index_tree(container_id)
-    if !params[:propertyid].blank?
-      @root = OpenStruct.new({ children: property_tree(params[:propertyid], params[:ontology]) })
-      not_found(@root.children.errors.join) if @root.children.respond_to?(:errors)
-
+    if !params[:propertyid].blank? && (@root= OpenStruct.new({ children: property_tree(params[:propertyid], params[:ontology]) }))  && !@root.children.respond_to?(:errors)
       @property = get_property(params[:propertyid], params[:ontology])
     else
+
       @root = OpenStruct.new({ children: property_roots(params[:ontology]) })
       not_found(@root.children.errors.join) if @root.children.respond_to?(:errors)
 


### PR DESCRIPTION
Querying an invalid `propertyid` Triggers a `500 Internal Server Error`:
**Example**: https://agroportal.lirmm.fr/ontologies/AGROVOC?p=properties&propertyid=http%3A%2F%2Fpurl.org%85Fdc%2Fterms%2Fcreated
- **Before** the fix:
![Screenshot from 2024-11-30 23-32-28](https://github.com/user-attachments/assets/fd110362-87db-43ec-9928-18846a25a401)
- **After** the fix: 
![Screenshot from 2024-12-01 00-33-03](https://github.com/user-attachments/assets/2fbbb1df-1dd5-45ef-9df1-4c87d85da980)
It just shows a warning saying that the property doesn't exist.