### PR TITLE
Fix: `display_in_multiple_languages` method to add the missing params

### DIFF
--- a/app/helpers/multi_languages_helper.rb
+++ b/app/helpers/multi_languages_helper.rb
@@ -166,7 +166,7 @@ module MultiLanguagesHelper
   end
 
   # @param label String | Array | OpenStruct
-  def display_in_multiple_languages(label)
+  def display_in_multiple_languages(label, style_as_badge: false, show_max: nil)
     if label.blank?
       return render Display::AlertComponent.new(message: t('ontology_details.concept.no_preferred_name_for_selected_language'),
                                                 type: "warning",

--- a/app/helpers/multi_languages_helper.rb
+++ b/app/helpers/multi_languages_helper.rb
@@ -166,7 +166,7 @@ module MultiLanguagesHelper
   end
 
   # @param label String | Array | OpenStruct
-  def display_in_multiple_languages(label, style_as_badge: false, show_max: nil)
+  def display_in_multiple_languages(label, style_as_badge: false, show_max: 5)
     if label.blank?
       return render Display::AlertComponent.new(message: t('ontology_details.concept.no_preferred_name_for_selected_language'),
                                                 type: "warning",


### PR DESCRIPTION
### Issue source
404 error on StagePortal when trying to do a search on search page.

### Changes
- Update `display_in_multiple_languages` method to add some missing params to it (https://github.com/ontoportal-lirmm/bioportal_web_ui/commit/c4e4b1d7045991a551f6106326ba249e4564f2b3)

The method was defined with only one param which is label, but expecting two other params which are style_as_badge and show_max.

![image](https://github.com/user-attachments/assets/bca2d4b2-c54b-48d2-b8f2-d83f992af6e9)
