### PR TITLE
Feature: Add `Subjects` and `Categories` components to the metadata administration page

### DIFF
--- a/app/helpers/submission_inputs_helper.rb
+++ b/app/helpers/submission_inputs_helper.rb
@@ -25,13 +25,13 @@ module SubmissionInputsHelper
     end
 
     def values
-      @submission.send(@attr_metadata['attribute'])
+      @submission.send(@attr_metadata['attribute']) if @attr_metadata && @submission
     rescue StandardError
       nil
     end
 
     def help_text
-      CGI.unescape_html(@attr_metadata['helpText']) if @attr_metadata['helpText']
+      CGI.unescape_html(@attr_metadata['helpText']) if @attr_metadata && @attr_metadata['helpText']
     end
 
     def label
@@ -41,7 +41,7 @@ module SubmissionInputsHelper
     end
 
     def type?(type)
-      @attr_metadata['enforce'].include?(type)
+      @attr_metadata && @attr_metadata['enforce'] && @attr_metadata['enforce'].include?(type)
     end
 
     def metadata
@@ -49,7 +49,7 @@ module SubmissionInputsHelper
     end
 
     def required?
-      Array(@attr_metadata['enforce']).include?('existence')
+      @attr_metadata && Array(@attr_metadata['enforce']).include?('existence')
     end
   end
 
@@ -537,25 +537,29 @@ module SubmissionInputsHelper
     label = attr.label
     help = attr.help_text
     required = attr.required?
-    attr = attr.metadata
-    attribute = !attr['namespace'].nil? ? "#{attr['namespace']}:#{attr['attribute']}" : "bioportal:#{attr['attribute']}"
+    metadata = attr.metadata
+    if metadata
+      attribute = !metadata['namespace'].nil? ? "#{metadata['namespace']}:#{metadata['attribute']}" : "bioportal:#{metadata['attribute']}"
+    else
+      attribute = attr.attr_key.to_s
+    end
 
     title = content_tag(:span, "#{label} (#{attribute})")
     title += content_tag(:span, 'required', class: 'badge badge-danger mx-1') if required
 
     render SummarySectionComponent.new(title: title, show_card: false) do
       help_text = ''
-      unless attr['metadataMappings'].nil?
-        help_text += render(FieldContainerComponent.new(label: t('submission_inputs.equivalents'), value: attr['metadataMappings'].join(', ')))
+      if metadata && !metadata['metadataMappings'].nil?
+        help_text += render(FieldContainerComponent.new(label: t('submission_inputs.equivalents'), value: metadata['metadataMappings'].join(', ')))
       end
 
