### PR TITLE
feat: Add generic ontology class picker for keyClasses and exampleIdentifier

### DIFF
--- a/app/assets/stylesheets/components/nested_form.scss
+++ b/app/assets/stylesheets/components/nested_form.scss
@@ -16,7 +16,8 @@
   border: 1px solid var(--primary-color) !important;
 }
 
-.nested-form-input-container .delete{
+.nested-form-input-container .delete,
+.ontology-class-single-picker .delete{
   display: flex;
   border: 1px dashed #BDBDBD;
   justify-content: center;

--- a/app/assets/stylesheets/components/search_input.scss
+++ b/app/assets/stylesheets/components/search_input.scss
@@ -52,6 +52,27 @@
   max-width: 280px;
 }
 
+.class-picker-display{
+  display: flex;
+  flex-direction: column;
+  padding: 6px 10px;
+  border: 1px solid #e6e6e6;
+  border-radius: 4px;
+  background: #fafafa;
+
+  .class-label_name{
+    margin: 0;
+    font-weight: 500;
+    color: #333;
+    word-break: break-word;
+  }
+
+  .class-uri{
+    color: #777;
+    word-break: break-all;
+  }
+}
+
 .searched-elements{
   margin-bottom: 0;
 }

--- a/app/components/ontology_class_search_input_component.rb
+++ b/app/components/ontology_class_search_input_component.rb
@@ -1,13 +1,18 @@
 # frozen_string_literal: true
 
 class OntologyClassSearchInputComponent < ViewComponent::Base
-  def initialize(ontology_acronym:, name_prefix:, values: [])
+  def initialize(ontology_acronym:, name_prefix:, values: [], multiple: true)
     @ontology_acronym = ontology_acronym
     @name_prefix = name_prefix
     @values = values
+    @multiple = multiple
   end
 
   def row_class
     "nested-#{@name_prefix.parameterize}-form-input-row"
+  end
+
+  def multiple?
+    @multiple
   end
 end

--- a/app/components/ontology_class_search_input_component.rb
+++ b/app/components/ontology_class_search_input_component.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class OntologyClassSearchInputComponent < ViewComponent::Base
+  def initialize(ontology_acronym:, name_prefix:, values: [])
+    @ontology_acronym = ontology_acronym
+    @name_prefix = name_prefix
+    @values = values
+  end
+
+  def row_class
+    "nested-#{@name_prefix.parameterize}-form-input-row"
+  end
+end

--- a/app/components/ontology_class_search_input_component/ontology_class_search_input_component.html.haml
+++ b/app/components/ontology_class_search_input_component/ontology_class_search_input_component.html.haml
@@ -1,6 +1,6 @@
 = render NestedFormInputsComponent.new(object_name: 'class') do |c|
   - c.template do
-    .ontology-classes-container{ data: { controller: "class-picker", "class-picker-name-prefix-value": @name_prefix, "class-picker-row-class-value": row_class } }
+    .ontology-classes-container{ data: { controller: "class-picker", "class-picker-name-prefix-value": @name_prefix, "class-picker-row-class-value": row_class, "class-picker-show-uri-value": "true" } }
       .search-wrapper{ data: { "class-picker-target": "searchWrapper" } }
         = helpers.ontology_classes_content_autocomplete(ontology_acronym: @ontology_acronym)
       .ontology-classes-list{ data: { "class-picker-target": "list" } }
@@ -10,7 +10,9 @@
     - label = v[:label]
     - c.row do
       %div{class: row_class}
-        = helpers.text_input(name: "", value: label, readonly: true)
+        .class-picker-display
+          %p.class-label_name= label
+          %small.class-uri= value
         = hidden_field_tag "#{@name_prefix}[#{i}]", value
 
   - c.empty_state do

--- a/app/components/ontology_class_search_input_component/ontology_class_search_input_component.html.haml
+++ b/app/components/ontology_class_search_input_component/ontology_class_search_input_component.html.haml
@@ -1,19 +1,41 @@
-= render NestedFormInputsComponent.new(object_name: 'class') do |c|
-  - c.template do
-    .ontology-classes-container{ data: { controller: "class-picker", "class-picker-name-prefix-value": @name_prefix, "class-picker-row-class-value": row_class, "class-picker-show-uri-value": "true" } }
-      .search-wrapper{ data: { "class-picker-target": "searchWrapper" } }
-        = helpers.ontology_classes_content_autocomplete(ontology_acronym: @ontology_acronym)
-      .ontology-classes-list{ data: { "class-picker-target": "list" } }
+- if multiple?
+  = render NestedFormInputsComponent.new(object_name: 'class') do |c|
+    - c.template do
+      .ontology-classes-container{ data: { controller: "class-picker", "class-picker-name-prefix-value": @name_prefix, "class-picker-row-class-value": row_class, "class-picker-show-uri-value": "true" } }
+        .search-wrapper{ data: { "class-picker-target": "searchWrapper" } }
+          = helpers.ontology_classes_content_autocomplete(ontology_acronym: @ontology_acronym)
+        .ontology-classes-list{ data: { "class-picker-target": "list" } }
 
-  - Array(@values).each_with_index do |v, i|
-    - value = v[:value]
-    - label = v[:label]
-    - c.row do
-      %div{class: row_class}
-        .class-picker-display
-          %p.class-label_name= label
-          %small.class-uri= value
-        = hidden_field_tag "#{@name_prefix}[#{i}]", value
+    - Array(@values).each_with_index do |v, i|
+      - value = v[:value]
+      - label = v[:label]
+      - c.row do
+        %div{class: row_class}
+          .class-picker-display
+            %p.class-label_name= label
+            %small.class-uri= value
+          = hidden_field_tag "#{@name_prefix}[#{i}]", value
 
-  - c.empty_state do
-    = hidden_field_tag "#{@name_prefix}[0]", ""
+    - c.empty_state do
+      = hidden_field_tag "#{@name_prefix}[0]", ""
+
+- else
+  - picked = Array(@values).reject { |v| v[:value].blank? }.first
+  .ontology-class-single-picker{ data: { controller: "class-picker", "class-picker-name-prefix-value": @name_prefix, "class-picker-single-value": "true" } }
+    %template{ data: { "class-picker-target": "deleteIconTemplate" } }
+      = inline_svg 'icons/delete.svg'
+    .search-wrapper{ data: { "class-picker-target": "searchWrapper" } }
+      = helpers.ontology_classes_content_autocomplete(ontology_acronym: @ontology_acronym)
+    .picked-class{ data: { "class-picker-target": "picked" } }
+      - if picked
+        %div.d-flex.align-items-center.nested-form-wrapper.my-1
+          %div{ style: 'width: 90%' }
+            .class-picker-display
+              %p.class-label_name= picked[:label]
+              %small.class-uri= picked[:value]
+          %div.d-flex.justify-content-end{ style: 'width: 10%' }
+            %div.delete{ data: { action: "click->class-picker#removePicked" } }
+              = inline_svg 'icons/delete.svg'
+        = hidden_field_tag @name_prefix, picked[:value]
+      - else
+        = hidden_field_tag @name_prefix, ""

--- a/app/components/ontology_class_search_input_component/ontology_class_search_input_component.html.haml
+++ b/app/components/ontology_class_search_input_component/ontology_class_search_input_component.html.haml
@@ -1,0 +1,17 @@
+= render NestedFormInputsComponent.new(object_name: 'class') do |c|
+  - c.template do
+    .ontology-classes-container{ data: { controller: "class-picker", "class-picker-name-prefix-value": @name_prefix, "class-picker-row-class-value": row_class } }
+      .search-wrapper{ data: { "class-picker-target": "searchWrapper" } }
+        = helpers.ontology_classes_content_autocomplete(ontology_acronym: @ontology_acronym)
+      .ontology-classes-list{ data: { "class-picker-target": "list" } }
+
+  - Array(@values).each_with_index do |v, i|
+    - value = v[:value]
+    - label = v[:label]
+    - c.row do
+      %div{class: row_class}
+        = helpers.text_input(name: "", value: label, readonly: true)
+        = hidden_field_tag "#{@name_prefix}[#{i}]", value
+
+  - c.empty_state do
+    = hidden_field_tag "#{@name_prefix}[0]", ""

--- a/app/components/subjects_search_input_component/subjects_search_input_component.html.haml
+++ b/app/components/subjects_search_input_component/subjects_search_input_component.html.haml
@@ -6,10 +6,10 @@
       = t('submission_inputs.subjects_notice', ontologies: @ontologies.join(','))
 
   - c.template do
-    .subjects-container{ data: { controller: "subjects" } }
-      .search-wrapper{ data: { subjects_target: "searchWrapper" } }
+    .subjects-container{ data: { controller: "class-picker", "class-picker-name-prefix-value": "submission[hasDomain]", "class-picker-row-class-value": "nested-subjects-form-input-row" } }
+      .search-wrapper{ data: { "class-picker-target": "searchWrapper" } }
         = helpers.subjects_ontologies_content_autocomplete(ontologies: @ontologies)
-      .subjects-list{ data: { subjects_target: "list" } }
+      .subjects-list{ data: { "class-picker-target": "list" } }
 
   - Array(@values).each_with_index do |v, i|
     - value = v[:value]

--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -114,6 +114,43 @@ class SearchController < ApplicationController
     render plain: response, content_type: content_type
   end
 
+  def json_ontology_classes_search
+    acronym = params[:ontology_acronym]
+    query = params[:search].to_s
+    page_size = (params[:page_size] || 25).to_i
+
+    if acronym.blank? || query.blank?
+      render json: []
+      return
+    end
+
+    query = "#{query.strip}*" unless query.end_with?('*')
+
+    search_page = LinkedData::Client::Models::Class.search(query, {
+      ontologies: acronym,
+      pagesize: page_size,
+      also_search_obsolete: false,
+      also_search_views: false,
+      include: 'prefLabel,synonym,definition'
+    })
+
+    results = Array(search_page&.collection).map do |cls|
+      ontology_link = cls.links && cls.links['ontology']
+      ontology_acronym = ontology_link ? ontology_link.split('/').last : acronym
+      label = main_language_label(cls.prefLabel) || cls.id
+
+      {
+        id: cls.id,
+        name: cls.id,
+        label: label,
+        acronym: ontology_acronym,
+        type: 'Class'
+      }
+    end
+
+    render json: results
+  end
+
   def json_ontology_content_search
     query = params[:search] || '*'
     page = (params[:page] || 1).to_i

--- a/app/helpers/auto_complete_helper.rb
+++ b/app/helpers/auto_complete_helper.rb
@@ -24,6 +24,21 @@ module AutoCompleteHelper
   end
 
 
+  def ontology_classes_content_autocomplete(ontology_acronym:, id: '', name: '', search: '', search_icon_type: nil)
+    render SearchInputComponent.new(id: id, name: name,
+                                    ajax_url: "/ajax/search/ontologies/#{ontology_acronym}/classes?search=#{search}",
+                                    item_base_url: "", id_key: 'id', placeholder: t("ontologies.class_search_prompt"),
+                                    use_cache: false, search_icon_type: search_icon_type, display_all: true) do |s|
+      s.template do
+        content_tag(:div, class: "search-content clickable-result", data: { action: "click->class-picker#addResult" }, 'data-turbo-frame': '_top') do
+          content_tag(:div, class: 'search-element home-searched-ontology flex-column') do
+            content_tag(:p, "LABEL", class: "class-label_name") + content_tag(:small, "NAME", class: "class-uri") + content_tag(:small, "ACRONYM", class: 'text-primary')
+          end + content_tag(:p, "TYPE", class: 'home-result-type')
+        end
+      end
+    end
+  end
+
   def subjects_ontologies_content_autocomplete(id: '', name: '', search: '', ontologies: [], types: [], search_icon_type: nil)
     if ontologies.empty?
       render Display::AlertComponent.new(type:'warning', closable: false, message: t('submission_inputs.theme_taxonomy_not_set'))
@@ -32,7 +47,7 @@ module AutoCompleteHelper
                                       item_base_url: "", id_key: 'id', placeholder: t("ontologies.ontology_search_prompt"),
                                       use_cache: false, search_icon_type: search_icon_type, display_all: true) do |s|
         s.template do
