### PR TITLE
Feat/mappings api button

### DIFF
--- a/app/controllers/mappings_controller.rb
+++ b/app/controllers/mappings_controller.rb
@@ -132,7 +132,8 @@ class MappingsController < ApplicationController
     end
 
     ontologies = [ontology_acronym, target_acronym]
-    @mapping_pages = LinkedData::Client::HTTP.get("#{MAPPINGS_URL}", { page: page, ontologies: ontologies.join(',') })
+    @ontologies_param = ontologies.join(',')
+    @mapping_pages = LinkedData::Client::HTTP.get("#{MAPPINGS_URL}", { page: page, ontologies: @ontologies_param })
     not_found(@mapping_pages.errors) if @mapping_pages.respond_to?(:errors)
     @mappings = @mapping_pages.collection
     @delete_mapping_permission = check_delete_mapping_permission(@mappings)

--- a/app/helpers/mappings_helper.rb
+++ b/app/helpers/mappings_helper.rb
@@ -1,5 +1,13 @@
 module MappingsHelper
 
+  def mappings_rest_url(ontologies = nil, display = nil)
+    url = rest_url + mappings_path
+    params = []
+    params << "ontologies=#{ontologies}" if ontologies
+    params << "display=#{display}" if display
+    url + (params.any? ? "?#{params.join('&')}" : '')
+  end
+
   # Used to replace the full URI by the prefixed URI
   RELATIONSHIP_PREFIX = {
     'http://www.w3.org/2004/02/skos/core#' => 'skos:',

--- a/app/views/mappings/_show.html.haml
+++ b/app/views/mappings/_show.html.haml
@@ -1,4 +1,7 @@
 = render_in_modal do
+  .d-flex.justify-content-end.mb-2
+    - link, target = api_button_link_and_target(mappings_rest_url(@ontologies_param))
+    = render RoundedButtonComponent.new(link: link, target: target, size: 'medium', title: t("components.go_to_api"))
   #mappings.paginate_ajax{:style => "overflow: auto; max-height: 600px;"}
     #mapping_results
       .mappings-table-pagination

--- a/app/views/mappings/index.html.haml
+++ b/app/views/mappings/index.html.haml
@@ -5,13 +5,9 @@
                         }
   .mappings-page-subcontainer
     .mappings-page-title
-      .d-flex.justify-content-between.align-items-center
-        .d-flex.flex-column
-          .text
-            = @title
-          .line
-        - link, target = api_button_link_and_target(mappings_rest_url)
-        = render RoundedButtonComponent.new(link: link, target: target, size: 'medium', title: t("components.go_to_api"))
+      .text
+        = @title
+      .line
     .mappings-page-decription
       = t('mappings.description')
     = render TabsContainerComponent.new do |c|

--- a/app/views/mappings/index.html.haml
+++ b/app/views/mappings/index.html.haml
@@ -5,9 +5,13 @@
                         }
   .mappings-page-subcontainer
     .mappings-page-title
-      .text
-        = @title
-      .line
+      .d-flex.justify-content-between.align-items-center
+        .d-flex.flex-column
+          .text
+            = @title
+          .line
+        - link, target = api_button_link_and_target(mappings_rest_url)
+        = render RoundedButtonComponent.new(link: link, target: target, size: 'medium', title: t("components.go_to_api"))
     .mappings-page-decription
       = t('mappings.description')
     = render TabsContainerComponent.new do |c|


### PR DESCRIPTION
  Summary:
  - Added a RoundedButtonComponent button in the mappings modal (_show.html.haml) that links to the REST API for the current ontology pair mappings
  - Added mappings_rest_url helper that constructs the API URL with optional ontologies and display parameters
  - Exposed @ontologies_param in the controller to pass the current ontology pair to the modal view

<img width="1858" height="930" alt="image" src="https://github.com/user-attachments/assets/a9782d27-3a59-4876-bc2b-cd690cb54584" />