### PR TITLE
feat: Support choosing from multiple SPARQL endpoints via dropdown action icon

### DIFF
--- a/app/controllers/ontologies_controller.rb
+++ b/app/controllers/ontologies_controller.rb
@@ -369,7 +369,6 @@ class OntologiesController < ApplicationController
                             %w[summary/homepage homepage],
                             %w[summary/documentation documentation],
                             %w[icons/github repository],
-                            %w[summary/sparql endpoint],
                             %w[icons/publication publication],
                             %w[icons/searching_database openSearchDescription]
     ]

--- a/app/helpers/ontologies_helper.rb
+++ b/app/helpers/ontologies_helper.rb
@@ -665,8 +665,6 @@ module OntologiesHelper
     end
   end
 
-  private
-
   def ontology_icon_button(icon, url, title, interactive: false, **options)
     data = { controller: 'tooltip' }
     data['tooltip-interactive-value'] = 'true' if interactive

--- a/app/helpers/ontologies_helper.rb
+++ b/app/helpers/ontologies_helper.rb
@@ -628,47 +628,77 @@ module OntologiesHelper
 
   def ontology_icon_links(links, submission_latest)
     links.map do |icon, attr, label|
-      raw_value = submission_latest.nil? ? nil : submission_latest.send(attr)
+      raw_value = submission_latest&.send(attr)
       values = Array(raw_value).compact.reject(&:blank?)
 
-      link_options = {
-        style: "text-decoration: none; width: 30px; height: 30px"
-      }
-
       if values.empty?
-        link_options[:class] = 'disabled-icon'
-        link_options[:disabled] = 'disabled'
-        title = label
-        
-        content_tag(:span, data: {controller: "tooltip" }, title: title) do
-          link_to(inline_svg("#{icon}.svg", width: "32", height: '32'), "javascript:void(0);", link_options)
-        end
+        ontology_icon_button(icon, "javascript:void(0);", label, class: 'disabled-icon', disabled: 'disabled')
       elsif values.size == 1
         link = values.first
-        title = label + '<br>' + link_to(link, target: '_blank')
-        url, target_attr = api_button_link_and_target(link, allow_annonymous = true)
-        
-        content_tag(:span, data: {controller: "tooltip" }, title: title) do
-          link_to(inline_svg("#{icon}.svg", width: "32", height: '32'), url, link_options.merge(target: target_attr))
-        end
+        url, target = api_button_link_and_target(link, true)
+        title = label + '<br>' + link_to(link, link, target: '_blank')
+        ontology_icon_button(icon, url, title, interactive: false, target: target)
       else
-        title = label
-        content_tag(:span, data: {controller: "tooltip"}, title: title) do
-          content_tag(:div, class: "dropdown d-inline-block") do
-            trigger = link_to(inline_svg("#{icon}.svg", width: "32", height: '32'), "#", class: "text-decoration-none", id: "dropdown_icon_#{attr}", data: { toggle: "dropdown", bs_toggle: "dropdown" }, aria: { haspopup: "true", expanded: "false" }, style: "width: 30px; height: 30px;")
-            
-            menu = content_tag(:div, class: "dropdown-menu shadow border-0 rounded p-2", aria: { labelledby: "dropdown_icon_#{attr}" }, style: "left: 50%; transform: translateX(-50%); min-width: max-content;") do
-              values.map do |v|
-                content_tag(:div, class: "p-1") do
-                  render LinkFieldComponent.new(value: v, raw: true, enable_copy: true)
-                end
-              end.join.html_safe
-            end
-            trigger + menu
-          end
-        end
+        ontology_render_icon_dropdown(icon, attr, label, values)
       end
     end.join.html_safe
+  end
+
+  def ontology_sparql_endpoint_link(submission_latest)
+    icon = 'summary/sparql'
+    attr = 'endpoint'
+    label = attr_label(attr, attr_metadata: attr_metadata(attr), show_tooltip: false)
+    
+    raw_value = submission_latest&.send(attr)
+    values = Array(raw_value).compact.reject(&:blank?)
+
+    if values.empty?
+      ontology_icon_button(icon, "javascript:void(0);", label, class: 'disabled-icon', disabled: 'disabled')
+    elsif values.size == 1
+      link = values.first
+      url, target = api_button_link_and_target(link, true)
+      title = label + '<br>' + link_to(link, link, target: '_blank')
+      ontology_icon_button(icon, url, title, interactive: true, target: target)
+    else
+      title = "<b>#{label}</b>" + values.map { |v| "<br>" + link_to(v, v, target: '_blank') }.join
+      ontology_icon_button(icon, "javascript:void(0);", title, interactive: true)
+    end
+  end
+
+  private
+
+  def ontology_icon_button(icon, url, title, interactive: false, **options)
+    data = { controller: 'tooltip' }
+    data['tooltip-interactive-value'] = 'true' if interactive
+    
+    options[:style] ||= "text-decoration: none; width: 30px; height: 30px"
+    
+    content_tag(:span, data: data, title: title) do
+      link_to(inline_svg("#{icon}.svg", width: "32", height: '32'), url, options)
+    end
+  end
+
+  def ontology_render_icon_dropdown(icon, attr, label, values)
+    content_tag(:span, data: { controller: 'tooltip' }, title: label) do
+      content_tag(:div, class: 'dropdown d-inline-block') do
+        trigger = link_to(inline_svg("#{icon}.svg", width: '32', height: '32'), '#',
+                          class: 'text-decoration-none', id: "dropdown_icon_#{attr}",
+                          data: { toggle: 'dropdown', bs_toggle: 'dropdown' },
+                          aria: { haspopup: 'true', expanded: 'false' },
+                          style: 'width: 30px; height: 30px;')
+
+        menu = content_tag(:div, class: 'dropdown-menu shadow border-0 rounded p-2',
+                           aria: { labelledby: "dropdown_icon_#{attr}" },
+                           style: 'left: 50%; transform: translateX(-50%); min-width: max-content;') do
+          values.map do |v|
+            content_tag(:div, class: 'p-1') do
+              render LinkFieldComponent.new(value: v, raw: true, enable_copy: true)
+            end
+          end.join.html_safe
+        end
+        trigger + menu
+      end
+    end
   end
 
   def ontology_depiction_card