-      unless attr['enforce'].nil? || attr['enforce'].empty?
-        help_text += render(FieldContainerComponent.new(label: t('submission_inputs.validators'), value: attr['enforce'].map do |x|
+      if metadata && !metadata['enforce'].nil? && !metadata['enforce'].empty?
+        help_text += render(FieldContainerComponent.new(label: t('submission_inputs.validators'), value: metadata['enforce'].map do |x|
           content_tag(:span, x.humanize, class: 'badge badge-primary mx-1')
         end.join.html_safe))
       end
 
-      unless attr['helpText'].nil?
+      if help.present?
         help_text += render(FieldContainerComponent.new(label: t('submission_inputs.help_text'), value: help.html_safe))
       end
 

--- a/app/helpers/submissions_helper.rb
+++ b/app/helpers/submissions_helper.rb
@@ -198,6 +198,8 @@ module SubmissionsHelper
     out = submission_metadata.map { |x| x['attribute'] }.reject { |x| equivalents.include?(x) }
     out << [:format, format_equivalent]
     out << [:location, location_equivalent]
+    # Add mapping for subjects to hasDomain for submission scope
+    out << [:subjects, :hasDomain]
 
     out
   end
@@ -221,7 +223,12 @@ module SubmissionsHelper
   def submission_editable_properties
     properties = submission_properties.map do |x|
       if x.is_a? Array
-        [attr_label(x[0], show_tooltip: false), x[0]]
+        # Special case for subjects
+        if x[0] == :subjects
+          ['Subjects', :subjects]
+        else
+          [attr_label(x[0], show_tooltip: false), x[0]]
+        end
       else
         [attr_label(x, show_tooltip: false), x]
       end

--- a/app/helpers/submissions_helper.rb
+++ b/app/helpers/submissions_helper.rb
@@ -383,4 +383,22 @@ module SubmissionsHelper
       output.html_safe
     end
   end
+
+  # Returns the display label for a property key as shown in the dropdown
+  def property_label(key)
+    # Look in ontology_properties first
+    ontology_properties.each do |item|
+      if item.is_a?(Array) && item[1].to_s == key.to_s
+        return item[0]
+      elsif item.to_s == key.to_s
+        return item.to_s.humanize
+      end
+    end
+    # Look in submission_editable_properties
+    submission_editable_properties.each do |label, value|
+      return label if value.to_s == key.to_s
+    end
+    # Fallback to humanize
+    key.to_s.humanize
+  end
 end

--- a/app/views/ontologies_metadata_curator/_attribute.html.haml
+++ b/app/views/ontologies_metadata_curator/_attribute.html.haml
@@ -23,6 +23,36 @@
                 - elsif attribute == "naturalLanguage"
                   - submission.send(attribute).each do |lang|
                     = render LanguageFieldComponent.new(value: lang)
+                - elsif attribute == "hasDomain"
+                  - if from_ontology
+                    - values = ontology.instance_values[attr.to_s]
+                  - else
+                    - values = submission.instance_values[attr.to_s]
+                  - domains = show_ontology_domains(Array(values))
+                  - unless domains.empty?
+                    - if from_ontology
+                      - domains.each do |domain|
+                        = category_chip(domain)
+                    - else
+                      - theme_taxonomy_ontologies = get_theme_taxonomy_ontologies() || []
+                      - domains.each do |domain|
+                        = subject_chip(domain, theme_taxonomy_ontologies)
+                - elsif attribute == "subjects"
+                  - # Subjects always from submission
+                  - values = submission.instance_values["hasDomain"]
+                  - domains = show_ontology_domains(Array(values))
+                  - unless domains.empty?
+                    - theme_taxonomy_ontologies = get_theme_taxonomy_ontologies() || []
+                    - domains.each do |domain|
+                      = subject_chip(domain, theme_taxonomy_ontologies)
+                - elsif attribute == "keywords"
+                  - if from_ontology
+                    - values = ontology.instance_values[attr.to_s]
+                  - else
+                    - values = submission.instance_values[attr.to_s]
+                  - keyword_list = Array(values).flat_map { |v| v.to_s.split(',') }.map(&:strip).reject(&:empty?)
+                  - keyword_list.each do |keyword|
+                    = keyword_chip(keyword)
                 - elsif attribute == "ontology"
                   = acronym
                 - else
@@ -40,6 +70,6 @@
                       %p
                         = value
             %div
-              - if !from_ontology
+              - if !from_ontology || attribute == "hasDomain"
                 = edit_submission_property_link(acronym, submission.submissionId, attribute) do
                   %i.far.fa-edit

--- a/app/views/ontologies_metadata_curator/_metadata_table.html.haml
+++ b/app/views/ontologies_metadata_curator/_metadata_table.html.haml
@@ -15,11 +15,9 @@
         - @metadata_sel.each do |meta|
           - h.th do
             %div
+              - label = property_label(meta)
               - attr_metadata = attr_metadata(meta)
-              - if attr_metadata
-                %h6{style:'margin-top: 0.2rem'}=attr_label(meta, attr_metadata: attr_metadata)
-              - else
-                %h6{style:'margin-top: 0.2rem'}=meta
+              %h6{style:'margin-top: 0.2rem'}=attr_label(meta, label, attr_metadata: attr_metadata)
 
       - @hash.each do |acronym, data|
         - ontology = data[:ontology]


### PR DESCRIPTION
- Related Issue : https://github.com/agroportal/project-management/issues/810

1. Fix the issue of **Subjects** not appearing in the list.
2. Harmonize **Categories**, **Subjects**, and **Keywords** with the ontology description page.

<img width="1902" height="546" alt="Screenshot 2026-04-14 at 13 03 34" src="https://github.com/user-attachments/assets/a54bd037-05e8-436d-9836-7665af3d2298" />
