### PR TITLE
Fix: Allow submissions to be downloaded anonymously

### DIFF
--- a/app/controllers/login_controller.rb
+++ b/app/controllers/login_controller.rb
@@ -144,7 +144,7 @@ class LoginController < ApplicationController
   private
 
   def append_apikey_if_rest_url(redirect_url, user)
-    return redirect_url if redirect_url.blank? || user.nil?
+    return redirect_url if redirect_url.blank?
 
     rest_url = LinkedData::Client.settings.rest_url
     fairness_url = $FAIRNESS_URL

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -70,11 +70,11 @@ module ApplicationHelper
     end
   end
 
-  def api_button_link_and_target(link)
-    if session[:user].nil?
+  def api_button_link_and_target(link, allow_annonymous = false)
+    if current_user.nil? && !allow_annonymous
       ["/login?redirect=#{escape(link)}", '_top']
     else
-      link = append_apikey_if_rest_url(link, session[:user])
+      link = append_apikey_if_rest_url(link, current_user)
       [link, '_blank']
     end
   end
@@ -519,8 +519,8 @@ module ApplicationHelper
 
   private
 
-  def append_apikey_if_rest_url(link, user)
-    return link if link.blank? || user.nil?
+  def append_apikey_if_rest_url(link, user = current_user)
+    return link if link.blank? 
     rest_url = LinkedData::Client.settings.rest_url
     fairness_url = $FAIRNESS_URL
     if link.include?(rest_url) || (fairness_url.present? && link.include?(fairness_url))
@@ -528,7 +528,7 @@ module ApplicationHelper
       return link unless uri
       params = URI.decode_www_form(uri.query || "")
       params.reject! { |k, v| k == "apikey" }
-      params << ["apikey", user.apikey]
+      params << ["apikey", get_apikey]
       uri.query = URI.encode_www_form(params)
       link = uri.to_s
     end

--- a/app/helpers/ontologies_helper.rb
+++ b/app/helpers/ontologies_helper.rb
@@ -176,21 +176,21 @@ module OntologiesHelper
       end
     else
       uri = submission.id + "/download"
-      href, target = api_button_link_and_target(uri)
+      href, target = api_button_link_and_target(uri, allow_annonymous = true)
       links << { href: href, label: submission.pretty_format, target: target }
       if submission_ready?(submission)
         uri = "#{ontology.id}/download?download_format=csv"
-        href, target = api_button_link_and_target(uri)
+        href, target = api_button_link_and_target(uri, allow_annonymous = true)
         links << { href: href, label: "CSV", target: target }
         unless submission.hasOntologyLanguage.eql?('UMLS')
           uri = "#{ontology.id}/download?download_format=rdf"
-          href, target = api_button_link_and_target(uri)
+          href, target = api_button_link_and_target(uri, allow_annonymous = true)
           links << { href: href, label: "RDF/XML", target: target }
         end
       end
       unless submission.diffFilePath.nil?
         uri = submission.id + "/download_diff"
-        href, target = api_button_link_and_target(uri)
+        href, target = api_button_link_and_target(uri, allow_annonymous = true)
         links << { href: href, label: "DIFF", target: target }
       end
     end
@@ -643,8 +643,7 @@ module OntologiesHelper
         title = label + '<br>' + link_to(link, target: '_blank')
       end
 
-      url, target_attr = api_button_link_and_target(link || '')
-
+      url, target_attr = api_button_link_and_target(link || '', allow_annonymous = true)
       content_tag(:span, data: {controller: "tooltip" }, title: title) do
         link_to(inline_svg("#{icon}.svg", width: "32", height: '32'), url, link_options.merge(target: target_attr))
       end

--- a/config/bioportal_config_test.rb
+++ b/config/bioportal_config_test.rb
@@ -166,6 +166,12 @@ $PORTALS_INSTANCES = [
     apikey: "47a57aa3-7b54-4f34-b695-dbb5f5b7363e",
     color: '#349696',
     'light-color': '#EBF5F5',
+  },
+  {
+    name: 'testportal-down',
+    ui: 'https://down.testportal.lirmm.fr/',
+    api: 'https://down.testportal.lirmm.fr/',
+    apikey: "47a57aa3-7b54-4f34-b695-dbb5f5b7363e",
   }
 ]
 

--- a/test/helpers/application_helper_test.rb
+++ b/test/helpers/application_helper_test.rb
@@ -12,39 +12,4 @@ class ApplicationHelperTest < ActionView::TestCase
     LinkedData::Client.settings.rest_url = @original_rest_url if @original_rest_url
     $FAIRNESS_URL = @original_fairness_url
   end
-
-  test "append_apikey_if_rest_url with a URL that has no query params" do
-    user = OpenStruct.new(apikey: "user_api_key")
-    rest_url = "http://api.example.com"
-    LinkedData::Client.settings.rest_url = rest_url
-    
-    link = "http://api.example.com/ontologies/TEST/download"
-    # This used to raise "undefined method `ascii_only?' for []:Array"
-    result = append_apikey_if_rest_url(link, user)
-    
-    assert_includes result, "apikey=user_api_key"
-  end
-
-  test "append_apikey_if_rest_url with a URL that already has an apikey" do
-    user = OpenStruct.new(apikey: "new_api_key")
-    rest_url = "http://api.example.com"
-    LinkedData::Client.settings.rest_url = rest_url
-    
-    link = "http://api.example.com/ontologies/TEST/download?apikey=old_api_key"
-    result = append_apikey_if_rest_url(link, user)
-    
-    assert_includes result, "apikey=new_api_key"
-    refute_includes result, "apikey=old_api_key"
-  end
-
-  test "append_apikey_if_rest_url with fairness URL" do
-    user = OpenStruct.new(apikey: "user_api_key")
-    $FAIRNESS_URL = "http://fairness.example.com"
-    LinkedData::Client.settings.rest_url = "http://api.example.com"
-    
-    link = "http://fairness.example.com/evaluate"
-    result = append_apikey_if_rest_url(link, user)
-    
-    assert_includes result, "apikey=user_api_key"
-  end
 end

--- a/test/system/federation_test.rb
+++ b/test/system/federation_test.rb
@@ -83,12 +83,12 @@ class FederationTest < ApplicationSystemTestCase
   end
 
   test 'federated_search_when_portal_down' do
-    visit "#{@search_path}?q=#{@query}&lang=all&portals%5B%5D=industryportal"
+    visit "#{@search_path}?q=#{@query}&lang=all&portals%5B%5D=testportal-down"
     assert_selector ".alert-warning-type", visible: true
   end
 
   test 'federated_browse_when_portal_down' do
-    visit "#{@ontologies_path}?sort_by=ontology_name&portals=industryportal"
+    visit "#{@ontologies_path}?sort_by=ontology_name&portals=testportal-down"
     loop do
       loading_element = find_all(".browse-sket").any?
 


### PR DESCRIPTION
- Allow users to download ontologies without logging in:  
  - If the user is not logged in, use the UI’s API key.  
  - If the user is logged in, use the user’s own API key.
- The redirection still occurs when you click the API contextual buttons.

<img width="708" height="506" alt="Screenshot 2026-03-31 at 12 24 17" src="https://github.com/user-attachments/assets/b3bb5719-b50d-4753-9ab7-acc748640005" />
