### PR TITLE
Fix: browse categories issue when a portal is down + portals status cache expires in 10 minutes

### DIFF
--- a/app/controllers/ontologies_controller.rb
+++ b/app/controllers/ontologies_controller.rb
@@ -588,6 +588,7 @@ class OntologiesController < ApplicationController
 
   def keep_only_root_categories(categories)
     categories.select do |category|
+      next unless category.id
       category.id.start_with?(rest_url) || category.parentCategory.blank?
     end
   end

--- a/app/helpers/federation_helper.rb
+++ b/app/helpers/federation_helper.rb
@@ -163,7 +163,7 @@ module FederationHelper
   end
 
   def federation_portal_status(portal_name: nil)
-    Rails.cache.fetch("federation_portal_up_#{portal_name}", expires_in: 2.hours) do
+    Rails.cache.fetch("federation_portal_up_#{portal_name}", expires_in: 10.minutes) do
       portal_api = federated_portals&.dig(portal_name,:api)
       return false unless portal_api
       portal_up = false


### PR DESCRIPTION
### Changes
- Make portals status cache expires in 10 minutes (https://github.com/ontoportal-lirmm/bioportal_web_ui/commit/25dc425d840abb71ec44ff74405dbad5e377156e)
- Fix an issue in browse categories when a portal is down (https://github.com/ontoportal-lirmm/bioportal_web_ui/commit/27b52ca0222671d8a7d0be38bea7c3271c2a5ba2)