### PR TITLE
feat: Use api_button_link_and_target helper for API JSON/RDF buttons

### DIFF
--- a/app/views/annotator/index.html.haml
+++ b/app/views/annotator/index.html.haml
@@ -97,11 +97,13 @@
                     = result[:score] 
         .annotator-bottom-actions
           .json-button
-            = render Buttons::RegularButtonComponent.new(id:'annotator_json', value: "JSON", variant: "secondary", href: @json_link, size: "slim", target: '_blank', state: "regular") do |btn|
+            - json_href, json_target = api_button_link_and_target(@json_link)
+            = render Buttons::RegularButtonComponent.new(id:'annotator_json', value: "JSON", variant: "secondary", href: json_href, size: "slim", target: json_target, state: "regular") do |btn|
               - btn.icon_left do
                 = inline_svg_tag "json.svg"
           .rdf-button
-            = render Buttons::RegularButtonComponent.new(id:'annotator_rdf', value: "RDF", variant: "secondary", href: @rdf_link, size: "slim", target: '_blank', state: "regular") do |btn|
+            - rdf_href, rdf_target = api_button_link_and_target(@rdf_link)
+            = render Buttons::RegularButtonComponent.new(id:'annotator_rdf', value: "RDF", variant: "secondary", href: rdf_href, size: "slim", target: rdf_target, state: "regular") do |btn|
               - btn.icon_left do
                 = inline_svg_tag "summary/sparql.svg"
           .cite-us-button

--- a/app/views/recommender/index.html.haml
+++ b/app/views/recommender/index.html.haml
@@ -111,7 +111,8 @@
                     = render Input::RadioChipComponent.new(label: result[:annotations].length.to_s+' annotations', name: 'highlighted_recommendation', value: result[:annotations], checked: result[:highlighted])
         .recommender-bottom-actions
           .json-button
-            = render Buttons::RegularButtonComponent.new(id:'recommender_cite_json', value: "JSON", variant: "secondary", href: @json_link, size: "slim", target: '_blank', state: "regular") do |btn|
+            - json_href, json_target = api_button_link_and_target(@json_link)
+            = render Buttons::RegularButtonComponent.new(id:'recommender_cite_json', value: "JSON", variant: "secondary", href: json_href, size: "slim", target: json_target, state: "regular") do |btn|
               - btn.icon_left do
                 = inline_svg_tag "json.svg"
           .cite-us-button

--- a/app/views/search/index.html.haml
+++ b/app/views/search/index.html.haml
@@ -43,7 +43,8 @@
               = "#{t('search.match_in')} #{@search_results.length} #{t('search.ontologies')} #{t('search.from')} #{request_portals_names(@federation_counts, @time)}".html_safe
           %div.d-flex
             .search-page-advanced-button.mr-4{class: @search_results.blank? ? 'd-none' : ''}
-              %a.d-flex{href: @json_url, target: '_blank'}
+              - json_href, json_target = api_button_link_and_target(@json_url)
+              %a.d-flex{href: json_href, target: json_target}
                 = text_with_icon(text: "API JSON", icon: 'json.svg')
 
             .search-page-advanced-button.show-options{class: "#{@advanced_options_open ? 'd-none' : ''}",'data': {'action': 'click->reveal-component#show', 'reveal-component-target': 'showButton'}}


### PR DESCRIPTION
- Related issue: https://github.com/agroportal/bioportal_web_ui/issues/1233

Apply api_button_link_and_target to the annotator JSON/RDF buttons, the search API JSON button, and the recommender JSON button so anonymous users are redirected to login and authenticated users get the apikey appended automatically.