### PR TITLE
  Statistics page enhancements

### DIFF
--- a/app/assets/stylesheets/application.css.scss.erb
+++ b/app/assets/stylesheets/application.css.scss.erb
@@ -48,6 +48,7 @@
 @import "components/index";
 @import "account";
 @import "agents";
+@import "statistics";
 @import "upload_ontology";
 @import "edit-ontology";
 @import "nav_bar";

--- a/app/assets/stylesheets/statistics.scss
+++ b/app/assets/stylesheets/statistics.scss
@@ -1,3 +1,56 @@
+.statistics-kpi-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 1rem;
+  margin-bottom: 1.5rem;
+}
+
+.statistics-kpi-card {
+  --kpi-color: #1976D2;
+  position: relative;
+  padding: 1rem 1.25rem;
+  background: #fff;
+  border: 1px solid rgba(0, 0, 0, 0.06);
+  border-radius: 12px;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.04);
+  overflow: hidden;
+
+  &::before {
+    content: '';
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 4px;
+    height: 100%;
+    background: var(--kpi-color);
+  }
+
+  .statistics-kpi-label {
+    font-size: 0.8125rem;
+    font-weight: 500;
+    color: #6c757d;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    margin-bottom: 0.35rem;
+  }
+
+  .statistics-kpi-value {
+    font-size: 2rem;
+    font-weight: 600;
+    color: #212529;
+    line-height: 1.1;
+  }
+
+  .statistics-kpi-delta {
+    margin-top: 0.4rem;
+    font-size: 0.8125rem;
+    font-weight: 500;
+
+    &.up   { color: #2E7D32; }
+    &.down { color: #C62828; }
+  }
+}
+
 .statistics-chart-container {
   margin-bottom: 1.5rem;
   padding: 1.25rem 1rem 0.75rem;

--- a/app/assets/stylesheets/statistics.scss
+++ b/app/assets/stylesheets/statistics.scss
@@ -1,0 +1,8 @@
+.statistics-chart-container {
+  margin-bottom: 1.5rem;
+  padding: 1.25rem 1rem 0.75rem;
+  background: #fff;
+  border: 1px solid rgba(0, 0, 0, 0.06);
+  border-radius: 12px;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.04);
+}

--- a/app/components/table_component.rb
+++ b/app/components/table_component.rb
@@ -8,7 +8,8 @@ class TableComponent < ViewComponent::Base
   def initialize(id: '', stripped: true, borderless: false, custom_class: '', layout_fixed: false,
                  small_text: false, outline: false, sort_column: nil,
                  paging: false, searching: false, search_placeholder: nil,
-                 no_init_sort: false, server_side: false, ajax_url: nil, columns: [], ordering: true)
+                 no_init_sort: false, server_side: false, ajax_url: nil, columns: [], ordering: true,
+                 show_all: false)
     super()
     @id = id
     @stripped = stripped
@@ -26,6 +27,7 @@ class TableComponent < ViewComponent::Base
     @ajax_url = ajax_url
     @columns = columns
     @ordering = ordering
+    @show_all = show_all
 
   end
 

--- a/app/components/table_component/table_component.html.haml
+++ b/app/components/table_component/table_component.html.haml
@@ -8,6 +8,7 @@
     'data-table-component-ajax-url-value': @ajax_url,
     'data-table-component-columns-value': @columns,
     'data-table-component-ordering-value': @ordering,
+    'data-table-component-show-all-value': @show_all,
     }
   %table.table-content{id: @id ,class: @custom_class + ' ' + stripped_class + ' ' + borderless_class + ' ' + layout_fixed_class + ' ' + mini_class + ' ' + outline_class}
     %thead

--- a/app/components/table_component/table_component_controller.js
+++ b/app/components/table_component/table_component_controller.js
@@ -12,7 +12,8 @@
       serverSide: Boolean,
       ordering: Boolean,
       ajaxUrl: String,
