### PR TITLE
Feature: Add edit sample queries component

### DIFF
--- a/app/components/sample_queries_edit_component.rb
+++ b/app/components/sample_queries_edit_component.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+class SampleQueriesEditComponent < ViewComponent::Base
+  include ModalHelper, ApplicationHelper
+  def initialize(sample_queries: [], graph: nil)
+    super
+    @sample_queries = sample_queries
+    @graph = graph
+  end
+end

--- a/app/components/sample_queries_edit_component/sample_queries_edit_component.html.haml
+++ b/app/components/sample_queries_edit_component/sample_queries_edit_component.html.haml
@@ -1,0 +1,4 @@
+= link_to_modal(t('sparql_endpoint.edit_sample_queries'),
+                edit_sample_queries_path(graph: @graph, sample_queries: @sample_queries),
+                id: "new_category_btn",
+                data: { show_modal_title_value: t('sparql_endpoint.edit_sample_queries')}) 

--- a/app/controllers/admin/catalog_configuration_controller.rb
+++ b/app/controllers/admin/catalog_configuration_controller.rb
@@ -73,7 +73,7 @@ class Admin::CatalogConfigurationController < ApplicationController
       usage: %w[knownUsage coverage example themeTaxonomy],
       methodology_and_provenance: %w[accrualMethod accrualPeriodicity accrualPolicy],
       media: %w[associatedMedia depiction logo],
-      other: %w[color federated_portals relation]
+      other: %w[color federated_portals relation sampleQueries]
     }.freeze
   end
 
@@ -164,8 +164,8 @@ class Admin::CatalogConfigurationController < ApplicationController
     config['rightsHolder'] = config['rightsHolder']&.first&.presence || '' if config['rightsHolder']
 
     # rebuild themeTaxonomy as URIs
-    config['themeTaxonomy'] = config['themeTaxonomy'].map { |value| "#{rest_url.chomp('/')}/#{value}" }
-    config['themeTaxonomy'] << "http://vocabularies.unesco.org/thesaurus"
+    config['themeTaxonomy'] = config['themeTaxonomy'].map { |value| "#{rest_url.chomp('/')}/#{value}" } if config['themeTaxonomy']
+    config['themeTaxonomy'] << "http://vocabularies.unesco.org/thesaurus" if config['themeTaxonomy']
     config.compact
   end
 

--- a/app/controllers/concerns/ontology_updater.rb
+++ b/app/controllers/concerns/ontology_updater.rb
@@ -26,7 +26,7 @@ module OntologyUpdater
     return {} unless params[:ontology]
 
     p = params.require(:ontology).permit(:name, :acronym, { administeredBy: [] }, :viewingRestriction, { acl: [] },
-                                         { hasDomain: [] }, :viewOf, :isView, :subscribe_notifications, { group: [] })
+                                         { hasDomain: [] }, :viewOf, :isView, :subscribe_notifications, { group: [] }, { sampleQueries: [] })
 
     p[:administeredBy].reject!(&:blank?) if p[:administeredBy]
     # p[:acl].reject!(&:blank?)

--- a/app/controllers/sparql_endpoint_controller.rb
+++ b/app/controllers/sparql_endpoint_controller.rb
@@ -1,5 +1,15 @@
 class SparqlEndpointController < ApplicationController
   layout :determine_layout
+  
+  include SparqlHelper
+
   def index
+    
+  end
+
+  def edit_sample_queries
+    @sample_queries = params[:sample_queries]  ? params[:sample_queries] : helpers.get_catalog_sample_queries
+    @graph = params[:graph]
+    render partial: 'sample_queries_edit_modal',layout: false
   end
 end

--- a/app/controllers/submissions_controller.rb
+++ b/app/controllers/submissions_controller.rb
@@ -68,6 +68,7 @@ class SubmissionsController < ApplicationController
 
   def edit
     @ontology = LinkedData::Client::Models::Ontology.find_by_acronym(params[:ontology_id]).first
+    @submission_latest = @ontology.explore.latest_submission({ display: 'sampleQueries' })
     ontology_not_found(params[:ontology_id]) unless @ontology
     category_attributes = submission_metadata.group_by{|x| x['category']}.transform_values{|x| x.map{|attr| attr['attribute']} }
     category_attributes = category_attributes.reject{|key| ['no'].include?(key.to_s)}

--- a/app/helpers/sparql_helper.rb
+++ b/app/helpers/sparql_helper.rb
@@ -60,14 +60,28 @@ module SparqlHelper
     end
   end
 