-          content_tag(:div, class: "search-content clickable-result", data: {action: "click->subjects#addResult"},'data-turbo-frame': '_top') do
+          content_tag(:div, class: "search-content clickable-result", data: {action: "click->class-picker#addResult"},'data-turbo-frame': '_top') do
             content_tag(:div, class: 'search-element home-searched-ontology flex-column') do
               content_tag(:p, "LABEL", class: "class-label_name") + content_tag(:small, "NAME", class: "class-uri") + content_tag(:small, "ACRONYM", class: 'text-primary')
             end + content_tag(:p, "TYPE", class: 'home-result-type')

--- a/app/helpers/submission_inputs_helper.rb
+++ b/app/helpers/submission_inputs_helper.rb
@@ -438,11 +438,11 @@ module SubmissionInputsHelper
   end
 
   def ontology_class_list_attribute?(attr_key)
-    %w[keyClasses exampleIdentifier].include?(attr_key.to_s)
+    %w[keyClasses].include?(attr_key.to_s)
   end
 
   def ontology_class_single_attribute?(attr_key)
-    %w[obsoleteParent].include?(attr_key.to_s)
+    %w[obsoleteParent exampleIdentifier].include?(attr_key.to_s)
   end
 
   def generate_ontology_class_picker_input(attr)

