### PR TITLE
chore: enable Puma request logging via log_requests

### DIFF
--- a/config/puma.rb
+++ b/config/puma.rb
@@ -13,6 +13,9 @@ threads min_threads_count, max_threads_count
 rails_env = ENV.fetch("RAILS_ENV") { "development" }
 environment rails_env
 
+# Log each request as it occurs.
+log_requests true
+
 if %w[production staging appliance].include?(rails_env)
 
   # Define Puma socket (for Nginx)


### PR DESCRIPTION
Since the migration to the new appliance we are using Puma for running Rails and we didn't activate the logging for our frontend requests

- I've also added logging rotation in the server  

```
ubuntu@stageportal:~$ cat  /etc/logrotate.d/rails
/opt/ontoportal/ontoportal_web_ui/current/*.log {
  compress
  copytruncate
  dateext
  delaycompress
  missingok
  notifempty
  rotate 7
  size 10M
  postrotate
    kill -HUP `cat /opt/ontoportal/ontoportal_web_ui/shared/tmp/pids/puma.pid`
  endscript
}
```