-  def sparql_query_container(username: current_user&.username, graph: nil, apikey: get_apikey, sparql_endpoint: "/sparql_proxy/")
+  def sparql_query_container(username: current_user&.username, graph: nil, apikey: get_apikey, sample_queries: nil, sparql_endpoint: "/sparql_proxy/")
     content_tag(:div, '', data: { controller: 'sparql',
                                   'sparql-proxy-value': $SPARQL_ENDPOINT_URL,
                                   'sparql-apikey-value': apikey,
                                   'sparql-username-value': username,
-                                  'sparql-graph-value': graph })
+                                  'sparql-graph-value': graph,
+                                  'sparql-sample-queries-value': sample_queries,
+                                })
   end
 
+  def get_catalog_sample_queries
+    begin
+      response = LinkedData::Client::HTTP.get("#{$REST_URL}", {include: "sampleQueries", display_context: false, display_links: false}, headers: {
+        'Cache-Control': 'no-cache',
+        'Pragma': 'no-cache'
+      })
+      response.to_hash[:sampleQueries]
+    rescue => e
+      logger.error "Failed to fetch catalog sample queries: #{e.message}"
+      []
+    end
+  end
   private
 
   def is_allowed_query?(sparql_query)

--- a/app/javascript/controllers/sparql_controller.js
+++ b/app/javascript/controllers/sparql_controller.js
@@ -1,73 +1,171 @@
 import { Controller } from '@hotwired/stimulus'
 import { getYasgui } from '../mixins/useYasgui'
 
-// Connects to data-controller="sparql"
 export default class extends Controller {
   static values = {
     proxy: String,
     apikey: String,
     graph: String,
+    sampleQueries: Array
   }
-  
-  connect () {
+
+  connect() {
     localStorage.removeItem('yagui__config');
     this.yasgui = getYasgui(this.element,
       {
         copyEndpointOnNewTab: true,
         requestConfig: {
-          endpoint: this.#proxyUrl(), 
+          endpoint: this.#proxyUrl(),
           acceptHeaderGraph: false,
           acceptHeaderUpdate: false,
         }
       })
 
-    // Add example query tabs
-    this.#addExampleTabs()
+    if (this.sampleQueriesValue.length > 0) {
+      this.#addExampleTabs()
+    }
+
+    this.#setupSaveButton()
+
   }
 
-  #proxyUrl(){
+  #proxyUrl() {
     return `${this.proxyValue}?default-graph-uri=${this.graphValue}&apikey=${this.apikeyValue}`
   }
 
   #addExampleTabs() {
-    // Wait a bit for YASGUI to fully initialize
+
     setTimeout(() => {
-      const queries = [
-        {
-          name: "Discover Classes",
-          query: `SELECT DISTINCT ?class (COUNT(?instance) AS ?instanceCount)
-WHERE {
-  ?instance a ?class .
-}
-GROUP BY ?class
-ORDER BY DESC(?instanceCount) LIMIT 10`
-        },
-        {
-          name: "Datatype Properties", 
-          query: `SELECT DISTINCT ?property ?datatype
-           (COUNT(*) AS ?usageCount)
-WHERE {
-  ?subject ?property ?object .
-  FILTER isLiteral(?object)
-  BIND(datatype(?object) AS ?datatype)
-}
-GROUP BY ?property ?datatype
-ORDER BY DESC(?usageCount) LIMIT 50`
-        },
-        {
-          name: "Explore All Triples",
-          query: `SELECT ?subject ?predicate ?object
-WHERE {
-  ?subject ?predicate ?object .
-} LIMIT 50`
-        }
-      ];
+      const queries = this.sampleQueriesValue;
       this.yasgui.getTab().close()
       for (let i = 0; i < queries.length; i++) {
-        const tab = this.yasgui.addTab(true, { name: queries[i].name}, {atIndex: 0});
-        tab.setQuery(queries[i].query);
+        const tab = this.yasgui.addTab(true, { name: `Sample query ${i + 1}` }, { atIndex: 0 });
+        tab.setQuery(queries[i]);
       }
+    }, 50);
+  }
 
