### PR TITLE
Fix: Exclude current ontology from viewOf select list

### DIFF
--- a/app/helpers/submission_inputs_helper.rb
+++ b/app/helpers/submission_inputs_helper.rb
@@ -265,7 +265,8 @@ module SubmissionInputsHelper
       end
       c.container do
         content_tag(:div) do
-          render SelectInputComponent.new(id: 'viewOfSelect', values: onts_for_select, name: 'ontology[viewOf]', selected: ontology.viewOf&.split('/')&.last)
+          filtered_values = onts_for_select.reject { |label, acronym| acronym == ontology.acronym }
+          render SelectInputComponent.new(id: 'viewOfSelect', values: filtered_values, name: 'ontology[viewOf]', selected: ontology.viewOf&.split('/')&.last)
         end
       end
     end


### PR DESCRIPTION
## Fix: Exclude current ontology from viewOf select list
- Related issue: https://github.com/agroportal/project-management/issues/809

Prevent an ontology from being selected as a view of itself by filtering out the current ontology's acronym from the list of options.
  
  https://github.com/user-attachments/assets/372a80db-03f9-49fb-97b8-29fc057aa4b2