--- a/app/helpers/submission_inputs_helper.rb
+++ b/app/helpers/submission_inputs_helper.rb
@@ -434,17 +434,27 @@ module SubmissionInputsHelper
   end
 
   def ontology_class_attribute?(attr_key)
+    ontology_class_list_attribute?(attr_key) || ontology_class_single_attribute?(attr_key)
+  end
+
+  def ontology_class_list_attribute?(attr_key)
     %w[keyClasses exampleIdentifier].include?(attr_key.to_s)
   end
 
+  def ontology_class_single_attribute?(attr_key)
+    %w[obsoleteParent].include?(attr_key.to_s)
+  end
+
   def generate_ontology_class_picker_input(attr)
+    multiple = ontology_class_list_attribute?(attr.attr_key)
     values = Array(attr.values).reject(&:blank?).map do |uri|
       { value: uri, label: resolve_ontology_class_label(uri, @ontology.acronym) }
     end
     render Input::InputFieldComponent.new(name: '', label: attr_header_label(attr), error_message: attribute_error(attr.attr)) do
       render OntologyClassSearchInputComponent.new(ontology_acronym: @ontology.acronym,
                                                    name_prefix: attr.name,
-                                                   values: values)
+                                                   values: values,
+                                                   multiple: multiple)
     end
   end
 