-    }, 50); 
+  #setupSaveButton() {
+    const saveButton = document.getElementById('queries-save-button');
+    if (saveButton) {
+      saveButton.addEventListener('click', (e) => {
+        this.#showMessage('Query saved successfully', 'success');
+        e.preventDefault();
+        this.#saveCurrentQuery();
+      });
+    }
+  }
+
+  #saveCurrentQuery() {
+
+
+
+    const tabElements = document.querySelectorAll('.edit_sparql_container [role="tab"]');
+    const queries = [];
+    tabElements.forEach(tabElement => {
+      console.log('tabElement.id :', tabElement.id);
+      const tab = this.yasgui.getTab(`${tabElement.id.split('-')[1]}`);
+      query = tab.getQuery();
+      if (query) {
+        queries.push(query);
+      }
+    })
+    if (queries.length > 0) {
+      const ontologyId = this.#extractOntologyId();
+      this.#sendSaveRequest(queries, ontologyId);
+    }
+  }
+
+
+
+  #extractOntologyId() {
+    const graph = this.graphValue;
+    if (graph) {
+      const match = graph.match(/\/ontologies\/([^\/]+)\/submissions\/([^\/]+)/);
+      if (match) {
+        return `/ontologies/${match[1]}/submissions/${match[2]}`;
+      }
+    }
+    return null;
+  }
+
+  #sendSaveRequest(queries, ontologyId) {
+    console.log('queryKey :', queries);
+
+    const csrfToken = document.querySelector('meta[name="csrf-token"]')?.getAttribute('content');
+    const formData = new FormData();
+    formData.append('_method', 'patch');
+
+    const queryKey = ontologyId ? 'ontology[sampleQueries][]' : 'config[sampleQueries][]';
+    if (Array.isArray(queries)) {
+      queries.forEach(query => {
+        formData.append(queryKey, query);
+      });
+    } else {
+      formData.append(queryKey, queries);
+    }
+
+    const endpoint = ontologyId ? `${ontologyId}` : '/admin/catalog_configuration'
+    const graph = this.graphValue;
+
+    const match = graph.match(/\/ontologies\/([^\/]+)\/submissions\/([^\/]+)/);
+
+    if (ontologyId) {
+      formData.append('ontology_id', match[1]);
+    }
+
+    fetch(endpoint, {
+      method: 'POST',
+      headers: {
+        'X-CSRF-Token': csrfToken
+      },
+      body: formData
+    })
+      .then(response => {
+        if (response.ok) {
+          console.log('Queries saved successfully');
+        } else {
+          console.error('Failed to save queries');
+        }
+      })
+      .catch(error => {
+        console.error('Error saving queries:', error);
+      });
+  }
+
+
+  #showMessage(message, type) {
+    const notificationContainer = document.querySelector('.sparql-notifications');
+    const messageDiv = document.createElement('div');
+    messageDiv.textContent = message;
+    messageDiv.style.padding = '10px 20px';
+    messageDiv.style.borderRadius = '4px';
+    messageDiv.style.backgroundColor = type === 'success' ? '#d4edda' : '#f8d7da';
+    messageDiv.style.color = type === 'success' ? '#155724' : '#721c24';
+    messageDiv.style.border = type === 'success' ? '1px solid #c3e6cb' : '1px solid #f5c6cb';
+    messageDiv.style.marginBottom = '10px'
+
+    if (notificationContainer) {
+      notificationContainer.appendChild(messageDiv);
+
+      setTimeout(() => {
+        if (notificationContainer.contains(messageDiv)) {
+          notificationContainer.removeChild(messageDiv);
+        }
+      }, 3000);
+    } else {
+      messageDiv.style.position = 'fixed';
+      messageDiv.style.top = '20px';
+      messageDiv.style.right = '20px';
+      messageDiv.style.zIndex = '1000';
+
+      document.body.appendChild(messageDiv);
+
+      setTimeout(() => {
+        if (document.body.contains(messageDiv)) {
+          document.body.removeChild(messageDiv);
+        }
+      }, 3000);
+    }
   }
 }

--- a/app/views/admin/catalog_configuration/show.html.haml
+++ b/app/views/admin/catalog_configuration/show.html.haml
@@ -42,6 +42,9 @@
                       - else
                         = render Input::InputFieldComponent.new(name: "config[#{key}]", error_message: attribute_error(key.to_s)) do
                           = render NestedAgentSearchInputComponent.new(label: label_tooltip, agents: value_attr || [], agent_type: "", name_prefix: "config[#{key}]", editable: false, parent_id: key.to_s, create_new_agent_action: false)
+                    - elsif key == "sampleQueries"
+                      = render Input::InputFieldComponent.new(name: "config[#{key}]", label: "Sample Queries", error_message: attribute_error(key.to_s)) do
+                        = render SampleQueriesEditComponent.new()
                     - elsif attr_metadata.enforce.include?("list")
                       - if key == "themeTaxonomy"
                         = hidden_field_tag "config[#{key}][]", "", id: "empty_config_#{key}"
@@ -68,5 +71,6 @@
                       = switch_input(id: "config-boolean-#{key}", name: "config[#{key}]", label: label_tooltip, checked: (value_attr == true), value: (value_attr == true).to_s, boolean_switch: true)
                     - elsif attr_metadata.enforce.include?("date")
                       = date_input(name: "config[#{key}]", value: (Date.parse(value_attr).to_s rescue value_attr), label: label_tooltip, max_date: Date.today)
+
       .save-button
         = form_save_button

--- a/app/views/ontologies/sections/_sparql.html.haml
+++ b/app/views/ontologies/sections/_sparql.html.haml
@@ -1,4 +1,5 @@
 = render TurboFrameComponent.new(id: "sparql", data: {"turbo-frame-target": "frame"} ) do
   - if @ontology.private?
     = render Display::AlertComponent.new(type:'warning', closable: false, message: t('sparql_endpoint.private_ontology_warning'))