-      columns: Array
+      columns: Array,
+      showAll: Boolean
     }
 
     connect() {
@@ -25,7 +26,10 @@
           paging: this.pagingValue,
           ...(this.columnsValue?.length > 0 && { columns: this.columnsValue.map(name => ({ data: name })) }),
           info: false,
-          lengthMenu: [
+          lengthMenu: this.showAllValue ? [
+            [10, 25, 50, 100, -1],
+            [10, 25, 50, 100, 'All']
+          ] : [
             [10, 25, 50, 100],
             [10, 25, 50, 100]
           ],

--- a/app/controllers/statistics_controller.rb
+++ b/app/controllers/statistics_controller.rb
@@ -6,9 +6,20 @@ class StatisticsController < ApplicationController
   def index
     projects = LinkedData::Client::Models::Project.all({include: 'created'})
     users = LinkedData::Client::Models::User.all({include: 'created'})
+    agents = LinkedData::Client::Models::Agent.all({include: 'created'})
     year_month_count,  @year_month_visits =  ontologies_by_year_month
-    @merged_data = merge_time_evolution_data([group_by_year_month(users),
-                                              group_by_year_month(projects),
-                                              year_month_count])
+
+    users_grouped = group_by_year_month(users)
+    projects_grouped = group_by_year_month(projects)
+
+    fallback = [users_grouped.keys.first,
+                projects_grouped.keys.first,
+                year_month_count.keys.sort.first].compact.min
+    agents_grouped = group_by_year_month(agents, fallback: fallback)
+
+    @merged_data = merge_time_evolution_data([users_grouped,
+                                              projects_grouped,
+                                              year_month_count,
+                                              agents_grouped])
   end
 end

--- a/app/controllers/statistics_controller.rb
+++ b/app/controllers/statistics_controller.rb
@@ -4,22 +4,26 @@ class StatisticsController < ApplicationController
   layout :determine_layout
 
   def index
-    projects = LinkedData::Client::Models::Project.all({include: 'created'})
-    users = LinkedData::Client::Models::User.all({include: 'created'})
-    agents = LinkedData::Client::Models::Agent.all({include: 'created'})
-    year_month_count,  @year_month_visits =  ontologies_by_year_month
+    @merged_data, @year_month_visits = Rails.cache.fetch("statistics_index_data-#{$SITE}", expires_in: 24.hours) do
+      projects = LinkedData::Client::Models::Project.all({include: 'created'})
+      users = LinkedData::Client::Models::User.all({include: 'created'})
+      agents = LinkedData::Client::Models::Agent.all({include: 'created'})
+      year_month_count, year_month_visits = ontologies_by_year_month
 
-    users_grouped = group_by_year_month(users)
-    projects_grouped = group_by_year_month(projects)
+      users_grouped = group_by_year_month(users)
+      projects_grouped = group_by_year_month(projects)
 
-    fallback = [users_grouped.keys.first,
-                projects_grouped.keys.first,
-                year_month_count.keys.sort.first].compact.min
-    agents_grouped = group_by_year_month(agents, fallback: fallback)
+      fallback = [users_grouped.keys.first,
+                  projects_grouped.keys.first,
+                  year_month_count.keys.sort.first].compact.min
+      agents_grouped = group_by_year_month(agents, fallback: fallback)
 
-    @merged_data = merge_time_evolution_data([users_grouped,
-                                              projects_grouped,
-                                              year_month_count,
-                                              agents_grouped])
+      merged_data = merge_time_evolution_data([users_grouped,
+                                               projects_grouped,
+                                               year_month_count,
+                                               agents_grouped])
+
+      [merged_data, year_month_visits]
+    end
   end
 end

--- a/app/helpers/statistics_helper.rb
+++ b/app/helpers/statistics_helper.rb
@@ -50,11 +50,12 @@ module StatisticsHelper
   }.freeze
 
   def statistics_chart_datasets(series)
-    series.map do |key, label, data|
+    series.map do |entry|
+      key = entry[:key]
       color = STATISTICS_SERIES_COLORS[key]
-      {
-        label: label,
-        data: data,
+      dataset = {
+        label: entry[:label],
+        data: entry[:data],
         borderColor: color,
         backgroundColor: "#{color}1A",
         pointBackgroundColor: color,
@@ -68,6 +69,10 @@ module StatisticsHelper
         tension: 0.4,
         fill: false
       }
+      dataset[:cumulative] = true if entry[:cumulative]
+      dataset[:yAxisID] = entry[:axis] if entry[:axis]
+      dataset[:borderDash] = entry[:dashed] if entry[:dashed]
+      dataset
     end.to_json
   end
 

--- a/app/helpers/statistics_helper.rb
+++ b/app/helpers/statistics_helper.rb
@@ -77,6 +77,20 @@ module StatisticsHelper
     end.to_json
   end
 
+  def statistics_kpi_cards(merged_data)
+    [
+      { key: :ontologies, label: t('statistics.ontologies'), series: merged_data[:visits][2] },
+      { key: :users,      label: t('statistics.users'),      series: merged_data[:visits][0] },
+      { key: :projects,   label: t('statistics.projects'),   series: merged_data[:visits][1] },
+      { key: :agents,     label: t('statistics.agents'),     series: merged_data[:visits][3] }
+    ].map do |kpi|
+      series = Array(kpi[:series])
+      total = series.last || 0
+      previous = series[-2] || 0
+      kpi.merge(total: total, delta: total - previous, color: STATISTICS_SERIES_COLORS[kpi[:key]])
+    end
+  end
+
   def merge_time_evolution_data(data)
     min_year = data.map { |x| x.keys.first&.first }.compact.min
     old = data.size.times.map { |x|  0 }

--- a/app/helpers/statistics_helper.rb
+++ b/app/helpers/statistics_helper.rb
@@ -42,14 +42,46 @@ module StatisticsHelper
     grouped.sort_by { |(year, month), _| [year, month] }.to_h
   end
 
+  STATISTICS_SERIES_COLORS = {
+    ontologies: '#1976D2',
+    users: '#F57C00',
+    projects: '#7B1FA2',
+    agents: '#2E7D32'
+  }.freeze
+
+  def statistics_chart_datasets(series)
+    series.map do |key, label, data|
+      color = STATISTICS_SERIES_COLORS[key]
+      {
+        label: label,
+        data: data,
+        borderColor: color,
+        backgroundColor: "#{color}1A",
+        pointBackgroundColor: color,
+        pointBorderColor: '#fff',
+        pointHoverBackgroundColor: '#fff',
+        pointHoverBorderColor: color,
+        pointRadius: 3,
+        pointHoverRadius: 5,
+        borderWidth: 2,
+        cubicInterpolationMode: 'monotone',
+        tension: 0.4,
+        fill: false
+      }
+    end.to_json
+  end
+
   def merge_time_evolution_data(data)
     min_year = data.map { |x| x.keys.first&.first }.compact.min
     old = data.size.times.map { |x|  0 }
 
     visits_data = { visits: data.size.times.map { |x|  [] }, labels: [] }
 
-    (min_year..Date.today.year).each do |year|
+    today = Date.today
+    (min_year..today.year).each do |year|
       (1..12).each do |month|
+        break if year == today.year && month > today.month
+
         data.each_with_index do |x , i|
           old[i] += x[[year, month]]&.size || 0
         end

--- a/app/helpers/statistics_helper.rb
+++ b/app/helpers/statistics_helper.rb
@@ -72,6 +72,7 @@ module StatisticsHelper
       dataset[:cumulative] = true if entry[:cumulative]
       dataset[:yAxisID] = entry[:axis] if entry[:axis]
       dataset[:borderDash] = entry[:dashed] if entry[:dashed]
+      dataset[:hidden] = true if entry[:hidden]
       dataset
     end.to_json
   end

--- a/app/helpers/statistics_helper.rb
+++ b/app/helpers/statistics_helper.rb
@@ -29,12 +29,21 @@ module StatisticsHelper
   def string_year_month(year, month)
     DateTime.parse("#{year}/#{month}").strftime("%b %Y")
   end
-  def group_by_year_month(data)
-    data.group_by{|x| [Date.parse(x.created).year, Date.parse(x.created).month] }.sort_by { |(year, month), _| [year, month] }.to_h
+  def group_by_year_month(data, fallback: nil)
+    grouped = data.group_by do |x|
+      created = x.respond_to?(:created) ? x.created : nil
+      if created.nil? || created.to_s.strip.empty?
+        fallback
+      else
+        [Date.parse(created).year, Date.parse(created).month]
+      end
+    end
+    grouped.delete(nil)
+    grouped.sort_by { |(year, month), _| [year, month] }.to_h
   end
 
   def merge_time_evolution_data(data)
-    min_year =  data.map{|x| x.keys.first.first}.min
+    min_year = data.map { |x| x.keys.first&.first }.compact.min
     old = data.size.times.map { |x|  0 }
 
     visits_data = { visits: data.size.times.map { |x|  [] }, labels: [] }

--- a/app/javascript/controllers/load_chart_controller.js
+++ b/app/javascript/controllers/load_chart_controller.js
@@ -20,12 +20,23 @@ export default class extends Controller {
 
     const context = this.element.getContext('2d')
 
+    const hasSecondaryAxis = datasets.some(d => d.yAxisID && d.yAxisID !== 'y')
+
+    const scales = {
+      x: this.#xScale(),
+      y: this.#scales('y')
+    }
+    if (hasSecondaryAxis) {
+      scales.y1 = this.#secondaryScale()
+    }
+
     this.chart = new Chart(context, {
       type: this.typeValue,
       data: {
         labels: labels,
         datasets: datasets
       },
+      plugins: [this.#yearSeparatorPlugin()],
       options: {
         indexAxis: this.indexAxisValue,
         interaction: {
@@ -53,17 +64,94 @@ export default class extends Controller {
             titleFont: { weight: '600' },
             bodySpacing: 4,
             cornerRadius: 6,
-            usePointStyle: true
+            usePointStyle: true,
+            callbacks: {
+              label: (ctx) => this.#tooltipLabel(ctx)
+            }
           }
         },
         responsive: true,
-        scales: {
-          x: this.#scales('x'),
-          y: this.#scales('y')
-        },
+        scales: scales,
       }
     })
 
+  }
+
+  #tooltipLabel (ctx) {
+    const value = ctx.parsed.y
+    const formatted = value.toLocaleString()
+    const label = ctx.dataset.label || ''
+    if (ctx.dataset.cumulative) {
+      const previous = ctx.dataIndex > 0 ? ctx.dataset.data[ctx.dataIndex - 1] : 0
+      const delta = value - previous
+      const sign = delta >= 0 ? '+' : ''
+      return `${label}: ${formatted} (${sign}${delta.toLocaleString()} this month)`
+    }
+    return `${label}: ${formatted}`
+  }
+
+  #xScale () {
+    if (this.indexAxisValue !== 'x') {
+      return this.#scales('x')
+    }
+    return {
+      border: { display: false },
+      grid: { display: false, drawTicks: false },
+      ticks: {
+        beginAtZero: false,
+        maxRotation: 0,
+        autoSkipPadding: 16,
+        color: '#6c757d'
+      }
+    }
+  }
+
+  #yearSeparatorPlugin () {
+    return {
+      id: 'yearSeparator',
+      beforeDatasetsDraw: (chart) => {
+        const xScale = chart.scales.x
+        if (!xScale) return
+        const labels = chart.data.labels || []
+        const { top, bottom } = chart.chartArea
+        const yearOf = (label) => {
+          const match = String(label || '').match(/(\d{4})/)
+          return match ? match[1] : null
+        }
+        const ctx = chart.ctx
+        ctx.save()
+        ctx.strokeStyle = 'rgba(0, 0, 0, 0.15)'
+        ctx.lineWidth = 1
+        ctx.setLineDash([3, 3])
+        let prev = null
+        for (let i = 0; i < labels.length; i++) {
+          const year = yearOf(labels[i])
+          if (year && prev && year !== prev) {
+            const x = xScale.getPixelForValue(i)
+            ctx.beginPath()
+            ctx.moveTo(x, top)
+            ctx.lineTo(x, bottom)
+            ctx.stroke()
+          }
+          if (year) prev = year
+        }
+        ctx.restore()
+      }
+    }
+  }
+
+  #secondaryScale () {
+    return {
+      position: 'right',
+      border: { display: false },
+      grid: { drawOnChartArea: false },
+      ticks: {
+        color: '#6c757d',
+        padding: 8,
+        maxTicksLimit: 6
+      },
+      beginAtZero: true
+    }
   }
 
   disconnect () {

--- a/app/javascript/controllers/load_chart_controller.js
+++ b/app/javascript/controllers/load_chart_controller.js
@@ -28,6 +28,10 @@ export default class extends Controller {
       },
       options: {
         indexAxis: this.indexAxisValue,
+        interaction: {
+          mode: 'index',
+          intersect: false
+        },
         plugins: {
           colors: {enabled: true},
           title: {
@@ -35,7 +39,21 @@ export default class extends Controller {
             text: this.titleValue
           },
           legend: {
-            display: this.legendValue
+            display: this.legendValue,
+            position: 'top',
+            labels: {
+              usePointStyle: true,
+              boxWidth: 8,
+              padding: 16
+            }
+          },
+          tooltip: {
+            backgroundColor: 'rgba(33, 33, 33, 0.92)',
+            padding: 10,
+            titleFont: { weight: '600' },
+            bodySpacing: 4,
+            cornerRadius: 6,
+            usePointStyle: true
           }
         },
         responsive: true,
@@ -56,27 +74,28 @@ export default class extends Controller {
   #scales (axe) {
     if (this.indexAxisValue === axe) {
       return {
-        border: {
-          display: false
-        },
-        grid: {
-          display: false
-        },
+        border: { display: false },
+        grid: { display: false },
         ticks: {
-          beginAtZero: false
+          beginAtZero: false,
+          maxRotation: 0,
+          autoSkipPadding: 16,
+          color: '#6c757d'
         }
       }
     } else {
       return {
-        border: {
-          display: false
-        },
+        border: { display: false },
         grid: {
-          display: false
+          color: 'rgba(0, 0, 0, 0.06)',
+          drawTicks: false
         },
         ticks: {
-          display: false
-        }
+          color: '#6c757d',
+          padding: 8,
+          maxTicksLimit: 6
+        },
+        beginAtZero: true
       }
     }
   }

--- a/app/views/statistics/index.html.haml
+++ b/app/views/statistics/index.html.haml
@@ -4,11 +4,11 @@
     %p.lead
       = t('statistics.lead', last_years: Date.today.year - Date.parse(@merged_data[:labels].first).year)
 %div.container
-  %div
+  - series = [[:ontologies, t('statistics.ontologies'), @merged_data[:visits][2]], [:users, t('statistics.users'), @merged_data[:visits][0]], [:projects, t('statistics.projects'), @merged_data[:visits][1]], [:agents, t('statistics.agents'), @merged_data[:visits][3]]]
+  .statistics-chart-container
     = chart_component(title: nil, type: 'line', show_legend: true,
-                      labels: @merged_data[:labels], datasets: visits_chart_dataset_array({ t('statistics.ontologies') => @merged_data[:visits][2],
-                      t('statistics.users') => @merged_data[:visits][0], t('statistics.projects') => @merged_data[:visits][1],
-                      t('statistics.agents') => @merged_data[:visits][3] }, fill: false))
+                      labels: @merged_data[:labels],
+                      datasets: statistics_chart_datasets(series))
 
   %div.pb-3.pb-md-4
     - size = @merged_data[:labels].size - 1

--- a/app/views/statistics/index.html.haml
+++ b/app/views/statistics/index.html.haml
@@ -21,7 +21,7 @@
   %div.pb-3.pb-md-4
     - size = @merged_data[:labels].size - 1
     - visits =  @year_month_visits
-    = render TableComponent.new(id: 'statistics_table') do |t|
+    = render TableComponent.new(id: 'statistics_table', paging: true, sort_column: '0', no_init_sort: true, show_all: true) do |t|
       - t.header do |h|
         - h.th {t('statistics.date')}
         - h.th {t('statistics.ontologies')}

--- a/app/views/statistics/index.html.haml
+++ b/app/views/statistics/index.html.haml
@@ -5,9 +5,10 @@
       = t('statistics.lead', last_years: Date.today.year - Date.parse(@merged_data[:labels].first).year)
 %div.container
   %div
-    = chart_component(title: nil, type: 'line', show_legend: true, 
-                      labels: @merged_data[:labels], datasets: visits_chart_dataset_array({ t('statistics.ontologies') => @merged_data[:visits][2], 
-                      t('statistics.users') => @merged_data[:visits][0], t('statistics.projects') => @merged_data[:visits][1] }, fill: false))
+    = chart_component(title: nil, type: 'line', show_legend: true,
+                      labels: @merged_data[:labels], datasets: visits_chart_dataset_array({ t('statistics.ontologies') => @merged_data[:visits][2],
+                      t('statistics.users') => @merged_data[:visits][0], t('statistics.projects') => @merged_data[:visits][1],
+                      t('statistics.agents') => @merged_data[:visits][3] }, fill: false))
 
   %div.pb-3.pb-md-4
     - size = @merged_data[:labels].size - 1
@@ -18,6 +19,7 @@
         - h.th {t('statistics.ontologies')}
         - h.th {t('statistics.users')}
         - h.th {t('statistics.projects')}
+        - h.th {t('statistics.agents')}
         - h.th {t('statistics.ontology_visits')}
 
       - @merged_data[:labels].reverse.each_with_index  do |year_month, i|
@@ -26,6 +28,7 @@
           - r.td {@merged_data[:visits][2][size - i].to_s}
           - r.td {@merged_data[:visits][0][size - i].to_s}
           - r.td {@merged_data[:visits][1][size - i].to_s}
+          - r.td {@merged_data[:visits][3][size - i].to_s}
           - r.td do
             - year = Date.parse(year_month).year
             - month = Date.parse(year_month).month

--- a/app/views/statistics/index.html.haml
+++ b/app/views/statistics/index.html.haml
@@ -4,7 +4,7 @@
     %p.lead
       = t('statistics.lead', last_years: Date.today.year - Date.parse(@merged_data[:labels].first).year)
 %div.container
-  - series = [[:ontologies, t('statistics.ontologies'), @merged_data[:visits][2]], [:users, t('statistics.users'), @merged_data[:visits][0]], [:projects, t('statistics.projects'), @merged_data[:visits][1]], [:agents, t('statistics.agents'), @merged_data[:visits][3]]]
+  - series = [{ key: :ontologies, label: t('statistics.ontologies'), data: @merged_data[:visits][2], cumulative: true }, { key: :users, label: t('statistics.users'), data: @merged_data[:visits][0], cumulative: true }, { key: :projects, label: t('statistics.projects'), data: @merged_data[:visits][1], cumulative: true }, { key: :agents, label: t('statistics.agents'), data: @merged_data[:visits][3], cumulative: true }]
   .statistics-chart-container
     = chart_component(title: nil, type: 'line', show_legend: true,
                       labels: @merged_data[:labels],

--- a/app/views/statistics/index.html.haml
+++ b/app/views/statistics/index.html.haml
@@ -1,6 +1,17 @@
 .container.d-flex.flex-column.py-4{ style: "width: 1248px;" }
   .d-flex.justify-content-between
     = render PageHeaderComponent.new(title: t('statistics.title', portal: portal_name), description: t('statistics.description', portal: portal_name, last_years: Date.today.year - Date.parse(@merged_data[:labels].first).year))
+  .statistics-kpi-grid
+    - statistics_kpi_cards(@merged_data).each do |kpi|
+      .statistics-kpi-card{ style: "--kpi-color: #{kpi[:color]};" }
+        .statistics-kpi-label= kpi[:label]
+        .statistics-kpi-value= number_with_delimiter(kpi[:total])
+        - if kpi[:delta] > 0
+          .statistics-kpi-delta.up
+            = "+#{number_with_delimiter(kpi[:delta])} #{t('statistics.this_month')}"
+        - elsif kpi[:delta] < 0
+          .statistics-kpi-delta.down
+            = "#{number_with_delimiter(kpi[:delta])} #{t('statistics.this_month')}"
   - series = [{ key: :ontologies, label: t('statistics.ontologies'), data: @merged_data[:visits][2], cumulative: true }, { key: :users, label: t('statistics.users'), data: @merged_data[:visits][0], cumulative: true }, { key: :projects, label: t('statistics.projects'), data: @merged_data[:visits][1], cumulative: true }, { key: :agents, label: t('statistics.agents'), data: @merged_data[:visits][3], cumulative: true, hidden: true }]
   .statistics-chart-container
     = chart_component(title: nil, type: 'line', show_legend: true,

--- a/app/views/statistics/index.html.haml
+++ b/app/views/statistics/index.html.haml
@@ -4,7 +4,7 @@
     %p.lead
       = t('statistics.lead', last_years: Date.today.year - Date.parse(@merged_data[:labels].first).year)
 %div.container
-  - series = [{ key: :ontologies, label: t('statistics.ontologies'), data: @merged_data[:visits][2], cumulative: true }, { key: :users, label: t('statistics.users'), data: @merged_data[:visits][0], cumulative: true }, { key: :projects, label: t('statistics.projects'), data: @merged_data[:visits][1], cumulative: true }, { key: :agents, label: t('statistics.agents'), data: @merged_data[:visits][3], cumulative: true }]
+  - series = [{ key: :ontologies, label: t('statistics.ontologies'), data: @merged_data[:visits][2], cumulative: true }, { key: :users, label: t('statistics.users'), data: @merged_data[:visits][0], cumulative: true }, { key: :projects, label: t('statistics.projects'), data: @merged_data[:visits][1], cumulative: true }, { key: :agents, label: t('statistics.agents'), data: @merged_data[:visits][3], cumulative: true, hidden: true }]
   .statistics-chart-container
     = chart_component(title: nil, type: 'line', show_legend: true,
                       labels: @merged_data[:labels],

--- a/app/views/statistics/index.html.haml
+++ b/app/views/statistics/index.html.haml
@@ -1,9 +1,6 @@
-%div.px-3.py-3.pt-md-5.pb-md-4.text-center
-  %h1.display-4
-    = t('statistics.title', portal: portal_name)
-    %p.lead
-      = t('statistics.lead', last_years: Date.today.year - Date.parse(@merged_data[:labels].first).year)
-%div.container
+.container.d-flex.flex-column.py-4{ style: "width: 1248px;" }
+  .d-flex.justify-content-between
+    = render PageHeaderComponent.new(title: t('statistics.title', portal: portal_name), description: t('statistics.description', portal: portal_name, last_years: Date.today.year - Date.parse(@merged_data[:labels].first).year))
   - series = [{ key: :ontologies, label: t('statistics.ontologies'), data: @merged_data[:visits][2], cumulative: true }, { key: :users, label: t('statistics.users'), data: @merged_data[:visits][0], cumulative: true }, { key: :projects, label: t('statistics.projects'), data: @merged_data[:visits][1], cumulative: true }, { key: :agents, label: t('statistics.agents'), data: @merged_data[:visits][3], cumulative: true, hidden: true }]
   .statistics-chart-container
     = chart_component(title: nil, type: 'line', show_legend: true,

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1531,6 +1531,7 @@ en:
     ontologies: Ontologies
     ontology_visits: Ontology visits
     projects: Projects
+    this_month: this month
     title: "%{portal} Statistics"
     users: Users
   submission_inputs:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1526,6 +1526,7 @@ en:
   statistics:
     agents: Agents
     date: Date
+    description: "Evolution of resources in %{portal} through numbers (last %{last_years} years)."
     lead: "(last %{last_years} years)"
     ontologies: Ontologies
     ontology_visits: Ontology visits

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1524,6 +1524,7 @@ en:
     show_advanced_options: Show options
   show_advanced_options: Show advanced options
   statistics:
+    agents: Agents
     date: Date
     lead: "(last %{last_years} years)"
     ontologies: Ontologies

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -1581,6 +1581,7 @@ fr:
     ontologies: Ontologies
     ontology_visits: Visites de l'ontologie
     projects: Projets
+    this_month: ce mois-ci
     title: Statistiques de %{portal}
     users: Utilisateurs
   submission_inputs:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -1576,6 +1576,7 @@ fr:
   statistics:
     agents: Agents
     date: Date
+    description: "Évolution des ressources de %{portal} en chiffres (dernières %{last_years} années)."
     lead: "(dernières %{last_years} années)"
     ontologies: Ontologies
     ontology_visits: Visites de l'ontologie

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -1574,6 +1574,7 @@ fr:
     show_advanced_options: Afficher les options
   show_advanced_options: Afficher les options avancées
   statistics:
+    agents: Agents
     date: Date
     lead: "(dernières %{last_years} années)"
     ontologies: Ontologies


### PR DESCRIPTION
  ## Summary

  A focused pass on `/statistics` to make the page more useful at a glance and faster to render.
<img width="1792" height="882" alt="Screenshot 2026-05-08 at 01 57 49" src="https://github.com/user-attachments/assets/7d6facf8-19d2-4114-8b7b-5626f847f6c7" />
