### PR TITLE
Feature: Add card to display accessible private ontologies in user account settings

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -40,6 +40,7 @@ class UsersController < ApplicationController
     @user_ontologies ||= []
 
     @admin_ontologies = @ontologies.select {|o| o.administeredBy.include? @user.id }
+    @accessed_ontologies = @ontologies.select {|o| o.acl.include? @user.id }
 
     projects = LinkedData::Client::Models::Project.all;
     @user_projects = projects.select {|p| p.creator.include? @user.id }

--- a/app/views/users/show.html.haml
+++ b/app/views/users/show.html.haml
@@ -120,6 +120,20 @@
                       %a{href: "/ontologies/#{view.match(/\/([^\/]+)$/)[1]}"}= view.match(/\/([^\/]+)$/)[1]
 
         .account-page-card
+          %h4.account-page-card-title= t('users.show.accessible_semantic_resources')
+          .account-page-small-cards-container
+            - if @accessed_ontologies.nil? || @accessed_ontologies.empty?
+              = t('users.show.no_accessible_resources')
+            - else
+              - @accessed_ontologies.each do |ont|
+                .account-page-submitted-ontology{data: {controller: 'tooltip'}, title: ont.name}
+                  %a{href: "/ontologies/#{ont.acronym}"}= ont.acronym
+                - unless ont.views.nil? || ont.views.empty?
+                  - ont.views.each do |view|
+                    .account-page-submitted-ontology{data: {controller: 'tooltip'}, title: ont.name}
+                      %a{href: "/ontologies/#{view.match(/\/([^\/]+)$/)[1]}"}= view.match(/\/([^\/]+)$/)[1]
+
+        .account-page-card
           %h4.account-page-card-title= t('users.show.projects_created')
           .account-page-small-cards-container
             - if @user_projects.nil? || @user_projects.empty?

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -879,6 +879,7 @@ en:
       save_custom_semantic_resources: Save custom ontologies
       not_subscribed: Not subscribed to any ontology
       submitted_semantic_resources: Submitted Ontologies
+      accessible_semantic_resources: Accessible Ontologies
       upload_semantic_resources: Upload Ontologies
       projects_created: Projects Created
       no_project_created: No project created
@@ -886,6 +887,7 @@ en:
       subscribe: Subscribe
       subscriptions: Subscriptions
       no_uploaded_resources: You didn't upload any ontology yet
+      no_accessible_resources: You do not have access to other ontologies. You can only access ontologies you own.
       notes: Notes
   search:
     no_search_class_provided: No search class provided

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -892,7 +892,8 @@ fr:
       note_feature_logged_in: "Note : cette fonctionnalité ne fonctionne que lorsque vous êtes connecté."
       save_custom_semantic_resources: Sauvegarder les ontologies personnalisées
       not_subscribed: Non abonné à aucune ontologie
-      submitted_semantic_resources: Ressources Ontologies
+      submitted_semantic_resources: Ontologies Soumises
+      accessible_semantic_resources: Ontologies Accessibles
       upload_semantic_resources: Télécharger ontologies
       projects_created: Projets Créés
       no_project_created: Aucun projet créé
@@ -900,6 +901,7 @@ fr:
       subscribe: S'abonner
       subscriptions: Abonnements
       no_uploaded_resources: Vous n'avez encore téléchargé aucune ontologie
+      no_accessible_resources: Vous n'avez pas accès aux d'autres ontologies. Vous ne pouvez accéder qu'aux ontologies dont vous êtes propriétaire.
       notes: Notes
 
   search:


### PR DESCRIPTION
### Description
When user has access to private ontology (i.e he is in the list of `acl` attribute of the ontology) , he cannot see it in the browse page because he does not have the option so filter by private ontologies, so the only solution to see it is to put it's url in the search bar

### What's change
This pr is done so that users that has access to private ontologies (not admin of the ontology) can see these ontologies from the interface through account settings

- when user does not have access to any ontology
![Screenshot from 2024-12-20 11-08-15](https://github.com/user-attachments/assets/c077dba8-196d-4e05-ae22-0e860714379f)

- when user has access to a priv
![Screenshot from 2024-12-20 11-09-58](https://github.com/user-attachments/assets/58aa087d-c876-47d6-a774-41c37704f9df)

