### PR TITLE
feat: always show add-agent button, redirect to login when logged out

### DIFF
--- a/app/helpers/agent_helper.rb
+++ b/app/helpers/agent_helper.rb
@@ -319,27 +319,31 @@ module AgentHelper
   end
 
   def agents_create_button
-    link_to_modal(
-      nil,
-      new_agent_path,
-      id: "new_agent_btn",
-      role: "button",
-      data: {
-        show_modal_title_value: t("agents.index.create_new_agent"),
-        show_modal_size_value: "modal-xl"
-      }
-    ) do
-      regular_button(
-        "new_agent_btn",
-        t("agents.index.create_new_agent"),
-        variant: "secondary",
-        state: "regular",
-        size: nil
-      ) do |btn|
-        btn.icon_left do
-          inline_svg_tag "icons/plus.svg"
-        end
+    button = regular_button(
+      "new_agent_btn",
+      t("agents.index.create_new_agent"),
+      variant: "secondary",
+      state: "regular",
+      size: nil
+    ) do |btn|
+      btn.icon_left do
+        inline_svg_tag "icons/plus.svg"
       end
+    end
+
+    if session[:user]
+      link_to_modal(
+        nil,
+        new_agent_path,
+        id: "new_agent_btn",
+        role: "button",
+        data: {
+          show_modal_title_value: t("agents.index.create_new_agent"),
+          show_modal_size_value: "modal-xl"
+        }
+      ) { button }
+    else
+      link_to(button, "/login?redirect=#{CGI.escape(agents_path)}", id: "new_agent_btn", role: "button")
     end
   end
   def agents_edit_button

--- a/app/views/agents/index.html.haml
+++ b/app/views/agents/index.html.haml
@@ -4,9 +4,8 @@
     .d-flex.align-items-center
       - link, target = api_button_link_and_target(agents_rest_url)
       = render RoundedButtonComponent.new(link: link, target: target, size: 'medium', title: t("components.go_to_api"))
-      - if session[:user]
-        .span.m-2
-        = agents_create_button
+      .span.m-2
+      = agents_create_button
   = render_alerts_container(AgentsController)
   - columns_names = ['name', 'acronym', 'affiliations', 'usages']
   - if session[:user] && session[:user].admin?


### PR DESCRIPTION
Always display the “Create Agent” button, and redirect the user when they aren’t logged in

https://github.com/user-attachments/assets/1b6aa4d6-56e5-4842-981e-6c9580aada3a