--- a/app/helpers/submission_inputs_helper.rb
+++ b/app/helpers/submission_inputs_helper.rb
@@ -438,12 +438,30 @@ module SubmissionInputsHelper
   end
 
   def generate_ontology_class_picker_input(attr)
-    values = Array(attr.values).reject(&:blank?).map { |uri| { value: uri, label: uri } }
+    values = Array(attr.values).reject(&:blank?).map do |uri|
+      { value: uri, label: resolve_ontology_class_label(uri, @ontology.acronym) }
+    end
     render Input::InputFieldComponent.new(name: '', label: attr_header_label(attr), error_message: attribute_error(attr.attr)) do
       render OntologyClassSearchInputComponent.new(ontology_acronym: @ontology.acronym,
                                                    name_prefix: attr.name,
                                                    values: values)
     end
+  end
+
+  def resolve_ontology_class_label(class_uri, ontology_acronym)
+    return class_uri if class_uri.blank? || ontology_acronym.blank?
+
+    response = LinkedData::Client::HTTP.get(
+      "#{rest_url}/ontologies/#{ontology_acronym}/classes/#{CGI.escape(class_uri.strip)}",
+      lang: portal_lang,
+      display_context: false,
+      display_links: false,
+      include: 'prefLabel'
+    )
+
+    main_language_label(response&.prefLabel).presence || class_uri
+  rescue StandardError
+    class_uri
   end
 
   def generate_url_input(attr, helper_text: nil)

--- a/app/helpers/submission_inputs_helper.rb
+++ b/app/helpers/submission_inputs_helper.rb
@@ -85,6 +85,8 @@ module SubmissionInputsHelper
       end
     elsif attr.type?('isOntology')
       generate_select_input(attr, multiple: attr['enforce'].include?('list'))
