### PR TITLE
Fix: Home page portals tooltips

### DIFF
--- a/app/helpers/home_helper.rb
+++ b/app/helpers/home_helper.rb
@@ -24,8 +24,8 @@ module HomeHelper
     end
   end
 
-  def portal_config_tooltip(portal_name, &block)
-    portal_id = portal_name&.downcase
+  def portal_config_tooltip(portal, &block)
+    portal_id = portal&.downcase
     title = if (federation_portal_status(portal_name: portal_id) || portal_id.eql?(portal_name&.downcase))
       render(
         TurboFrameComponent.new(


### PR DESCRIPTION
### Issue

https://github.com/user-attachments/assets/9a6ec531-70aa-4869-8844-a6f69f87ba73

### Problem  
In the `portal_config_tooltip` method, there is a parameter named `portal_name`. However, within the same context, there is also a method named `portal_name`, causing a conflict when working inside `portal_config_tooltip`.  

### Solution  
- Renamed the `portal_name` parameter to `portal` in the `portal_config_tooltip` method. 

### Demo

https://github.com/user-attachments/assets/ef04c366-9f18-4109-956c-2a1a093af5ab