--- a/app/helpers/ontologies_helper.rb
+++ b/app/helpers/ontologies_helper.rb
@@ -628,24 +628,45 @@ module OntologiesHelper
 
   def ontology_icon_links(links, submission_latest)
     links.map do |icon, attr, label|
-      value = submission_latest.nil? ? nil : submission_latest.send(attr)
-      link = Array(value).first || ''
+      raw_value = submission_latest.nil? ? nil : submission_latest.send(attr)
+      values = Array(raw_value).compact.reject(&:blank?)
 
       link_options = {
         style: "text-decoration: none; width: 30px; height: 30px"
       }
 
-      if link.blank?
+      if values.empty?
         link_options[:class] = 'disabled-icon'
         link_options[:disabled] = 'disabled'
         title = label
-      else
+        
+        content_tag(:span, data: {controller: "tooltip" }, title: title) do
+          link_to(inline_svg("#{icon}.svg", width: "32", height: '32'), "javascript:void(0);", link_options)
+        end
+      elsif values.size == 1
+        link = values.first
         title = label + '<br>' + link_to(link, target: '_blank')
-      end
-
-      url, target_attr = api_button_link_and_target(link || '', allow_annonymous = true)
-      content_tag(:span, data: {controller: "tooltip" }, title: title) do
-        link_to(inline_svg("#{icon}.svg", width: "32", height: '32'), url, link_options.merge(target: target_attr))
+        url, target_attr = api_button_link_and_target(link, allow_annonymous = true)
+        
+        content_tag(:span, data: {controller: "tooltip" }, title: title) do
+          link_to(inline_svg("#{icon}.svg", width: "32", height: '32'), url, link_options.merge(target: target_attr))
+        end
+      else
+        title = label
+        content_tag(:span, data: {controller: "tooltip"}, title: title) do
+          content_tag(:div, class: "dropdown d-inline-block") do
+            trigger = link_to(inline_svg("#{icon}.svg", width: "32", height: '32'), "#", class: "text-decoration-none", id: "dropdown_icon_#{attr}", data: { toggle: "dropdown", bs_toggle: "dropdown" }, aria: { haspopup: "true", expanded: "false" }, style: "width: 30px; height: 30px;")
+            
+            menu = content_tag(:div, class: "dropdown-menu shadow border-0 rounded p-2", aria: { labelledby: "dropdown_icon_#{attr}" }, style: "left: 50%; transform: translateX(-50%); min-width: max-content;") do
+              values.map do |v|
+                content_tag(:div, class: "p-1") do
+                  render LinkFieldComponent.new(value: v, raw: true, enable_copy: true)
+                end
+              end.join.html_safe
+            end
+            trigger + menu
+          end
+        end
       end
     end.join.html_safe
   end

--- a/app/views/ontologies/sections/metadata/_ontology_description_section.html.haml
+++ b/app/views/ontologies/sections/metadata/_ontology_description_section.html.haml
@@ -71,6 +71,7 @@
   %hr.w-100.my-3
   .icons_container
     = ontology_icon_links(@ontology_icon_links, @submission_latest)
+    = ontology_sparql_endpoint_link(@submission_latest)
   %hr.w-100.my-3
   %div.text-center.pb-3
     = link_to_modal(nil, metadata_export_index_path(ontology: @ontology.acronym), {data: {show_modal_title_value: metadata_filled_count, show_modal_size_value: 'modal-xl' }}) do


### PR DESCRIPTION
introduces support for displaying and interacting with multiple SPARQL endpoints (or any other properties returning multiple links) within the ontology action icons bar. Previously, if an ontology had multiple endpoints, the script would arbitrarily truncate the options and only render the first one.

Related Issue: https://github.com/agroportal/bioportal_web_ui/issues/1220#event-24113933719

[demo4.webm](https://github.com/user-attachments/assets/5dcce16b-c2f3-486b-82e0-98c9f2d0f385)