+    elsif ontology_class_attribute?(attr.attr_key)
+      generate_ontology_class_picker_input(attr)
     elsif attr.type?('uri')
       generate_url_input(attr, helper_text: help)
     elsif attr.type?('boolean')
@@ -429,6 +431,19 @@ module SubmissionInputsHelper
       end
     end
 
+  end
+
+  def ontology_class_attribute?(attr_key)
+    %w[keyClasses exampleIdentifier].include?(attr_key.to_s)
+  end
+
+  def generate_ontology_class_picker_input(attr)
+    values = Array(attr.values).reject(&:blank?).map { |uri| { value: uri, label: uri } }
+    render Input::InputFieldComponent.new(name: '', label: attr_header_label(attr), error_message: attribute_error(attr.attr)) do
+      render OntologyClassSearchInputComponent.new(ontology_acronym: @ontology.acronym,
+                                                   name_prefix: attr.name,
+                                                   values: values)
+    end
   end
 
   def generate_url_input(attr, helper_text: nil)

--- a/app/helpers/submissions_helper.rb
+++ b/app/helpers/submissions_helper.rb
@@ -172,7 +172,7 @@ module SubmissionsHelper
   end
 
   def format_equivalent
-    %w[hasOntologyLanguage prefLabelProperty synonymProperty definitionProperty authorProperty obsoleteProperty obsoleteParent]
+    %w[hasOntologyLanguage prefLabelProperty synonymProperty definitionProperty authorProperty obsoleteProperty]
   end
 
   def location_equivalent

