### PR TITLE
FIx: enforce sparql proxy to have always a from with a graph that the user have access to

### DIFF
--- a/app/helpers/sparql_helper.rb
+++ b/app/helpers/sparql_helper.rb
@@ -2,10 +2,9 @@ module SparqlHelper
   def change_from_clause(query, graph)
     unless graph.blank?
       graph = graph.gsub($REST_URL, 'http://data.bioontology.org')
-
       if query.match?(/FROM <[^>]+>/i)
         # Use a regular expression to replace all instances of FROM <uri>
-        query = query.gsub(/FROM <[^>]+>/i, "")
+        query = query.gsub(/FROM <[^>]+>/i, "FROM <#{graph}>")
       else
         query = query.gsub("WHERE", "FROM <#{graph}> WHERE")
       end


### PR DESCRIPTION
### Context
This PR resolve a critical security issue raised by @muhammedBkf, concerning the UI spaqrl proxy, not preventing correclty the access to private graphs.
This PR fix that.

#### before
![image](https://github.com/user-attachments/assets/a8cb632c-8b1d-43da-88a9-9bfab93c95b5)
#### after
![image](https://github.com/user-attachments/assets/c06627af-2558-4b52-b1a8-9948c88d0fb5)

### Changes
* enforce having always from with a graph that the user have access to (https://github.com/ontoportal-lirmm/bioportal_web_ui/commit/5740ddaf8ee399ca0ea794ea0aa70fa8582ce84e)