-  = sparql_query_container(graph: @submission_latest.id.gsub($REST_URL, 'http://data.bioontology.org'), sparql_endpoint: $SPARQL_ENDPOINT_URL)
+  = sparql_query_container(graph: @submission_latest.id.gsub($REST_URL, 'http://data.bioontology.org'), sparql_endpoint: $SPARQL_ENDPOINT_URL, sample_queries: @ontology.sampleQueries || [])
+  = render SampleQueriesEditComponent.new(sample_queries: @ontology.sampleQueries , graph: @submission_latest.id.gsub($REST_URL, 'http://data.bioontology.org'))

--- a/app/views/sparql_endpoint/_sample_queries_edit_modal.html.haml
+++ b/app/views/sparql_endpoint/_sample_queries_edit_modal.html.haml
@@ -1,0 +1,8 @@
+= render_in_modal do
+  - @title = t('admin.categories.edit.edit_category')
+  .sparql-notifications
+  .edit_sparql_container 
+    = sparql_query_container(sparql_endpoint: $SPARQL_ENDPOINT_URL, sample_queries: @sample_queries, graph: @graph)
+  .save-button
+    = regular_button('queries-save-button', t('components.save_button'), variant: "primary", size: "slim") do
+      = inline_svg_tag "check.svg"

--- a/app/views/sparql_endpoint/index.html.haml
+++ b/app/views/sparql_endpoint/index.html.haml
@@ -1,5 +1,6 @@
 .container.d-flex.flex-column.py-4{ style: "width: 1248px;" }
   .d-flex.justify-content-between
     = render PageHeaderComponent.new(title: t('sparql_endpoint.title'), description: t('sparql_endpoint.description'))
+  - sample_queries = get_catalog_sample_queries
   .sparql-page-text-area
-    = sparql_query_container(sparql_endpoint: $SPARQL_ENDPOINT_URL)
+    = sparql_query_container(sparql_endpoint: $SPARQL_ENDPOINT_URL, sample_queries: sample_queries)

--- a/app/views/submissions/edit.html.haml
+++ b/app/views/submissions/edit.html.haml
@@ -37,6 +37,9 @@
                     - properties = @category_attributes[key]
                     .edit-ontology-tab.tab-pane.fade{id: key.parameterize+'-tab', class: section.eql?(key.parameterize) ? 'active show' : ''}
                       = render TurboFrameComponent.new(id: "ontology-content-#{index}", loading:"lazy", src: "edit_properties?properties=#{properties.join(',')}&container_id=ontology-content-#{index}")
+                      - if key == 'general'
+                        = render Input::InputFieldComponent.new(name: "config[#{key}]", label: "Sample Queries", error_message: attribute_error(key.to_s)) do
+                          = render SampleQueriesEditComponent.new(sample_queries: @ontology.sampleQueries , graph: @submission_latest.id.gsub($REST_URL, 'http://data.bioontology.org'))
                 - else
                   - link  = ontology_submission_edit_properties_path(@ontology.acronym, params[:id], properties: @selected_attributes.join(','), container_id: 'ontology-content-0')
                   = render TurboFrameComponent.new(id: "ontology-content-0", loading:"lazy", src: link)

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1709,4 +1709,4 @@ en:
       manipulate semantic artefacts efficiently. '
     title: SPARQL Query Editor
     private_ontology_warning: Make the ontology public to enable access from the SPARQL endpoint.
-
+    edit_sample_queries: Edit sample queries

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -1764,3 +1764,4 @@ fr:
       pour récupérer, filtrer et manipuler efficacement des artefacts sémantiques.
     title: Éditeur de requêtes SPARQL
     private_ontology_warning: Rendez l'ontologie publique pour activer l'accès depuis l’endpoint SPARQL.
+    edit_sample_queries: Éditer les requêtes d'exemple

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -146,6 +146,7 @@ Rails.application.routes.draw do
   # SPARQL 
   match 'sparql_proxy', to: 'admin#sparql_endpoint', via: [:get, :post]
   get 'sparql', to: 'sparql_endpoint#index', as: 'sparql_endpoint'
+  get 'sparql/edit_sample_queries', to: 'sparql_endpoint#edit_sample_queries', as: 'edit_sample_queries'
 
   # Top-level pages
   match '/feedback', to: 'home#feedback', via: [:get, :post]


### PR DESCRIPTION
## Feature: Add edit sample queries component

This is a new component designed to edit SPARQL`sampleQueries` for Catalog and Ontologies. This feature allows users to curate sample queries more effectively by providing a dedicated interface for writing, testing, and saving queries


<img width="825" height="808" alt="Screenshot 2025-11-20 at 23 10 18" src="https://github.com/user-attachments/assets/34a20465-a0ce-423e-add3-8895ab1bf5d0" />
