### PR TITLE
Feature: add portal configuration interface

### DIFF
--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -282,6 +282,21 @@ class AdminController < ApplicationController
 
   end
 
+  def change_portal_config
+    config_params = params.except(:controller, :action, :format, :authenticity_token, :commit)
+    root_url = "#{rest_url}/"
+    begin
+      response = LinkedData::Client::HTTP.patch(root_url, JSON.parse(config_params.to_json))
+      if response.success?
+        flash[:notice] = 'Configuration updated successfully'
+      else
+        flash[:alert] = "Update failed: #{response.body}"
+      end
+    rescue StandardError => e
+      flash[:error] = "An error occurred: #{e.message}"
+    end
+
+  end
 
   private
 

--- a/app/helpers/admin_helper.rb
+++ b/app/helpers/admin_helper.rb
@@ -22,4 +22,19 @@ module AdminHelper
                 form: {data: { turbo: true, turbo_confirm: t('admin.turbo_confirm', name: name), turbo_frame: '_top'}}
 
   end
+
+  def portal_config_container
+    attribute_to_delete = ["context", "links", "@id", "@type"]
+    attribute_to_not_modify = ["id", "federated_portals", "fundedBy", "keyword", "numberOfArtefacts", "metrics", "numberOfClasses", "numberOfIndividuals", "numberOfProperties", "numberOfAxioms", "numberOfObjectProperties", "numberOfDataProperties", "numberOfLabels", "numberOfDeprecated", "numberOfUsingProjects", "numberOfEndorsements", "numberOfMappings", "numberOfUsers", "numberOfAgents" ]
+    root_url = "#{rest_url}/?display=all"
+    attributes_catalog = LinkedData::Client::HTTP.get(root_url, {display: :all})
+    attribute_to_delete.each do |attr|
+      attributes_catalog.delete_field(attr.to_sym)
+    end
+    attribute_to_not_modify.each do |attr|
+      attributes_catalog.delete_field(attr.to_sym)
+    end
+    @config = attributes_catalog
+    render partial: 'admin/portal_config/metadata_tab'
+  end
 end

--- a/app/views/admin/index.html.haml
+++ b/app/views/admin/index.html.haml
@@ -11,7 +11,7 @@
 
 %div
   %div.mx-1
-    - sections = [t('admin.index.analytics'), t('admin.index.site_administration'),t('admin.index.ontology_administration'),  t('admin.index.licensing'), t('admin.index.users'), t('admin.index.metadata_administration'), t('admin.index.groups'), t('admin.index.categories'), t('admin.index.persons_and_organizations'), t('admin.index.sparql'), t('admin.index.search')]
+    - sections = [t('admin.index.analytics'), t('admin.index.site_administration'),t('admin.index.ontology_administration'),  t('admin.index.licensing'), t('admin.index.users'), t('admin.index.metadata_administration'), t('admin.index.groups'), t('admin.index.categories'), t('admin.index.persons_and_organizations'), t('admin.index.sparql'), t('admin.index.search'), t('admin.index.portal_config')]
     - selected = params[:section] || sections.first.downcase
     = render Layout::VerticalTabsComponent.new(header:  t('admin.index.administration_console'), titles: sections, selected: selected, url_parameter: 'section') do |t|
       - t.item_content do
@@ -63,3 +63,5 @@
         = sparql_query_container
       - t.item_content do
         = render TurboFrameComponent.new(id: 'search-admin', src: '/admin/search', loading: 'lazy')
+      - t.item_content do
+        = portal_config_container

--- a/app/views/admin/portal_config/_metadata_tab.html.haml
+++ b/app/views/admin/portal_config/_metadata_tab.html.haml
@@ -1,0 +1,25 @@
+- if flash[:notice]
+  .alert.alert-success= flash[:notice]
+- if flash[:alert]
+  .alert.alert-danger= flash[:alert]
+- if flash[:error]
+  .alert.alert-danger= flash[:error]
+
+%div
+  %div
+    = form_with url: "/admin/change_configs", method: :post, local: false, turbo: true, html: { id: 'config-form' } do |f|
+      - @config.each do |key, value|
+        .form-group
+          = f.label key, key.to_s.humanize
+          - if value.is_a?(String)
+            = f.text_field key, value: value, class: "form-control"
+          - elsif value.is_a?(Integer)
+            = f.number_field key, value: value, class: "form-control"
+          - elsif value.is_a?(TrueClass) || value.is_a?(FalseClass)
+            = f.check_box key, {}, true, false
+          - elsif value.nil?
+            = f.text_field key, value: value, class: "form-control"
+          - else
+            = f.text_area key, value: value, class: "form-control", rows: 3
+      %div.mt-3.flex-shrink-0
+        = f.submit "Save Changes", class: "btn btn-primary"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -151,6 +151,7 @@ en:
       valid_till: Valid till
       days_remaining: Days remaining
       renew_license: Renew license
+      portal_config: Portal configurations
     groups:
       group_created: Group successfully created in %{time}s
       group_error_creation: Problem creating the group  - %{message}

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -156,7 +156,7 @@ fr:
       valid_till: Valide jusqu'à
       days_remaining: Jours restants
       renew_license: Renouveler la licence
-
+      portal_config: Configurations du portail 
     groups:
       group_created: Groupe créé avec succès en %{time}s
       group_error_creation: Problème lors de la création du groupe - %{message}

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -104,6 +104,7 @@ Rails.application.routes.draw do
   put 'admin/ontologies', to: 'admin#process_ontologies'
   get 'admin/update_check_enabled', to: 'admin#update_check_enabled'
   get 'admin/ontologies/:acronym/log', to: 'admin#parse_log'
+  post 'admin/change_configs', to: 'admin#change_portal_config'
 
   resources :subscriptions
 


### PR DESCRIPTION
### Context 
- see issue: https://github.com/ontoportal-lirmm/bioportal_web_ui/issues/928

### What's new
Adding an interface for the admin of the portals to change the configurations of their portal (or Catalog) in the context of the MOD-API implementation. This interface will use the `/` route in the backend 
- See implementation of `/` route in the api: https://github.com/ontoportal-lirmm/ontologies_api/pull/117

### Screenshot
![image](https://github.com/user-attachments/assets/752f2a86-6716-42d3-a15c-91972b0d9375)
