### PR TITLE
Feat: Add agents number to the home page metrics section

### DIFF
--- a/app/helpers/metrics_helper.rb
+++ b/app/helpers/metrics_helper.rb
@@ -24,7 +24,8 @@ module MetricsHelper
       properties_count: prop_count,
       mappings_count: map_count,
       projects_count: projects_count,
-      users_count: users_count
+      users_count: users_count,
+      agents_count: agents_count
     }
   end
 
@@ -41,6 +42,12 @@ module MetricsHelper
   end
 
   private
+
+  def agents_count()
+    agents_page = LinkedData::Client::Models::Agent.all(include: "ID", page: 1, pagesize: 1, display_links: false, display_context: false).first
+    return 0 if agents_page.nil? || agents_page.errors
+    agents_page.respond_to?(:pageCount) ? agents_page.pageCount : 0
+  end
 
   def projects_count(ontologies_acronym = [])
     projects = LinkedData::Client::Models::Project.all

--- a/app/views/home/_metrics.html.haml
+++ b/app/views/home/_metrics.html.haml
@@ -43,5 +43,11 @@
           %h4
             = format_number_abbreviated(@metrics[:users_count])
           %p= t("home.users")
-    .home-statistics-link.justify-content-end{style: @analytics.empty? && "visibility: hidden"}
-      = link_to t("home.see_details"),'/statistics', target: "_blank"
+      .home-statistics-item
+        %hr/
+        %div
+          %h4
+            = format_number_abbreviated(@metrics[:agents_count])
+          %p= t("home.agents")
+    .home-statistics-link.justify-content-end
+      = link_to t("home.see_details"), '/statistics', target: "_blank", style: "font-size: 1em;"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -617,6 +617,7 @@ en:
     support_and_collaborations: Support & Collaborations
     twitter_news: News
     users: Users
+    agents: Agents
     view_full_site: View full website
     viewing_slice: 'Viewing the slice:'
   instances:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -633,6 +633,7 @@ fr:
     support_and_collaborations: Support & Collaborations
     twitter_news: Nouvelles
     users: Utilisateurs
+    agents: Agents
     view_full_site: Voir le site complet
     viewing_slice: 'Affichage de la slice:'
   instances:


### PR DESCRIPTION
See:
- https://github.com/ontoportal-lirmm/bioportal_web_ui/issues/1152

<img width="1340" height="253" alt="image" src="https://github.com/user-attachments/assets/886dac3b-1ea9-4a10-a12a-e9e8a802268f" />