### PR TITLE
Fix: strip values when editing ontology metadata

### DIFF
--- a/app/controllers/concerns/submission_updater.rb
+++ b/app/controllers/concerns/submission_updater.rb
@@ -124,14 +124,13 @@ module SubmissionUpdater
     end
     p = params.permit(attributes.uniq)
     p['pullLocation'] = '' if p['isRemote']&.eql?('3')
-
-    p = p.to_h.transform_values do |v|
-      if v.is_a? Hash
-        v.values.reject(&:empty?)
-      elsif v.is_a? Array
-        v.reject(&:empty?)
+    p = p.to_h.transform_values do |value|
+      if value.is_a?(Hash)
+        value.transform_values { |val| val.strip }.reject { |_, val| val.respond_to?(:empty?) && val.empty? }.values
+      elsif value.is_a?(Array)
+        value.map { |el| el.strip }.reject { |el| el.respond_to?(:empty?) && el.empty? }
       else
-        v
+        value.strip
       end
     end
 

--- a/app/controllers/concerns/submission_updater.rb
+++ b/app/controllers/concerns/submission_updater.rb
@@ -126,11 +126,9 @@ module SubmissionUpdater
     p['pullLocation'] = '' if p['isRemote']&.eql?('3')
     p = p.to_h.transform_values do |value|
       if value.is_a?(Hash)
-        value.transform_values { |val| val.strip }.reject { |_, val| val.respond_to?(:empty?) && val.empty? }.values
-      elsif value.is_a?(Array)
-        value.map { |el| el.strip }.reject { |el| el.respond_to?(:empty?) && el.empty? }
+        value.values.map { |v| normalize(v) }.reject { |v| v.respond_to?(:empty?) && v.empty? }
       else
-        value.strip
+        normalize(value)
       end
     end
 
@@ -151,4 +149,19 @@ module SubmissionUpdater
 
     p
   end
+
+  # this function will strip the values of all the types to ensure no spaces are kept in the user input
+  def normalize(value)
+    case value
+    when String
+      value.strip
+    when Array
+      value.map { |el| normalize(el) }.reject { |el| el.respond_to?(:empty?) && el.empty? }
+    when Hash
+      value.transform_values { |v| normalize(v) }.reject { |_, v| v.respond_to?(:empty?) && v.empty? }
+    else
+      value
+    end
+  end
+
 end

--- a/app/helpers/ontologies_helper.rb
+++ b/app/helpers/ontologies_helper.rb
@@ -322,7 +322,7 @@ module OntologiesHelper
 
   def subject_chip(subject)
     begin
-      agroportal_uri = "https://data.agroportal.lirmm.fr/ontologies/AGROVOC/classes/#{CGI.escape(subject)}"
+      agroportal_uri = "https://data.agroportal.lirmm.fr/ontologies/AGROVOC/classes/#{CGI.escape(subject.strip)}"
       response = LinkedData::Client::HTTP.get(
         agroportal_uri,
         params = {


### PR DESCRIPTION
### Context
related issue:
- https://github.com/agroportal/project-management/issues/744#issuecomment-3264937443

subject not shown correctly because the URIs of the subject has some white spaces. 

The root problem was that when we edit the ontology metadata sometimes the users add spaces or even add a white space elements without any character.

here we strip the values before saving the metadata.