### PR TITLE
Feature: Restrict access to ontology creation for non-privileged users in read-only mode

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -4,6 +4,8 @@ SITE=Testportal
 ORG=LIRMM
 ORG_URL=http://www.lirmm.fr
 
+READ_ONLY_PORTAL=false
+
 UI_URL=http://localhost:3000
 API_URL=http://localhost:9393
 API_KEY=

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -245,11 +245,9 @@ class ApplicationController < ActionController::Base
     redirect_to "/"
   end
 
-  # Verifies if user is logged in
+  # Verifies if user is logged in and not in read-only mode
   def authorize_and_redirect
-    unless session[:user]
-      redirect_to_home
-    end
+    redirect_to_home if !session[:user] || read_only_enabled?
   end
 
   def authorize_admin

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -247,7 +247,7 @@ class ApplicationController < ActionController::Base
   
   # Redirects to home if the application is in read-only mode.  
   def authorize_read_only
-    if read_only_enabled?
+    if helpers.read_only_enabled?
       redirect_to_home and return
     end
   end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -244,12 +244,21 @@ class ApplicationController < ActionController::Base
   def redirect_to_home # Redirect to Home Page
     redirect_to "/"
   end
-
-  # Verifies if user is logged in and not in read-only mode
-  def authorize_and_redirect
-    redirect_to_home if !session[:user] || read_only_enabled?
+  
+  # Redirects to home if the application is in read-only mode.  
+  def authorize_read_only
+    if read_only_enabled?
+      redirect_to_home and return
+    end
   end
 
+  # Verifies if user is logged in
+  def authorize_and_redirect
+    unless session[:user]
+      redirect_to_home
+    end
+  end
+  
   def authorize_admin
     redirect_to_home unless current_user_admin?
   end

--- a/app/controllers/ontologies_controller.rb
+++ b/app/controllers/ontologies_controller.rb
@@ -27,6 +27,7 @@ class OntologiesController < ApplicationController
   before_action :authorize_and_redirect, :only => [:edit, :update, :create, :new]
   before_action :submission_metadata, only: [:show]
   before_action :set_federated_portals, only: [:index, :ontologies_filter]
+  before_action :authorize_read_only, :only => [:new, :create, :edit, :update]
 
   KNOWN_PAGES = Set.new(["terms", "classes", "mappings", "notes", "widgets", "summary", "properties", "instances", "schemes", "collections", "sparql"])
   EXTERNAL_MAPPINGS_GRAPH = "http://data.bioontology.org/metadata/ExternalMappings"

--- a/app/controllers/ontologies_controller.rb
+++ b/app/controllers/ontologies_controller.rb
@@ -168,9 +168,6 @@ class OntologiesController < ApplicationController
   end
 
   def new
-    if $READ_ONLY_PORTAL && !session[:user]&.admin?
-      redirect_to "/login?redirect=#{new_ontology_path}"
-    end
     @ontology = LinkedData::Client::Models::Ontology.new
     @ontology.viewOf = params.dig(:ontology, :viewOf)
     @submission = LinkedData::Client::Models::OntologySubmission.new

--- a/app/controllers/ontologies_controller.rb
+++ b/app/controllers/ontologies_controller.rb
@@ -168,6 +168,9 @@ class OntologiesController < ApplicationController
   end
 
   def new
+    if $READ_ONLY_PORTAL && !session[:user]&.admin?
+      redirect_to "/login?redirect=#{new_ontology_path}"
+    end
     @ontology = LinkedData::Client::Models::Ontology.new
     @ontology.viewOf = params.dig(:ontology, :viewOf)
     @submission = LinkedData::Client::Models::OntologySubmission.new

--- a/app/controllers/submissions_controller.rb
+++ b/app/controllers/submissions_controller.rb
@@ -2,8 +2,9 @@ class SubmissionsController < ApplicationController
   include SubmissionsHelper, SubmissionUpdater, OntologyUpdater
   layout :determine_layout
   before_action :authorize_and_redirect, :only => [:edit, :update, :create, :new]
+  before_action :authorize_read_only, :only => [:new, :create, :edit, :update]
   before_action :submission_metadata, only: [:create, :edit, :new, :update, :index]
-
+  
 
   def index
     @ontology = LinkedData::Client::Models::Ontology.find_by_acronym(params[:ontology_id]).first

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -30,6 +30,10 @@ module ApplicationHelper
     render IconWithTooltipComponent.new(icon: "json.svg",link: link, target: '_blank', title: t('fair_score.go_to_api'), size:'small', style: custom_style)
   end
 
+  def read_only_enabled?
+    $READ_ONLY_PORTAL && !current_user_admin?
+  end
+
   def portal_name_from_uri(uri)
     URI.parse(uri).hostname.split('.').first
   end

--- a/app/helpers/ontologies_helper.rb
+++ b/app/helpers/ontologies_helper.rb
@@ -652,7 +652,7 @@ module OntologiesHelper
   end
 
   def upload_ontology_button
-    return if $READ_ONLY_PORTAL && !session[:user]&.admin?
+    return if read_only_enabled?
 
     href = if session[:user].nil?
              "/login?redirect=#{new_ontology_path}"

