### PR TITLE
Fix: ontoportal instances popups after migrating to MOD-API

### DIFF
--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -47,7 +47,7 @@ class HomeController < ApplicationController
   def portal_config
     @config = $PORTALS_INSTANCES.select { |x| x[:name].downcase.eql?((params[:portal] || helpers.portal_name).downcase) }.first
     if @config && @config[:api]
-      @portal_config = LinkedData::Client::Models::Ontology.top_level_links(@config[:api]).to_h
+      @portal_config = get_portal_config
       @color = @portal_config[:color].present? ? @portal_config[:color] : @config[:color]
       @name = @portal_config[:title].present? ? @portal_config[:title] : @config[:name]
     else
@@ -184,5 +184,15 @@ class HomeController < ApplicationController
 
     others, agriculture = @groups.partition { |g| g.acronym != 'CGIAR' }
     @groups = others + agriculture
+  end
+
+  def get_portal_config
+    portal_config = LinkedData::Client::Models::Ontology.top_level_links(@config[:api])
+    if portal_config.is_a?(LinkedData::Client::Models::SemanticArtefactCatalog)
+      portal_config = portal_config.to_hash
+    else
+      portal_config = portal_config.to_h
+    end
+    portal_config
   end
 end

--- a/app/helpers/federation_helper.rb
+++ b/app/helpers/federation_helper.rb
@@ -164,7 +164,7 @@ module FederationHelper
 
   def federation_portal_status(portal_name: nil)
     Rails.cache.fetch("federation_portal_up_#{portal_name}", expires_in: 10.minutes) do
-      portal_api = federated_portals&.dig(portal_name,:api)
+      portal_api = federated_portals&.dig(portal_name.to_sym,:api)
       return false unless portal_api
       portal_up = false
       begin

--- a/app/helpers/home_helper.rb
+++ b/app/helpers/home_helper.rb
@@ -26,7 +26,7 @@ module HomeHelper
 
   def portal_config_tooltip(portal, &block)
     portal_id = portal&.downcase
-    title = if (federation_portal_status(portal_name: portal_id) || portal_id.eql?(portal_name&.downcase))
+    title = if (federation_portal_status(portal_name: portal_id.to_sym) || portal_id.eql?(portal_name&.downcase))
       render(
         TurboFrameComponent.new(
           id: "portal_config_tooltip_#{portal_id}",

--- a/app/views/home/portal_config.html.haml
+++ b/app/views/home/portal_config.html.haml
@@ -24,7 +24,13 @@
           .text
             Federated with
         .d-flex.flex-wrap.my-1
-          - @portal_config[:federated_portals].to_h.values.compact.each do |portal|
+          -# Handling portals that implement MOD-API
+          - if @portal_config[:federated_portals].is_a?(Array)
+            - federated_portals = @portal_config[:federated_portals]
+          - elsif @portal_config[:federated_portals].is_a?(OpenStruct)
+            - federated_portals = @portal_config[:federated_portals].to_h.values.compact
+
+          - federated_portals.each do |portal|
             .portal-config-federated-with
               = link_to portal[:ui], target: '_blank', class: 'home-logo-instances-small', style: "background-color: #{portal[:color]};" do
                 = inline_svg 'logo-white.svg', width: "18", height: "13"


### PR DESCRIPTION
After implementing MOD-API, the pop up of ontoportal instances is not working and that's because we changed the structure of the / route. 
![image](https://github.com/user-attachments/assets/e7c2cc16-a24d-4691-a3df-b8cfe64847c2)


Why:
- Before we were expecting to have the data as a hash (and the  federated_portals as hash also)
- Now with MOD-API we are expecting an object of type `LinkedData::Client::Models::SemanticArtefactCatalog` and the federated_portals as an array 

This fix will handle both case, so that the portals that didn't implement the MOD-API will not be broken

