### PR TITLE
fix/ translates the ontology submission form into French

### DIFF
--- a/app/components/nested_form_inputs_component/nested_form_inputs_component.html.haml
+++ b/app/components/nested_form_inputs_component/nested_form_inputs_component.html.haml
@@ -31,4 +31,4 @@
   %div.add-another-object{data: {action:"click->nested-form#add"}}
     = inline_svg 'icons/plus.svg', width: "14px", height: "14px"
     %div
-      = t("components.add_another_object", object_name: t("components.#{@object_name}", default: @object_name), default: "Add another #{@object_name}")
+      = t("components.add_another_object", object_name: t("components.#{@object_name}"))

--- a/app/components/nested_form_inputs_component/nested_form_inputs_component.html.haml
+++ b/app/components/nested_form_inputs_component/nested_form_inputs_component.html.haml
@@ -31,4 +31,4 @@
   %div.add-another-object{data: {action:"click->nested-form#add"}}
     = inline_svg 'icons/plus.svg', width: "14px", height: "14px"
     %div
-      Add another #{@object_name}
+      = t("components.add_another_object", object_name: t("components.#{@object_name}", default: @object_name), default: "Add another #{@object_name}")

--- a/app/helpers/submission_inputs_helper.rb
+++ b/app/helpers/submission_inputs_helper.rb
@@ -108,11 +108,11 @@ module SubmissionInputsHelper
 
   end
 
-  def ontology_name_input(ontology = @ontology, label: t('submission_inputs.name', default: "Name"))
+  def ontology_name_input(ontology = @ontology, label: t('submission_inputs.name'))
     text_input(name: 'ontology[name]', value: ontology.name, label: label_required(label))
   end
 
-  def ontology_acronym_input(ontology = @ontology, update: @is_update_ontology, label: t('submission_inputs.acronym', default: "Acronym"))
+  def ontology_acronym_input(ontology = @ontology, update: @is_update_ontology, label: t('submission_inputs.acronym'))
     out = text_input(name: 'ontology[acronym]', value: ontology.acronym, disabled: update, label: label_required(label))
     out += hidden_field_tag('ontology[acronym]', ontology.acronym) if update
     out
@@ -131,7 +131,7 @@ module SubmissionInputsHelper
     categories_children = categories_with_children(categories)
     categories_parents = categories_with_parents(categories_children)
 
