### PR TITLE
feat: add show/hide password toggle with eye icon

### DIFF
--- a/app/assets/stylesheets/login.scss
+++ b/app/assets/stylesheets/login.scss
@@ -64,13 +64,13 @@
 
 .password-toggle-wrapper {
     position: relative;
-    display: block;
-    width: 100%;
+    display: inline-block;
 }
 
 .password-toggle-wrapper input {
     margin-bottom: 0;
     box-sizing: border-box;
+    padding-right: 40px;
 }
 
 .password-toggle-btn {

--- a/app/assets/stylesheets/login.scss
+++ b/app/assets/stylesheets/login.scss
@@ -61,3 +61,33 @@
 .login-active-sso path{
     fill: var(--primary-color)
 }
+
+.password-toggle-wrapper {
+    position: relative;
+    display: block;
+    width: 100%;
+}
+
+.password-toggle-wrapper input {
+    margin-bottom: 0;
+    box-sizing: border-box;
+}
+
+.password-toggle-btn {
+    position: absolute;
+    right: 12px;
+    top: 50%;
+    transform: translateY(-50%);
+    background: none;
+    border: none;
+    padding: 4px;
+    cursor: pointer;
+    color: #8f8f8f;
+    display: flex;
+    align-items: center;
+    line-height: 0;
+}
+
+.password-toggle-btn:hover {
+    color: var(--primary-color);
+}

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -109,3 +109,6 @@ application.register('parent-categories-selector', ParentCategoriesSelectorContr
 
 import SubjectsController from "./subjects_controller.js"
 application.register("subjects", SubjectsController)
+
+import PasswordToggleController from "./password_toggle_controller.js"
+application.register("password-toggle", PasswordToggleController)

--- a/app/javascript/controllers/password_toggle_controller.js
+++ b/app/javascript/controllers/password_toggle_controller.js
@@ -1,0 +1,38 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  connect() {
+    this.input = this.element.querySelector("input")
+    if (!this.input) return
+
+    const btn = document.createElement("button")
+    btn.type = "button"
+    btn.classList.add("password-toggle-btn")
+    btn.setAttribute("aria-label", "Show password")
+    btn.innerHTML = this.eyeIcon()
+    btn.addEventListener("click", (e) => { e.preventDefault(); this.toggle() })
+
+    this.element.appendChild(btn)
+  }
+
+  toggle() {
+    const btn = this.element.querySelector(".password-toggle-btn")
+    if (this.input.type === "password") {
+      this.input.type = "text"
+      btn.innerHTML = this.eyeOffIcon()
+      btn.setAttribute("aria-label", "Hide password")
+    } else {
+      this.input.type = "password"
+      btn.innerHTML = this.eyeIcon()
+      btn.setAttribute("aria-label", "Show password")
+    }
+  }
+
+  eyeIcon() {
+    return `<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z"/><circle cx="12" cy="12" r="3"/></svg>`
+  }
+
+  eyeOffIcon() {
+    return `<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M17.94 17.94A10.07 10.07 0 0 1 12 20c-7 0-11-8-11-8a18.45 18.45 0 0 1 5.06-5.94M9.9 4.24A9.12 9.12 0 0 1 12 4c7 0 11 8 11 8a18.5 18.5 0 0 1-2.16 3.19m-6.72-1.07a3 3 0 1 1-4.24-4.24"/><line x1="1" y1="1" x2="23" y2="23"/></svg>`
+  }
+}

--- a/app/javascript/controllers/password_toggle_controller.js
+++ b/app/javascript/controllers/password_toggle_controller.js
@@ -9,6 +9,7 @@ export default class extends Controller {
     btn.type = "button"
     btn.classList.add("password-toggle-btn")
     btn.setAttribute("aria-label", "Show password")
+    btn.setAttribute("aria-pressed", "false")
     btn.innerHTML = this.eyeIcon()
     btn.addEventListener("click", (e) => { e.preventDefault(); this.toggle() })
 
@@ -21,18 +22,20 @@ export default class extends Controller {
       this.input.type = "text"
       btn.innerHTML = this.eyeOffIcon()
       btn.setAttribute("aria-label", "Hide password")
+      btn.setAttribute("aria-pressed", "true")
     } else {
       this.input.type = "password"
       btn.innerHTML = this.eyeIcon()
       btn.setAttribute("aria-label", "Show password")
+      btn.setAttribute("aria-pressed", "false")
     }
   }
 
   eyeIcon() {
-    return `<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z"/><circle cx="12" cy="12" r="3"/></svg>`
+    return `<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z"/><circle cx="12" cy="12" r="3"/></svg>`
   }
 
   eyeOffIcon() {
-    return `<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M17.94 17.94A10.07 10.07 0 0 1 12 20c-7 0-11-8-11-8a18.45 18.45 0 0 1 5.06-5.94M9.9 4.24A9.12 9.12 0 0 1 12 4c7 0 11 8 11 8a18.5 18.5 0 0 1-2.16 3.19m-6.72-1.07a3 3 0 1 1-4.24-4.24"/><line x1="1" y1="1" x2="23" y2="23"/></svg>`
+    return `<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M17.94 17.94A10.07 10.07 0 0 1 12 20c-7 0-11-8-11-8a18.45 18.45 0 0 1 5.06-5.94M9.9 4.24A9.12 9.12 0 0 1 12 4c7 0 11 8 11 8a18.5 18.5 0 0 1-2.16 3.19m-6.72-1.07a3 3 0 1 1-4.24-4.24"/><line x1="1" y1="1" x2="23" y2="23"/></svg>`
   }
 }

