### PR TITLE
Feature: disable eager loading in production and  load the sections only if visited

### DIFF
--- a/app/assets/stylesheets/application.css.scss.erb
+++ b/app/assets/stylesheets/application.css.scss.erb
@@ -66,6 +66,6 @@
 @import "bootstrap_overrides";
 
 
-<% if (ui_theme = $UI_THEME.to_s.parameterize).present? && File.exists?(Rails.root.join('app', 'assets', 'stylesheets', 'themes', ui_theme)) %>
+<% if (ui_theme = $UI_THEME.to_s.parameterize).present? && File.exist?(Rails.root.join('app', 'assets', 'stylesheets', 'themes', ui_theme)) %>
   @import "themes/<%= ui_theme %>/main";
 <% end %>

--- a/app/helpers/ontologies_helper.rb
+++ b/app/helpers/ontologies_helper.rb
@@ -409,7 +409,7 @@ module OntologiesHelper
       block.call
     else
       render TurboFrameComponent.new(id: section_title, src: "/ontologies/#{@ontology.acronym}?p=#{section_title}",
-                                     loading: Rails.env.development? ? "lazy" : "eager",
+                                     loading: "lazy",
                                      target: '_top', data: { "turbo-frame-target": "frame" })
     end
   end

--- a/app/helpers/ontologies_helper.rb
+++ b/app/helpers/ontologies_helper.rb
@@ -395,6 +395,10 @@ module OntologiesHelper
     ontology_data_sections.include?(section_title)
   end
 
+  def lazy_load_section?(section_title)
+    !(ontology_data_section?(section_title) || section_title.eql?('summary'))
+  end
+
   def section_data(section_title)
     if ontology_data_section?(section_title)
       url_value = selected_section?(section_title) ? request.fullpath : "/ontologies/#{@ontology.acronym}?p=#{section_title}"
@@ -404,12 +408,13 @@ module OntologiesHelper
     end
   end
 
-  def lazy_load_section(section_title, &block)
+  def lazy_load_section(section_title, lazy_load: true, &block)
     if current_section.eql?(section_title)
       block.call
     else
       render TurboFrameComponent.new(id: section_title, src: "/ontologies/#{@ontology.acronym}?p=#{section_title}",
-                                     loading: "lazy",
+
+                                     loading: Rails.env.development? || lazy_load ? "lazy" : "eager",
                                      target: '_top', data: { "turbo-frame-target": "frame" })
     end
   end

--- a/app/views/layouts/_ontology_viewer.html.haml
+++ b/app/views/layouts/_ontology_viewer.html.haml
@@ -32,7 +32,7 @@
             - t.item_content do
               %div.p-1{data: section_data(section_title)}
                 = language_selector_hidden_tag(section_title) if ontology_data_section?(section_title)
-                = lazy_load_section(section_title) { yield }
+                = lazy_load_section(section_title, lazy_load:  lazy_load_section?(section_title)) { yield }
 
 
   = render partial: "layouts/footer"


### PR DESCRIPTION
### Context
One a user go to the ontology viewer of an ontology, e.g https://stageportal.lirmm.fr/ontologies/AGROVOC, it loads the current visited page and in the background fetch th remaining sections. 
It is good if our API could support that amount  of calls,  but unfortunately it does overload the server with calls that are even possibly not even seen by the end users (e.g  mappings section)  
Now the following section are loaded in the background `summary, classes, properties,instances,collections,schemes`
And the following will be loaded only in visit `mappings, notes, widgets, sparql`

### Changes

* Make the ontology viewer load the sections only if visited (https://github.com/ontoportal-lirmm/bioportal_web_ui/commit/6ab8354e3fc49152b7b72d621670ba9f8a9b3927)
* Update the ontology viewer to lazy the section that are not data (https://github.com/ontoportal-lirmm/bioportal_web_ui/pull/912/commits/de18fbddc26cd4f0b6a08bd0d28cb69fcd230972)