### PR TITLE
feat: add ROR organization search to agent form

### DIFF
--- a/app/assets/stylesheets/components/search_input.scss
+++ b/app/assets/stylesheets/components/search_input.scss
@@ -7,6 +7,7 @@
   border: none;
   box-shadow: 2px 30px 60px rgba(0, 0, 0, 0.1);
   position: absolute;
+  z-index: 10;
 }
 
 .search-container.search-container-scroll{

--- a/app/helpers/agent_helper.rb
+++ b/app/helpers/agent_helper.rb
@@ -83,7 +83,7 @@ module AgentHelper
   end
 
 
-  def agent_identifier_input(index, name_prefix, value = '', is_organization: true)
+  def agent_identifier_input(index, name_prefix, value = '', is_organization: true, input_data: nil)
 
     content_tag :div, id: index, class: 'd-flex' do
       content_tag(:div, class: 'w-100') do
@@ -94,7 +94,9 @@ module AgentHelper
         else
           concat inline_svg_tag('orcid.svg', class: 'agent-input-icon')
         end
-        concat text_field_tag(agent_identifier_name(index, :notation, name_prefix), value, class: 'agent-input-with-icon')
+        notation_options = { class: 'agent-input-with-icon' }
+        notation_options[:data] = input_data if input_data
+        concat text_field_tag(agent_identifier_name(index, :notation, name_prefix), value, notation_options)
       end
     end
   end

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -109,3 +109,6 @@ application.register('parent-categories-selector', ParentCategoriesSelectorContr
 
 import SubjectsController from "./subjects_controller.js"
 application.register("subjects", SubjectsController)
+
+import RorSearchController from "./ror_search_controller.js"
+application.register("ror-search", RorSearchController)

--- a/app/javascript/controllers/ror_search_controller.js
+++ b/app/javascript/controllers/ror_search_controller.js
@@ -1,0 +1,154 @@
+import { Controller } from "@hotwired/stimulus"
+import debounce from "debounce"
+
+// Connects to data-controller="ror-search"
+// When agent type is organization, typing in the name field searches
+// https://api.ror.org/v2/organizations and fills name, acronym, homepage,
+// and the ROR identifier from the selected result.
+export default class extends Controller {
+    static targets = ["nameInput", "results", "acronymInput", "homepageInput", "identifierInput", "organizationRadio"]
+    static values = {
+        apiUrl: { type: String, default: "https://api.ror.org/v2/organizations" },
+        minLength: { type: Number, default: 2 },
+        debounceMs: { type: Number, default: 300 }
+    }
+
+    connect() {
+        this.search = debounce(this.search.bind(this), this.debounceMsValue)
+    }
+
+    search() {
+        if (!this.#isOrganizationMode()) {
+            this.hideResults()
+            return
+        }
+
+        const query = this.nameInputTarget.value.trim()
+        if (query.length < this.minLengthValue) {
+            this.hideResults()
+            return
+        }
+
+        fetch(`${this.apiUrlValue}?query=${encodeURIComponent(query)}`)
+            .then(r => r.ok ? r.json() : Promise.reject(r.statusText))
+            .then(data => this.renderResults(data.items || []))
+            .catch(err => {
+                console.error("ROR search error", err)
+                this.hideResults()
+            })
+    }
+
+    prevent(event) {
+        event.preventDefault()
+    }
+
+    blur() {
+        this.resultsTarget.style.display = "none"
+    }
+
+    hide() {
+        this.hideResults()
+    }
+
+    renderResults(items) {
+        if (items.length === 0) {
+            this.hideResults()
+            return
+        }
+
+        this.resultsTarget.innerHTML = ""
+        items.slice(0, 10).forEach(item => {
+            const display = this.#displayName(item)
+            const acronym = this.#acronym(item)
+            const country = item.locations?.[0]?.geonames_details?.country_name || ""
+            const rorId = item.id?.split("/").pop() || ""
+
+            const a = document.createElement("a")
+            a.href = "#"
+            a.className = "search-content"
+            a.innerHTML = `
+                <p class="search-element">
+                    <strong>${this.#escape(display)}</strong>
+                    ${acronym ? `<small> (${this.#escape(acronym)})</small>` : ""}
+                    ${country ? `<small> — ${this.#escape(country)}</small>` : ""}
+                </p>
+                <p class="home-result-type"><small>${this.#escape(rorId)}</small></p>
+            `
+            a.addEventListener("click", (e) => {
+                e.preventDefault()
+                this.select(item)
+            })
+            this.resultsTarget.appendChild(a)
+        })
+
+        this.resultsTarget.style.display = "block"
+    }
+
+    select(item) {
+        const englishName = this.#englishName(item)
+        const acronym = this.#acronym(item)
+        const homepage = this.#homepage(item)
+        const rorId = item.id || ""
+
+        const finalName = englishName || this.#rorDisplayName(item) || acronym
+        if (finalName) this.#setValue(this.nameInputTarget, finalName)
+        if (this.hasAcronymInputTarget && acronym) this.#setValue(this.acronymInputTarget, acronym)
+        if (this.hasHomepageInputTarget && homepage) this.#setValue(this.homepageInputTarget, homepage)
+        if (this.hasIdentifierInputTarget && rorId) this.#setValue(this.identifierInputTarget, rorId)
+
+        this.hideResults()
+    }
+
+    hideResults() {
+        this.resultsTarget.style.display = "none"
+        this.resultsTarget.innerHTML = ""
+    }
+
+    #isOrganizationMode() {
+        if (!this.hasOrganizationRadioTarget) return true
+        return this.organizationRadioTarget.checked
+    }
+
+    #setValue(input, value) {
+        input.value = value
+        input.dispatchEvent(new Event("input", { bubbles: true }))
+        input.dispatchEvent(new Event("change", { bubbles: true }))
+    }
+
+    #displayName(item) {
+        return this.#englishName(item) || this.#rorDisplayName(item) || (item.names?.[0]?.value ?? "")
+    }
+
+    #englishName(item) {
+        const en = (item.names || []).find(n => n.lang === "en" && (n.types || []).includes("label"))
+        return en?.value || ""
+    }
+
+    #rorDisplayName(item) {
+        const d = (item.names || []).find(n => (n.types || []).includes("ror_display"))
+        return d?.value || ""
+    }
+
+    #acronym(item) {
+        const ac = (item.names || []).find(n => (n.types || []).includes("acronym"))
+        return ac?.value || ""
+    }
+
+    #homepage(item) {
+        const domain = (item.domains || [])[0]
+        if (domain) {
+            return domain.startsWith("http") ? domain : `https://${domain}`
+        }
+        const link = (item.links || []).find(l => l.type === "website")
+        return link?.value || ""
+    }
+
+    #escape(str) {
+        return String(str)
+            .replace(/&/g, "&amp;")
+            .replace(/</g, "&lt;")
+            .replace(/>/g, "&gt;")
+            .replace(/"/g, "&quot;")
+            .replace(/'/g, "&#39;")
+    }
+}

--- a/app/views/agents/_form.html.haml
+++ b/app/views/agents/_form.html.haml
@@ -1,5 +1,5 @@
 = agent_alert_container(@agent, params[:parent_id])
-%table.form.w-100{data:{ controller: 'form-options-display',  'form-options-display-hidden-class-value': 'd-none'}}
+%table.form.w-100{data:{ controller: 'form-options-display ror-search',  'form-options-display-hidden-class-value': 'd-none'}}
   %colgroup
     %col
     %col{style: "width: 100%"}
@@ -19,17 +19,19 @@
       %td.top
         %div.d-flex
           %div.custom-control.custom-radio.mx-1
-            = radio_button_tag agent_field_name(:agentType, name_prefix), :person, !agent.agentType.eql?('organization'), class: 'custom-control-input', 'data-action': "change->form-options-display#showOption1"
+            = radio_button_tag agent_field_name(:agentType, name_prefix), :person, !agent.agentType.eql?('organization'), class: 'custom-control-input', 'data-action': "change->form-options-display#showOption1 change->ror-search#hide"
             = label_tag :agentType_person, t('agents.form.person'),  class: 'custom-control-label'
           %div.custom-control.custom-radio.mx-1
-            = radio_button_tag agent_field_name(:agentType, name_prefix), :organization, agent.agentType.eql?('organization'), class: 'custom-control-input', 'data-action': "change->form-options-display#showOption2"
+            = radio_button_tag agent_field_name(:agentType, name_prefix), :organization, agent.agentType.eql?('organization'), class: 'custom-control-input', 'data-action': "change->form-options-display#showOption2", 'data-ror-search-target': 'organizationRadio'
             = label_tag :agentType_organization, t('agents.form.organization'),  class: 'custom-control-label'
   %tr
     %th
       = t("agents.form.name")
       %span.asterik *
     %td.top
-      = text_field_tag agent_field_name(:name, name_prefix), agent.name, class: "form-control"
+      %div.search-inputs
+        = text_field_tag agent_field_name(:name, name_prefix), agent.name, class: "form-control", autocomplete: 'off', data: { 'ror-search-target': 'nameInput', action: 'input->ror-search#search blur->ror-search#blur' }
+        %div.search-container.search-container-scroll{'data-ror-search-target': 'results', 'data-action': 'mousedown->ror-search#prevent', style: 'display: none;'}
   %tr{'data-form-options-display-target':"option1",  class: is_organization?(agent) && 'd-none'}
     %th
       = t("agents.form.email")
@@ -41,12 +43,12 @@
       = t("agents.form.acronym")
       %span.asterik
     %td.top
-      = text_field_tag agent_field_name(:acronym, name_prefix), agent.acronym,class: "form-control"
+      = text_field_tag agent_field_name(:acronym, name_prefix), agent.acronym, class: "form-control", data: { 'ror-search-target': 'acronymInput' }
   %tr{'data-form-options-display-target':"option2",  class: !is_organization?(agent) && 'd-none'}
     %th
       = t("agents.form.homepage")
     %td.top
-      = url_field_tag agent_field_name(:homepage, name_prefix), agent.homepage, class: "form-control"
+      = url_field_tag agent_field_name(:homepage, name_prefix), agent.homepage, class: "form-control", data: { 'ror-search-target': 'homepageInput' }
   %tr.d-none
     %th
       = t("agents.form.creator")
@@ -59,9 +61,9 @@
     %td.top
       %div.agents-identifiers{'data-form-options-display-target':"option2",  class: !is_organization?(agent) && 'd-none'}
         - if identifier&.schemaAgency&.eql?('ROR')
-          = agent_identifier_input('0', name_prefix, identifier.notation)
+          = agent_identifier_input('0', name_prefix, identifier.notation, input_data: { 'ror-search-target': 'identifierInput' })
         - else
-          = agent_identifier_input('0', name_prefix)
+          = agent_identifier_input('0', name_prefix, input_data: { 'ror-search-target': 'identifierInput' })
 
       %div.agents-identifiers{'data-form-options-display-target':"option1",  class: is_organization?(agent) && 'd-none'}
         - if identifier&.schemaAgency&.eql?('ORCID')


### PR DESCRIPTION
- Related issue:
https://github.com/agroportal/ontoportal_web_ui/issues/350


Typing in the agent name field now queries the ROR registry when the agent type is Organization, and selecting a result auto-fills name, acronym, homepage, and the ROR identifier.

https://github.com/user-attachments/assets/2c9cbfb0-69e9-49ac-83b5-19bbafd12895