-    render Input::InputFieldComponent.new(name: '', label: t('submission_inputs.categories', default: "Categories")) do
+    render Input::InputFieldComponent.new(name: '', label: t('submission_inputs.categories')) do
       content_tag(:div, class: 'upload-ontology-chips-container', 'data-controller': 'parent-categories-selector',
       'data-parent-categories-selector-categories-children-value': "#{categories_children.to_json}",
       'data-parent-categories-selector-categories-parents-value': "#{categories_parents.to_json}",
@@ -150,7 +150,7 @@ module SubmissionInputsHelper
 
   def ontology_submission_subjects_input
     attr_key = "hasDomain"
-    label = t('submission_inputs.subjects', default: "Subjects")
+    label = t('submission_inputs.subjects')
     attr = SubmissionMetadataInput.new(attribute_key: attr_key, submission: @submission, label: label, attr_metadata: attr_metadata(attr_key))
     ontologies = get_theme_taxonomy_ontologies || []
     resolved_subjects = []
@@ -206,7 +206,7 @@ module SubmissionInputsHelper
   def has_ontology_language_input(submission = @submission)
     render(Layout::RevealComponent.new(possible_values: %w[SKOS OBO UMLS OWL], selected: submission.hasOntologyLanguage)) do |c|
       c.button do
-        attribute_input("hasOntologyLanguage", label: t('ontologies.attributes.hasOntologyLanguage', default: 'Representation language'))
+        attribute_input("hasOntologyLanguage", label: t('submission_inputs.hasOntologyLanguage'))
       end
 
       c.container { ontology_skos_language_help }

--- a/app/helpers/submission_inputs_helper.rb
+++ b/app/helpers/submission_inputs_helper.rb
@@ -108,11 +108,11 @@ module SubmissionInputsHelper
 
   end
 
-  def ontology_name_input(ontology = @ontology, label: 'Name')
+  def ontology_name_input(ontology = @ontology, label: t('submission_inputs.name', default: "Name"))
     text_input(name: 'ontology[name]', value: ontology.name, label: label_required(label))
   end
 
-  def ontology_acronym_input(ontology = @ontology, update: @is_update_ontology, label: 'Acronym')
+  def ontology_acronym_input(ontology = @ontology, update: @is_update_ontology, label: t('submission_inputs.acronym', default: "Acronym"))
     out = text_input(name: 'ontology[acronym]', value: ontology.acronym, disabled: update, label: label_required(label))
     out += hidden_field_tag('ontology[acronym]', ontology.acronym) if update
     out
@@ -131,7 +131,7 @@ module SubmissionInputsHelper
     categories_children = categories_with_children(categories)
     categories_parents = categories_with_parents(categories_children)
 
-    render Input::InputFieldComponent.new(name: '', label: 'Categories') do
+    render Input::InputFieldComponent.new(name: '', label: t('submission_inputs.categories', default: "Categories")) do
       content_tag(:div, class: 'upload-ontology-chips-container', 'data-controller': 'parent-categories-selector',
       'data-parent-categories-selector-categories-children-value': "#{categories_children.to_json}",
       'data-parent-categories-selector-categories-parents-value': "#{categories_parents.to_json}",
@@ -206,7 +206,7 @@ module SubmissionInputsHelper
   def has_ontology_language_input(submission = @submission)
     render(Layout::RevealComponent.new(possible_values: %w[SKOS OBO UMLS OWL], selected: submission.hasOntologyLanguage)) do |c|
       c.button do
-        attribute_input("hasOntologyLanguage")
+        attribute_input("hasOntologyLanguage", label: t('ontologies.attributes.hasOntologyLanguage', default: 'Representation language'))
       end
 
       c.container { ontology_skos_language_help }

--- a/app/helpers/submission_inputs_helper.rb
+++ b/app/helpers/submission_inputs_helper.rb
@@ -150,7 +150,7 @@ module SubmissionInputsHelper
 
   def ontology_submission_subjects_input
     attr_key = "hasDomain"
-    label = "Subjects"
+    label = t('submission_inputs.subjects', default: "Subjects")
     attr = SubmissionMetadataInput.new(attribute_key: attr_key, submission: @submission, label: label, attr_metadata: attr_metadata(attr_key))
     ontologies = get_theme_taxonomy_ontologies || []
     resolved_subjects = []

--- a/app/helpers/submissions_helper.rb
+++ b/app/helpers/submissions_helper.rb
@@ -203,10 +203,8 @@ module SubmissionsHelper
   end
   
   def equivalent_ontology_property(attr)
-    equivalents = ontology_properties
-    found = equivalents.select { |x| x.is_a?(Array) ? x[1].eql?(attr.to_sym) : x.eql?(attr)}
-    
-    found.empty? ? nil : found.first.is_a?(Array) ? found.first[1] : found.first
+    found = ontology_properties.select { |x| x[1].eql?(attr.to_sym) }
+    found.empty? ? nil : found.first[1]
   end
 
   def equivalent_ontology_properties(attr_labels)
@@ -215,7 +213,16 @@ module SubmissionsHelper
   end
 
   def ontology_properties
-    ['acronym', 'name', [t('submission_inputs.visibility'), :viewingRestriction], 'viewOf', ['Groups', :group], ['Categories', :hasDomain], [t('submission_inputs.administrators'), :administeredBy], ['Sample Queries', :sampleQueries]]
+    [
+      [t('submission_inputs.acronym'), :acronym],
+      [t('submission_inputs.name'), :name],
+      [t('submission_inputs.visibility'), :viewingRestriction],
+      [t('submission_inputs.view_of'), :viewOf],
+      [t('submission_inputs.groups'), :group],
+      [t('submission_inputs.categories'), :hasDomain],
+      [t('submission_inputs.administrators'), :administeredBy],
+      [t('submission_inputs.sample_queries'), :sampleQueries]
+    ]
   end
 
   def submission_editable_properties
@@ -227,9 +234,7 @@ module SubmissionsHelper
       end
     end
 
-    properties += ontology_properties.map do |x|
-      x.is_a?(Array) ? x : [x.to_s.underscore.humanize, x]
-    end
+    properties += ontology_properties
 
     properties
   end

--- a/app/helpers/submissions_helper.rb
+++ b/app/helpers/submissions_helper.rb
@@ -203,8 +203,10 @@ module SubmissionsHelper
   end
   
   def equivalent_ontology_property(attr)
-    found = ontology_properties.select { |x| x[1].eql?(attr.to_sym) }
-    found.empty? ? nil : found.first[1]
+    equivalents = ontology_properties
+    found = equivalents.select { |x| x.is_a?(Array) ? x[1].eql?(attr.to_sym) : x.eql?(attr)}
+    
+    found.empty? ? nil : found.first.is_a?(Array) ? found.first[1] : found.first
   end
 
   def equivalent_ontology_properties(attr_labels)

--- a/app/helpers/submissions_helper.rb
+++ b/app/helpers/submissions_helper.rb
@@ -236,7 +236,9 @@ module SubmissionsHelper
       end
     end
 
-    properties += ontology_properties
+    properties += ontology_properties.map do |x|
+      x.is_a?(Array) ? x : [x.to_s.underscore.humanize, x]
+    end
 
     properties
   end

--- a/app/views/ontologies/new.html.haml
+++ b/app/views/ontologies/new.html.haml
@@ -25,7 +25,7 @@
                   .upload-ontology-input-field-container
                     = attribute_input('URI', label: t("ontologies.uri"))
                   .upload-ontology-input-field-container
-                    = attribute_input('description', long_text: true)
+                    = attribute_input('description', label: t('ontologies.attributes.description', default: 'Description'), long_text: true)
                   - if @is_update_ontology
                     .upload-ontology-input-field-container{id: "submissionnotes_from_group_input"}
                       = attribute_input("notes", label: t("ontologies.change_notes"), long_text: true)
@@ -34,11 +34,11 @@
                   .upload-ontology-field-container.mt-3
                     = render Layout::RevealComponent.new(selected: @submission.status, possible_values: ['retired']) do |c|
                       - c.button do
-                        = attribute_input("status")
+                        = attribute_input("status", label: t('ontologies.attributes.status', default: 'Status'))
                       - c.container do
                         .upload-ontology-field-container
                           - @submission.valid = nil unless @submission.status&.eql?('retired')
-                          = attribute_input("valid")
+                          = attribute_input("valid", label: t('ontologies.attributes.valid', default: 'Valid'))
                   .upload-ontology-field-container.mt-3
                     = render partial: 'ontologies/submission_location_form'
 

--- a/app/views/ontologies/new.html.haml
+++ b/app/views/ontologies/new.html.haml
@@ -25,7 +25,7 @@
                   .upload-ontology-input-field-container
                     = attribute_input('URI', label: t("ontologies.uri"))
                   .upload-ontology-input-field-container
-                    = attribute_input('description', label: t('ontologies.attributes.description', default: 'Description'), long_text: true)
+                    = attribute_input('description', label: t('ontologies.attributes.description'), long_text: true)
                   - if @is_update_ontology
                     .upload-ontology-input-field-container{id: "submissionnotes_from_group_input"}
                       = attribute_input("notes", label: t("ontologies.change_notes"), long_text: true)
@@ -34,11 +34,11 @@
                   .upload-ontology-field-container.mt-3
                     = render Layout::RevealComponent.new(selected: @submission.status, possible_values: ['retired']) do |c|
                       - c.button do
-                        = attribute_input("status", label: t('ontologies.attributes.status', default: 'Status'))
+                        = attribute_input("status", label: t('ontologies.attributes.status'))
                       - c.container do
                         .upload-ontology-field-container
                           - @submission.valid = nil unless @submission.status&.eql?('retired')
-                          = attribute_input("valid", label: t('ontologies.attributes.valid', default: 'Valid'))
+                          = attribute_input("valid", label: t('ontologies.attributes.valid'))
                   .upload-ontology-field-container.mt-3
                     = render partial: 'ontologies/submission_location_form'
 

--- a/app/views/ontologies/new.html.haml
+++ b/app/views/ontologies/new.html.haml
@@ -25,7 +25,7 @@
                   .upload-ontology-input-field-container
                     = attribute_input('URI', label: t("ontologies.uri"))
                   .upload-ontology-input-field-container
-                    = attribute_input('description', label: t('ontologies.attributes.description'), long_text: true)
+                    = attribute_input('description', label: t('submission_inputs.description'), long_text: true)
                   - if @is_update_ontology
                     .upload-ontology-input-field-container{id: "submissionnotes_from_group_input"}
                       = attribute_input("notes", label: t("ontologies.change_notes"), long_text: true)
@@ -34,11 +34,11 @@
                   .upload-ontology-field-container.mt-3
                     = render Layout::RevealComponent.new(selected: @submission.status, possible_values: ['retired']) do |c|
                       - c.button do
-                        = attribute_input("status", label: t('ontologies.attributes.status'))
+                        = attribute_input("status", label: t('submission_inputs.status'))
                       - c.container do
                         .upload-ontology-field-container
                           - @submission.valid = nil unless @submission.status&.eql?('retired')
-                          = attribute_input("valid", label: t('ontologies.attributes.valid'))
+                          = attribute_input("valid", label: t('submission_inputs.valid'))
                   .upload-ontology-field-container.mt-3
                     = render partial: 'ontologies/submission_location_form'
 

--- a/app/views/submissions/edit.html.haml
+++ b/app/views/submissions/edit.html.haml
@@ -2,12 +2,12 @@
 .center
   .edit-ontology-container
     .ontology-details-path
-      %a{href: "/ontologies"} Ontologies
+      %a{href: "/ontologies"}= t('ontologies.self')
       = inline_svg_tag 'arrow-right-outlined.svg'
       %a{href: "/ontologies/#{@ontology.acronym}"}= @ontology.acronym
       = inline_svg_tag 'arrow-right-outlined.svg'
       %div
-        = "Submissions"
+        = t('ontologies.sections.submissions')
       = inline_svg_tag 'arrow-right-outlined.svg'
       %div
         = params["id"]

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -395,6 +395,9 @@ en:
     preferred_name: Preferred name
     type: Type
   components:
+    add_another_object: "Add another %{object_name}"
+    contact: "contact"
+    portal: "portal"
     all_languages: All languages
     back: Back
     by: by
@@ -950,6 +953,12 @@ en:
     problem_of_creating_new_term: 'Problem creating a new term %{endpoint}: %{class}
       - %{message}'
   ontologies:
+    attributes:
+      description: 'Description'
+      status: 'Status'
+      valid: 'Valid date'
+      hasOntologyLanguage: 'Representation language'
+
     access_rights_information: Additional license and access rights information
     admin:
       title: "Administration"
@@ -1524,6 +1533,9 @@ en:
     title: "%{portal} Statistics"
     users: Users
   submission_inputs:
+    name: Name
+    acronym: Acronym
+    categories: Categories
     accounts_allowed: Add or remove accounts that are allowed to see this ontology
       in %{portal_name}.
     administrators: Administrators

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1596,6 +1596,8 @@ en:
     subjects: Subjects
     theme_taxonomy_not_set: Please set the themeTaxonomy field in the admin page to use it for subjects search
     subjects_notice: "The 'Subjects' must be selected from the following set of ontologies: %{ontologies}. If you wish to add another keyword or controlled term, use the 'Keywords' property."
+    attributes:
+      description: Description
   submissions:
     actions: Actions
     delete_submission_alert:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1591,6 +1591,9 @@ en:
       an ontology, see %{link}
     version_helper_link: guidelines and recommendations.
     visibility: Visibility
+    view_of: View of
+    sample_queries: Sample queries
+    subjects: Subjects
     theme_taxonomy_not_set: Please set the themeTaxonomy field in the admin page to use it for subjects search
     subjects_notice: "The 'Subjects' must be selected from the following set of ontologies: %{ontologies}. If you wish to add another keyword or controlled term, use the 'Keywords' property."
   submissions:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -953,11 +953,6 @@ en:
     problem_of_creating_new_term: 'Problem creating a new term %{endpoint}: %{class}
       - %{message}'
   ontologies:
-    attributes:
-      description: 'Description'
-      status: 'Status'
-      valid: 'Valid date'
-      hasOntologyLanguage: 'Representation language'
 
     access_rights_information: Additional license and access rights information
     admin:
@@ -1596,8 +1591,10 @@ en:
     subjects: Subjects
     theme_taxonomy_not_set: Please set the themeTaxonomy field in the admin page to use it for subjects search
     subjects_notice: "The 'Subjects' must be selected from the following set of ontologies: %{ontologies}. If you wish to add another keyword or controlled term, use the 'Keywords' property."
-    attributes:
-      description: Description
+    description: 'Description'
+    status: 'Status'
+    valid: 'Valid date'
+    hasOntologyLanguage: 'Representation language'
   submissions:
     actions: Actions
     delete_submission_alert:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -984,11 +984,6 @@ fr:
     problem_of_creating_new_term: 'Problème de création d''un nouveau terme %{endpoint}
       : %{class} - %{message}'
   ontologies:
-    attributes:
-      description: 'Description'
-      status: 'Statut'
-      valid: 'Date de validité'
-      hasOntologyLanguage: 'Langage de représentation'
 
     access_rights_information: Informations supplémentaires sur la licence et les
       droits d'accès
@@ -1641,6 +1636,10 @@ fr:
     visibility: Visibilité
     view_of: Vue de
     sample_queries: Requêtes d'exemple
+    description: 'Description'
+    status: 'Statut'
+    valid: 'Date de validité'
+    hasOntologyLanguage: 'Langage de représentation'
     subjects: Sujets
     theme_taxonomy_not_set: Veuillez définir le champ themeTaxonomy dans la page d'administration pour l'utiliser pour la recherche des sujets
     subjects_notice: "Les 'Subjets' doivent être sélectionnés dans l'ensemble d'ontologies suivant: %{ontologies}. Si vous souhaitez ajouter un autre mot-clé ou terme de vocabulaire, utilisez la propriété 'Mots-clés'."

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -405,7 +405,7 @@ fr:
     preferred_name: Nom préféré
     type: Type
   components:
-    add_another_object: "Ajouter un(e) autre %{object_name}"
+    add_another_object: "Ajouter un autre %{object_name}"
     contact: "contact"
     portal: "portail"
     all_languages: Toutes les langues

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -1643,7 +1643,9 @@ fr:
     sample_queries: Requêtes d'exemple
     subjects: Sujets
     theme_taxonomy_not_set: Veuillez définir le champ themeTaxonomy dans la page d'administration pour l'utiliser pour la recherche des sujets
-    subjects_notice: "Les 'Sujets' doivent être sélectionnés dans l'ensemble d'ontologies suivant: %{ontologies}. Si vous souhaitez ajouter un autre mot-clé ou terme de vocabulaire, utilisez la propriété 'Mots-clés'."
+    subjects_notice: "Les 'Subjets' doivent être sélectionnés dans l'ensemble d'ontologies suivant: %{ontologies}. Si vous souhaitez ajouter un autre mot-clé ou terme de vocabulaire, utilisez la propriété 'Mots-clés'."
+    attributes:
+      description: Description
   submissions:
     actions: Actions
     delete_submission_alert:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -1639,8 +1639,11 @@ fr:
       de version dans une ontologie, consultez %{link}
     version_helper_link: recommandations.
     visibility: Visibilité
+    view_of: Vue de
+    sample_queries: Requêtes d'exemple
+    subjects: Sujets
     theme_taxonomy_not_set: Veuillez définir le champ themeTaxonomy dans la page d'administration pour l'utiliser pour la recherche des sujets
-    subjects_notice: "Les 'Subjets' doivent être sélectionnés dans l'ensemble d'ontologies suivant: %{ontologies}. Si vous souhaitez ajouter un autre mot-clés ou termes de vocabulaires, utiliser la propriété 'Keywords'."
+    subjects_notice: "Les 'Sujets' doivent être sélectionnés dans l'ensemble d'ontologies suivant: %{ontologies}. Si vous souhaitez ajouter un autre mot-clé ou terme de vocabulaire, utilisez la propriété 'Mots-clés'."
   submissions:
     actions: Actions
     delete_submission_alert:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -405,6 +405,9 @@ fr:
     preferred_name: Nom préféré
     type: Type
   components:
+    add_another_object: "Ajouter un(e) autre %{object_name}"
+    contact: "contact"
+    portal: "portail"
     all_languages: Toutes les langues
     back: Retour
     by: par
@@ -981,6 +984,12 @@ fr:
     problem_of_creating_new_term: 'Problème de création d''un nouveau terme %{endpoint}
       : %{class} - %{message}'
   ontologies:
+    attributes:
+      description: 'Description'
+      status: 'Statut'
+      valid: 'Date de validité'
+      hasOntologyLanguage: 'Langage de représentation'
+
     access_rights_information: Informations supplémentaires sur la licence et les
       droits d'accès
     admin:
@@ -1574,6 +1583,9 @@ fr:
     title: Statistiques de %{portal}
     users: Utilisateurs
   submission_inputs:
+    name: Nom
+    acronym: Acronyme
+    categories: 'Catégories'
     accounts_allowed: Ajouter ou supprimer des comptes autorisés à voir cette ontologie
       dans %{portal_name}.
     administrators: Administrateurs

--- a/test/system/submission_flows_test.rb
+++ b/test/system/submission_flows_test.rb
@@ -611,7 +611,7 @@ class SubmissionFlowsTest < ApplicationSystemTestCase
   def fill_ontology(new_ontology, new_submission, add_submission: false)
     within 'form#ontologyForm' do
       # Page 1
-      fill_in 'ontology[name]', with: new_ontology.name
+        fill_in 'ontology[name]', with: new_ontology.name
       fill_in 'ontology[acronym]', with: new_ontology.acronym unless add_submission
 
       tom_select 'ontology[viewingRestriction]', new_ontology.viewingRestriction

--- a/test/system/submission_flows_test.rb
+++ b/test/system/submission_flows_test.rb
@@ -611,7 +611,7 @@ class SubmissionFlowsTest < ApplicationSystemTestCase
   def fill_ontology(new_ontology, new_submission, add_submission: false)
     within 'form#ontologyForm' do
       # Page 1
-        fill_in 'ontology[name]', with: new_ontology.name
+      fill_in 'ontology[name]', with: new_ontology.name
       fill_in 'ontology[acronym]', with: new_ontology.acronym unless add_submission
 
       tom_select 'ontology[viewingRestriction]', new_ontology.viewingRestriction


### PR DESCRIPTION
This PR translates the ontology submission form into French.
1-Fixed hardcoded English labels (Name, Acronym, Description, etc.).
2-Added missing keys in fr.yml and en.yml.

<img width="1236" height="940" alt="image" src="https://github.com/user-attachments/assets/3613f714-d240-4432-bc65-343f245ad0b9" />
<img width="1241" height="961" alt="image" src="https://github.com/user-attachments/assets/ed666938-850d-4d86-982f-34981467b5f5" />
<img width="1241" height="961" alt="image" src="https://github.com/user-attachments/assets/514acb3e-fb6b-4ca5-9408-194ec5723dc6" />