--- a/app/helpers/ontologies_helper.rb
+++ b/app/helpers/ontologies_helper.rb
@@ -652,17 +652,22 @@ module OntologiesHelper
   end
 
   def upload_ontology_button
-    if session[:user].nil?
-      render Buttons::RegularButtonComponent.new(id: "upload-ontology-button", value: t('home.ontology_upload_button'), variant: "secondary", state: "regular", href: "/login?redirect=/ontologies/new") do |btn|
-        btn.icon_left do
-          inline_svg_tag "upload.svg"
-        end
-      end
-    else
-      render Buttons::RegularButtonComponent.new(id: "upload-ontology-button", value: t('home.ontology_upload_button'), variant: "secondary", state: "regular", href: new_ontology_path) do |btn|
-        btn.icon_left do
-          inline_svg_tag "upload.svg"
-        end
+    href = session[:user].nil? ? "/login?redirect=#{new_ontology_path}" : new_ontology_path
+    render_button(href)
+  end
+  
+  private
+  
+  def render_button(href)
+    render Buttons::RegularButtonComponent.new(
+      id: "upload-ontology-button",
+      value: t('home.ontology_upload_button'),
+      variant: "secondary",
+      state: "regular",
+      href: href
+    ) do |btn|
+      btn.icon_left do
+        inline_svg_tag "upload.svg"
       end
     end
   end

--- a/app/helpers/ontologies_helper.rb
+++ b/app/helpers/ontologies_helper.rb
@@ -659,20 +659,19 @@ module OntologiesHelper
            else
              new_ontology_path
            end
-  
-    render = regular_button( 
-      "upload-ontology-button", 
-      t('home.ontology_upload_button'), 
+
+    render = regular_button(
+      "upload-ontology-button",
+      t('home.ontology_upload_button'),
       variant: "secondary",
       state: "regular",
-      size: nil, 
-      href: href) 
-      do |btn|
-      btn.icon_left do
-        inline_svg_tag "upload.svg"
+      size: nil,
+      href: href) do |btn|
+        btn.icon_left do
+          inline_svg_tag "upload.svg"
+        end
       end
     end
-  end
 
   def submission_json_button
     render RoundedButtonComponent.new(link: "#{(@submission_latest || @ontology).id}?display=all",

--- a/app/helpers/ontologies_helper.rb
+++ b/app/helpers/ontologies_helper.rb
@@ -652,10 +652,16 @@ module OntologiesHelper
   end
 
   def upload_ontology_button
-    href = session[:user].nil? ? "/login?redirect=#{new_ontology_path}" : new_ontology_path
+    return if $READ_ONLY_PORTAL && !session[:user]&.admin?
+
+    href = if session[:user].nil?
+             "/login?redirect=#{new_ontology_path}"
+           else
+             new_ontology_path
+           end
+  
     render_button(href)
   end
-  
   private
   
   def render_button(href)

--- a/app/helpers/ontologies_helper.rb
+++ b/app/helpers/ontologies_helper.rb
@@ -660,18 +660,14 @@ module OntologiesHelper
              new_ontology_path
            end
   
-    render_button(href)
-  end
-  private
-  
-  def render_button(href)
-    render Buttons::RegularButtonComponent.new(
-      id: "upload-ontology-button",
-      value: t('home.ontology_upload_button'),
+    render = regular_button( 
+      "upload-ontology-button", 
+      t('home.ontology_upload_button'), 
       variant: "secondary",
       state: "regular",
-      href: href
-    ) do |btn|
+      size: nil, 
+      href: href) 
+      do |btn|
       btn.icon_left do
         inline_svg_tag "upload.svg"
       end

--- a/config/bioportal_config_env.rb.sample
+++ b/config/bioportal_config_env.rb.sample
@@ -1,5 +1,6 @@
 $DEBUG_API_CLIENT = false
 $API_CLIENT_INVALIDATE_CACHE = false
+$READ_ONLY_PORTAL = ENV["READ_ONLY_PORTAL"].to_s.downcase == "true"
 
 # Organization info
 $ORG = ENV['ORG']


### PR DESCRIPTION
Related Issue : http://github.com/ontoportal-lirmm/bioportal_web_ui/issues/933

1. Disable **ontology upload** button for non-privileged users in read-only mode. This change ensures that non-privileged users cannot see or interact with the ontology upload button when the portal is in read-only mode. The button is now only visible to admins in this state.

![Screenshot from 2025-02-12 01-02-41](https://github.com/user-attachments/assets/d174a540-6d12-41f7-a77e-0ec54fd91ca5)
![Screenshot from 2025-02-12 01-03-05](https://github.com/user-attachments/assets/d25ca1f3-2a58-4e41-a7c2-d86f1f4b3861)
2. When the portal is in read-only mode. The page `/ontologies/new` is now restricted to admins only in this state, preventing unauthorized users from creating new ontologies while the portal is read-only.

https://github.com/user-attachments/assets/53deebe9-e215-4e9b-aaae-e7788bad127d