### PR TITLE
feat: separate Categories and Subjects in submission edit metadata

### DIFF
--- a/app/controllers/submissions_controller.rb
+++ b/app/controllers/submissions_controller.rb
@@ -74,7 +74,7 @@ class SubmissionsController < ApplicationController
     category_attributes['general'] << %w[acronym name groups administeredBy sampleQueries]
     category_attributes['licensing'] << 'viewingRestriction'
     category_attributes['relations'] << 'viewOf'
-    category_attributes["description"] << %w[hasDomain categories]
+    category_attributes["description"] << %w[hasDomain subjects]
     category_attributes["usage"].delete("hasDomain")
     @selected_attributes = Array(params[:properties])
     if @selected_attributes.empty?

--- a/app/helpers/submissions_helper.rb
+++ b/app/helpers/submissions_helper.rb
@@ -370,11 +370,14 @@ module SubmissionsHelper
       end
     end
 
-    if selected_attribute?('categories')
+    selected = Array(@selected_attributes)
+    show_all = selected.empty?
+
+    if show_all || selected.include?('hasDomain') || selected.include?('categories')
       output += ontology_categories_input
     end
 
-    if selected_attribute?('hasDomain')
+    if show_all || selected.include?('subjects')
       output += ontology_submission_subjects_input
     end
 


### PR DESCRIPTION
Wires the dropdown values to their respective inputs so picking "Categories" renders the ontology categories (omv:hasDomain) input and "Subjects" renders the submission subjects (omv:hasDomain) input, matching the admin Metadata administration page. The default description tab now lists both.
## Before
https://github.com/user-attachments/assets/f6f71d3f-16fa-411f-8775-a52bab24759f
## After
https://github.com/user-attachments/assets/4a6ee074-d474-4dc7-938c-d2ac28a58937