--- a/app/views/login/index.html.haml
+++ b/app/views/login/index.html.haml
@@ -11,7 +11,8 @@
       %p.login-input-title= t('login.username_or_email')
       = text_field 'user', 'username', class: "login-input email-input", placeholder: t('login.enter_email')
       %p.login-input-title= t('login.password')
-      = password_field 'user','password', :autocomplete => "off", class: "login-input password-input", placeholder:  t('login.enter_password')
+      .password-toggle-wrapper.password-input{data: { controller: "password-toggle" }}
+        = password_field 'user','password', :autocomplete => "off", class: "login-input mb-0", placeholder:  t('login.enter_password')
       %a.login-forgot-password{:href => "/lost_pass"}
         %p= t('login.forgot_password')
       .login-button-container

--- a/app/views/users/_form.html.haml
+++ b/app/views/users/_form.html.haml
@@ -42,11 +42,13 @@
     %p.register-input-title
       = t('register.password')
       %font{:color => "red"} *
-    = password_field :user, :password, class: "register-input-long"
+    .password-toggle-wrapper.mb-3{data: { controller: "password-toggle" }}
+      = password_field :user, :password, class: "register-input-long mb-0"
     %p.register-input-title
       = t('register.confirm_password')
       %font{:color => "red"} *
-    = password_field :user, :password_confirmation, class: "register-input-long"
+    .password-toggle-wrapper.mb-3{data: { controller: "password-toggle" }}
+      = password_field :user, :password_confirmation, class: "register-input-long mb-0"
     - if using_captcha?
       = recaptcha_tags
     .d-flex

--- a/app/views/users/edit.html.haml
+++ b/app/views/users/edit.html.haml
@@ -119,12 +119,14 @@
         %p.register-input-title
           = t('users.edit.new_password')
           %font{:color => "red"} *
-        = password_field :user, :password, class: "register-input-long"
+        .password-toggle-wrapper.mb-3{data: { controller: "password-toggle" }}
+          = password_field :user, :password, class: "register-input-long mb-0"
 
         %p.register-input-title
           = t('users.edit.confirm_password')
           %font{:color => "red"} *
-        = password_field :user, :password_confirmation, class: "register-input-long"
+        .password-toggle-wrapper.mb-3{data: { controller: "password-toggle" }}
+          = password_field :user, :password_confirmation, class: "register-input-long mb-0"
       %br
       = render Buttons::RegularButtonComponent.new(id: 'update-button', value: "Save", type:'submit')
       - unless params[:password].eql?("true")


### PR DESCRIPTION
  Summary
  - Added password visibility toggle (eye icon) on login and registration forms
  - Uses Stimulus controller for dynamic show/hide behavior
  - Works on login page, registration form, and user edit (password change) form

 Changes
  - New `password_toggle_controller.js` (Stimulus)
  - Updated login form (`login/index.html.haml`)
  - Updated registration form (`users/_form.html.haml`)
  - Updated user edit form (`users/edit.html.haml`)
  - New styles (`login.scss`)
