### PR TITLE
Style: Update synonym badge styling 

### DIFF
--- a/app/helpers/multi_languages_helper.rb
+++ b/app/helpers/multi_languages_helper.rb
@@ -180,7 +180,7 @@ module MultiLanguagesHelper
     elsif label.is_a?(Array)
       list_items_component(max_items: show_max) do |r|
         label.map do |x|
-          r.container { content_tag(:span, x, class: style_as_badge ? 'badge bg-secondary' : '').html_safe }
+          r.container { content_tag(:span, x, class: style_as_badge ? 'badge badge-pill p-2' : '', style: 'font-style: italic; color:var(--primary-color); background-color: var(--light-color);').html_safe }        
         end
       end
     else


### PR DESCRIPTION
- related issue 
  - https://github.com/agroportal/project-management/issues/813#issuecomment-3907908851
  - https://github.com/agroportal/bioportal_web_ui/issues/1214
  
## Changes
1. Change the synonym pill’s color to match the portal colors.  
2. Make the text italic.
<img width="1316" height="754" alt="Screenshot 2026-04-14 at 17 46 35" src="https://github.com/user-attachments/assets/47b678b8-3c37-4bcb-a5a9-a4f08c715bae" />
