### PR TITLE
Fix: Missing loading animation when loading multiple turbo frames in a fast way

### DIFF
--- a/app/javascript/controllers/turbo_frame_controller.js
+++ b/app/javascript/controllers/turbo_frame_controller.js
@@ -30,8 +30,12 @@ export default class extends Controller {
             }
 
             this.urlValue = this.#updatedPageUrl(data)
-
+            
             this.frame.src  = this.urlValue
+            
+            setTimeout(() => {
+                this.frame.setAttribute('busy', 'true')
+            }, 0);
         }
     }
 

--- a/app/javascript/controllers/turbo_frame_controller.js
+++ b/app/javascript/controllers/turbo_frame_controller.js
@@ -32,10 +32,10 @@ export default class extends Controller {
             this.urlValue = this.#updatedPageUrl(data)
             
             this.frame.src  = this.urlValue
-            
-            setTimeout(() => {
-                this.frame.setAttribute('busy', 'true')
-            }, 0);
+
+            requestAnimationFrame(() => {
+                this.frame.setAttribute('busy', 'true');
+            });
         }
     }
 


### PR DESCRIPTION
Related issue:
https://github.com/ontoportal-lirmm/bioportal_web_ui/issues/901

### Problem description
- Checking the federation input chip on the browse page automatically triggers the sorting filter to sort by name. This causes the page to reload multiple times, which leads to the turbo frame’s loading animation disappearing.

- Performing category-parent association logic also causes the same issue, as multiple category chips are selected in quick succession.

- Rapidly selecting parameters on the browse page can also result in the issue, causing a white page to appear on the right without any animation.

### Solution Implemented in This PR
- Ensure that each time we update a turbo frame, the busy attribute is set to true to show the animation.
- This logic is executed at the end of the JavaScript call stack using requestAnimationFrame method, ensuring that no other parts of the JavaScript interfere with the animation visibility.


Demo:

https://github.com/user-attachments/assets/f5da41e4-6f00-4e4e-8f95-90f2da994b59

