### PR TITLE
Fix: Canonical portal choice only from the request portals list

### DIFF
--- a/app/helpers/federation_helper.rb
+++ b/app/helpers/federation_helper.rb
@@ -260,8 +260,8 @@ module FederationHelper
   def most_referred_portal(ontology_submissions)
     portal_counts = Hash.new(0)
     ontology_submissions.each do |submission|
-      federated_portals.keys.each do |portal|
-        portal_counts[portal] += 1 if submission[:pullLocation]&.include?(portal.to_s)
+      request_portals.each do |portal|
+        portal_counts[portal.downcase] += 1 if submission[:pullLocation]&.include?(portal.downcase)
       end
     end
     portal_counts.max_by { |_, count| count }&.first


### PR DESCRIPTION
Related issue: https://github.com/ontoportal-lirmm/bioportal_web_ui/issues/909

### Issue description
When attempting to retrieve the canonical portal for a duplicated ontology during a federated call, the current implementation counts references across all portals, instead of limiting the count to only those mentioned in the current request. 
The issue raised in this example (https://github.com/ontoportal-lirmm/bioportal_web_ui/issues/909) is that AgroPortal and EcoPortal were selected, but the results included an ontology with the canonical portal BiodivPortal.

### Solution proposed in this PR
This PR updates the logic to count the most-referenced portals for duplicated ontologies using only the list of portals mentioned in the current request.