--- a/app/javascript/controllers/class_picker_controller.js
+++ b/app/javascript/controllers/class_picker_controller.js
@@ -1,11 +1,12 @@
 import { Controller } from "@hotwired/stimulus"
 
 export default class extends Controller {
-  static targets = ["list", "searchWrapper"]
+  static targets = ["list", "searchWrapper", "picked", "deleteIconTemplate"]
   static values = {
     namePrefix: String,
     rowClass: { type: String, default: "nested-class-picker-form-input-row" },
-    showUri: { type: Boolean, default: false }
+    showUri: { type: Boolean, default: false },
+    single: { type: Boolean, default: false }
   }
 
   addResult(event) {
@@ -19,6 +20,67 @@ export default class extends Controller {
     const uri = uriSpan.textContent.trim()
     const label = labelSpan.textContent.trim()
 
+    if (this.singleValue) {
+      this.replacePicked(label, uri)
+    } else {
+      this.appendRow(label, uri)
+    }
+  }
+
+  replacePicked(label, uri) {
+    if (!this.hasPickedTarget) return
+    this.pickedTarget.replaceChildren()
+
+    const wrapper = document.createElement("div")
+    wrapper.className = "d-flex align-items-center nested-form-wrapper my-1"
+
+    const displayWrapper = document.createElement("div")
+    displayWrapper.style.width = "90%"
+    displayWrapper.appendChild(this.buildDisplay(label, uri))
+
+    const deleteWrapper = document.createElement("div")
+    deleteWrapper.className = "d-flex justify-content-end"
+    deleteWrapper.style.width = "10%"
+
+    const removeBtn = document.createElement("div")
+    removeBtn.className = "delete"
+    removeBtn.dataset.action = "click->class-picker#removePicked"
+    removeBtn.innerHTML = this.deleteIconHtml()
+    deleteWrapper.appendChild(removeBtn)
+
+    wrapper.appendChild(displayWrapper)
+    wrapper.appendChild(deleteWrapper)
+
+    const hiddenInput = document.createElement("input")
+    hiddenInput.type = "hidden"
+    hiddenInput.name = this.namePrefixValue
+    hiddenInput.value = uri
+
+    this.pickedTarget.appendChild(wrapper)
+    this.pickedTarget.appendChild(hiddenInput)
+  }
+
+  removePicked(event) {
+    event.preventDefault()
+    if (!this.hasPickedTarget) return
+    this.pickedTarget.replaceChildren()
+
+    const hiddenInput = document.createElement("input")
+    hiddenInput.type = "hidden"
+    hiddenInput.name = this.namePrefixValue
+    hiddenInput.value = ""
+    this.pickedTarget.appendChild(hiddenInput)
+  }
+
+  deleteIconHtml() {
+    if (this.hasDeleteIconTemplateTarget) {
+      return this.deleteIconTemplateTarget.innerHTML
+    }
+    const existing = this.element.querySelector(".delete svg")
+    return existing ? existing.outerHTML : ""
+  }
+
+  appendRow(label, uri) {
     const namePrefix = this.namePrefixValue
     const rowClass = this.rowClassValue
     const nextIndex = document.querySelectorAll(`.${rowClass}`).length
@@ -27,20 +89,7 @@ export default class extends Controller {
     row.className = rowClass
 
     if (this.showUriValue) {
-      const display = document.createElement("div")
-      display.className = "class-picker-display"
-
-      const labelEl = document.createElement("p")
-      labelEl.className = "class-label_name"
-      labelEl.textContent = label
-
-      const uriEl = document.createElement("small")
-      uriEl.className = "class-uri"
-      uriEl.textContent = uri
-
-      display.appendChild(labelEl)
-      display.appendChild(uriEl)
-      row.appendChild(display)
+      row.appendChild(this.buildDisplay(label, uri))
     } else {
       const visibleInput = document.createElement("input")
       visibleInput.type = "text"
@@ -63,5 +112,22 @@ export default class extends Controller {
     if (this.hasSearchWrapperTarget) {
       this.searchWrapperTarget.remove()
     }
+  }
+
+  buildDisplay(label, uri) {
+    const display = document.createElement("div")
+    display.className = "class-picker-display"
+
+    const labelEl = document.createElement("p")
+    labelEl.className = "class-label_name"
+    labelEl.textContent = label
+
+    const uriEl = document.createElement("small")
+    uriEl.className = "class-uri"
+    uriEl.textContent = uri
+
+    display.appendChild(labelEl)
+    display.appendChild(uriEl)
+    return display
   }
 }

--- a/app/javascript/controllers/class_picker_controller.js
+++ b/app/javascript/controllers/class_picker_controller.js
@@ -1,8 +1,11 @@
-// app/javascript/controllers/subjects_controller.js
 import { Controller } from "@hotwired/stimulus"
 
 export default class extends Controller {
   static targets = ["list", "searchWrapper"]
+  static values = {
+    namePrefix: String,
+    rowClass: { type: String, default: "nested-class-picker-form-input-row" }
+  }
 
   addResult(event) {
     event.preventDefault()
@@ -15,39 +18,30 @@ export default class extends Controller {
     const uri = uriSpan.textContent.trim()
     const label = labelSpan.textContent.trim()
 
-    // Count ALL .nested-form-input-row in the entire form (or page)
-    const existingRows = document.querySelectorAll('.nested-subjects-form-input-row')
-    const nextIndex = existingRows.length
+    const namePrefix = this.namePrefixValue
+    const rowClass = this.rowClassValue
+    const nextIndex = document.querySelectorAll(`.${rowClass}`).length
 
-    // Create new hidden input (or visible, as you prefer)
     const visibleInput = document.createElement("input")
     visibleInput.type = "text"
-    visibleInput.name = `submission[hasDomain][${nextIndex}]`
+    visibleInput.name = `${namePrefix}[${nextIndex}]`
     visibleInput.value = label
     visibleInput.readOnly = true
     visibleInput.className = "form-control"
-    visibleInput.style.fontSize = "13px";
+    visibleInput.style.fontSize = "13px"
 
-    // Hidden input storing URI
     const hiddenInput = document.createElement("input")
     hiddenInput.type = "hidden"
-    hiddenInput.name = `submission[hasDomain][${nextIndex}]`
+    hiddenInput.name = `${namePrefix}[${nextIndex}]`
     hiddenInput.value = uri
-    
+
     const row = document.createElement("div")
-    row.className = "nested-subjects-form-input-row"
+    row.className = rowClass
     row.appendChild(visibleInput)
     row.appendChild(hiddenInput)
 
-    // Append to the same container where other rows live
-    // We find it by looking for a common parent (e.g., the nested form wrapper)
-    const formWrapper = this.element
-    if (formWrapper) {
-      // Insert before the "Add" button or at the end of the list
-      formWrapper.appendChild(row)
-    }
+    this.element.appendChild(row)
 
-    // Remove search UI
     if (this.hasSearchWrapperTarget) {
       this.searchWrapperTarget.remove()
     }

--- a/app/javascript/controllers/class_picker_controller.js
+++ b/app/javascript/controllers/class_picker_controller.js
@@ -4,7 +4,8 @@ export default class extends Controller {
   static targets = ["list", "searchWrapper"]
   static values = {
     namePrefix: String,
-    rowClass: { type: String, default: "nested-class-picker-form-input-row" }
+    rowClass: { type: String, default: "nested-class-picker-form-input-row" },
+    showUri: { type: Boolean, default: false }
   }
 
   addResult(event) {
@@ -22,22 +23,39 @@ export default class extends Controller {
     const rowClass = this.rowClassValue
     const nextIndex = document.querySelectorAll(`.${rowClass}`).length
 
-    const visibleInput = document.createElement("input")
-    visibleInput.type = "text"
-    visibleInput.name = `${namePrefix}[${nextIndex}]`
-    visibleInput.value = label
-    visibleInput.readOnly = true
-    visibleInput.className = "form-control"
-    visibleInput.style.fontSize = "13px"
+    const row = document.createElement("div")
+    row.className = rowClass
+
+    if (this.showUriValue) {
+      const display = document.createElement("div")
+      display.className = "class-picker-display"
+
+      const labelEl = document.createElement("p")
+      labelEl.className = "class-label_name"
+      labelEl.textContent = label
+
+      const uriEl = document.createElement("small")
+      uriEl.className = "class-uri"
+      uriEl.textContent = uri
+
+      display.appendChild(labelEl)
+      display.appendChild(uriEl)
+      row.appendChild(display)
+    } else {
+      const visibleInput = document.createElement("input")
+      visibleInput.type = "text"
+      visibleInput.name = `${namePrefix}[${nextIndex}]`
+      visibleInput.value = label
+      visibleInput.readOnly = true
+      visibleInput.className = "form-control"
+      visibleInput.style.fontSize = "13px"
+      row.appendChild(visibleInput)
+    }
 
     const hiddenInput = document.createElement("input")
     hiddenInput.type = "hidden"
     hiddenInput.name = `${namePrefix}[${nextIndex}]`
     hiddenInput.value = uri
-
-    const row = document.createElement("div")
-    row.className = rowClass
-    row.appendChild(visibleInput)
     row.appendChild(hiddenInput)
 
     this.element.appendChild(row)

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -107,5 +107,5 @@ import ParentCategoriesSelectorController from "./parent_categories_selector_con
 application.register('parent-categories-selector', ParentCategoriesSelectorController)
 
 
-import SubjectsController from "./subjects_controller.js"
-application.register("subjects", SubjectsController)
+import ClassPickerController from "./class_picker_controller.js"
+application.register("class-picker", ClassPickerController)

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -398,6 +398,7 @@ en:
     type: Type
   components:
     add_another_object: "Add another %{object_name}"
+    class: "class"
     contact: "contact"
     portal: "portal"
     all_languages: All languages
@@ -1101,6 +1102,7 @@ en:
     ontology_processing_failed: 'The ontology processing failed, with the current
       statuses: %{status}'
     ontology_search_prompt: Search an ontology or a term (e.g., plant height)
+    class_search_prompt: Search a class (e.g., plant height)
     ontology_submitted: Ontology submitted successfully!
     ontology_types: Ontology types
     outside: outside

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -408,6 +408,7 @@ fr:
     type: Type
   components:
     add_another_object: "Ajouter un autre %{object_name}"
+    class: "classe"
     contact: "contact"
     portal: "portail"
     all_languages: Toutes les langues
@@ -1137,6 +1138,7 @@ fr:
       statuts suivants : %{status}'
     ontology_search_prompt: Rechercher une ontologie ou un terme (e.g., hauteur de
       plante)
+    class_search_prompt: Rechercher une classe (e.g., hauteur de plante)
     ontology_submitted: Ontologie soumise avec succès !
     ontology_types: Types d'ontologies
     outside: extérieur

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -243,6 +243,7 @@ Rails.application.routes.draw do
   get 'search', to: 'search#index'
   get 'search/json_search/:id', to: 'search#json_search'
   get 'ajax/search/ontologies/content', to: 'search#json_ontology_content_search'
+  get 'ajax/search/ontologies/:ontology_acronym/classes', to: 'search#json_ontology_classes_search'
 
   get 'check_resolvability' => 'check_resolvability#index'
   get 'check_url_resolvability' => 'check_resolvability#check_resolvability'

--- a/test/system/submission_flows_test.rb
+++ b/test/system/submission_flows_test.rb
@@ -554,13 +554,12 @@ class SubmissionFlowsTest < ApplicationSystemTestCase
   def submission_content_edit_fill(submission)
     wait_for_text "Root of obsolete branch"
 
-    fill_in "submission[obsoleteParent]", with: submission.obsoleteParent
     fill_in "submission[uriRegexPattern]", with: submission.uriRegexPattern
     fill_in "submission[preferredNamespaceUri]", with: submission.preferredNamespaceUri
     fill_in "submission[preferredNamespacePrefix]", with: submission.preferredNamespacePrefix
-    # exampleIdentifier and keyClasses are now backed by an ontology class
-    # search picker (OntologyClassSearchInputComponent) that requires real
-    # indexed classes — skipped here, same as hasDomain/subjects.
+    # obsoleteParent, exampleIdentifier and keyClasses are now backed by an
+    # ontology class search picker (OntologyClassSearchInputComponent) that
+    # requires real indexed classes — skipped here, same as hasDomain/subjects.
     tom_select "submission[metadataVoc][]", submission.metadataVoc
 
   end

--- a/test/system/submission_flows_test.rb
+++ b/test/system/submission_flows_test.rb
@@ -251,8 +251,8 @@ class SubmissionFlowsTest < ApplicationSystemTestCase
 
     # Assert Content
     open_dropdown "#content"
-    assert_text submission_2.obsoleteParent
-    # exampleIdentifier is no longer filled via the class picker in this test
+    # obsoleteParent and exampleIdentifier are no longer filled via the
+    # class picker in this test, so their values aren't asserted here.
     assert_text submission_2.uriRegexPattern
     assert_text submission_2.preferredNamespaceUri
     assert_text submission_2.preferredNamespacePrefix

--- a/test/system/submission_flows_test.rb
+++ b/test/system/submission_flows_test.rb
@@ -252,7 +252,7 @@ class SubmissionFlowsTest < ApplicationSystemTestCase
     # Assert Content
     open_dropdown "#content"
     assert_text submission_2.obsoleteParent
-    assert_text submission_2.exampleIdentifier
+    # exampleIdentifier is no longer filled via the class picker in this test
     assert_text submission_2.uriRegexPattern
     assert_text submission_2.preferredNamespaceUri
     assert_text submission_2.preferredNamespacePrefix
@@ -558,9 +558,9 @@ class SubmissionFlowsTest < ApplicationSystemTestCase
     fill_in "submission[uriRegexPattern]", with: submission.uriRegexPattern
     fill_in "submission[preferredNamespaceUri]", with: submission.preferredNamespaceUri
     fill_in "submission[preferredNamespacePrefix]", with: submission.preferredNamespacePrefix
-    fill_in "submission[exampleIdentifier]", with: submission.exampleIdentifier
-    list_inputs "#submissionkeyClasses_from_group_input",
-                "submission[keyClasses]", submission.keyClasses
+    # exampleIdentifier and keyClasses are now backed by an ontology class
+    # search picker (OntologyClassSearchInputComponent) that requires real
+    # indexed classes — skipped here, same as hasDomain/subjects.
     tom_select "submission[metadataVoc][]", submission.metadataVoc
 
   end


### PR DESCRIPTION
## Summary
- Related issue:
https://github.com/agroportal/project-management/issues/388
- Introduces `OntologyClassSearchInputComponent`, a reusable class selector that picks classes from the current ontology only
- Replaces plain URI text inputs for `keyClasses` and `exampleIdentifier` with a search-as-you-type picker

https://github.com/user-attachments/assets/20decd5e-c1a5-4270-aefb-5655253bc1cb


