### PR TITLE
Generic Carousel component 

### DIFF
--- a/app/assets/stylesheets/components/carousel.scss
+++ b/app/assets/stylesheets/components/carousel.scss
@@ -1,0 +1,90 @@
+.carousel,
+.fairness-carousel {
+  position: relative;
+
+  .carousel-viewport,
+  .fairness-carousel-viewport {
+    overflow: hidden;
+    border-radius: 8px;
+  }
+
+  .carousel-track,
+  .fairness-carousel-track {
+    display: flex;
+    transition: transform 0.4s ease;
+
+    > * {
+      flex: 0 0 100%;
+      min-width: 0;
+    }
+  }
+
+  &.carousel--images {
+    > .carousel-track,
+    > .fairness-carousel-track {
+      > * {
+        padding: 0 32px;
+      }
+    }
+
+    .image-content {
+      width: 100%;
+      height: 300px;
+      object-fit: contain;
+    }
+  }
+
+  .carousel-btn,
+  .fairness-carousel-btn {
+    position: absolute;
+    top: 50%;
+    transform: translateY(-50%);
+    z-index: 10;
+    width: 32px;
+    height: 32px;
+    border-radius: 50%;
+    border: 1px solid var(--primary-color);
+    background: white;
+    cursor: pointer;
+    padding: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    transition: background-color ease 0.3s;
+
+    svg path {
+      stroke: var(--primary-color);
+      transition: stroke ease 0.3s;
+    }
+
+    .flip-x {
+      transform: scaleX(-1);
+    }
+
+    &:hover:not(.disabled) {
+      background-color: var(--primary-color);
+
+      svg path {
+        stroke: white;
+      }
+    }
+
+    &.disabled {
+      cursor: default;
+
+      svg {
+        opacity: 0.25;
+      }
+    }
+
+    &.carousel-btn-prev,
+    &.fairness-carousel-btn-prev {
+      left: -16px;
+    }
+
+    &.carousel-btn-next,
+    &.fairness-carousel-btn-next {
+      right: -16px;
+    }
+  }
+}

--- a/app/assets/stylesheets/components/index.scss
+++ b/app/assets/stylesheets/components/index.scss
@@ -37,3 +37,4 @@
 @import "tree_view";
 @import "page_header";
 @import "edit_sample_queries";
+@import "carousel";

--- a/app/assets/stylesheets/fair_assement.scss
+++ b/app/assets/stylesheets/fair_assement.scss
@@ -153,69 +153,6 @@ $non_applicable_color :  rgba(176, 190, 197, 0.4);
   }
 }
 
-.fairness-carousel {
-  position: relative;
-
-  .fairness-carousel-viewport {
-    overflow: hidden;
-    border-radius: 8px;
-  }
-
-  .fairness-carousel-track {
-    display: flex;
-    transition: transform 0.4s ease;
-    > * {
-      flex: 0 0 100%;
-      min-width: 0;
-    }
-  }
-
-  .fairness-carousel-btn {
-    position: absolute;
-    top: 50%;
-    transform: translateY(-50%);
-    z-index: 10;
-    width: 32px;
-    height: 32px;
-    border-radius: 50%;
-    border: 1px solid var(--primary-color);
-    background: white;
-    cursor: pointer;
-    padding: 0;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    transition: background-color ease 0.3s;
-
-    svg path {
-      stroke: var(--primary-color);
-      transition: stroke ease 0.3s;
-    }
-
-    .flip-x {
-      transform: scaleX(-1);
-    }
-
-    &:hover:not(.disabled) {
-      background-color: var(--primary-color);
-      svg path { stroke: white; }
-    }
-
-    &.disabled {
-      cursor: default;
-      svg { opacity: 0.25; }
-    }
-
-    &.fairness-carousel-btn-prev {
-      left: -16px;
-    }
-
-    &.fairness-carousel-btn-next {
-      right: -16px;
-    }
-  }
-}
-
 .fair-section-head {
   display: flex;
   align-items: center;

--- a/app/components/carousel_component.rb
+++ b/app/components/carousel_component.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class CarouselComponent < ViewComponent::Base
+  renders_many :slides
+
+  def initialize(images: false, loop: false)
+    super
+    @images = images
+    @loop = loop
+  end
+
+  def css_class
+    @images ? 'carousel carousel--images' : 'carousel'
+  end
+end

--- a/app/components/carousel_component/carousel_component.html.haml
+++ b/app/components/carousel_component/carousel_component.html.haml
@@ -4,8 +4,8 @@
       - slides.each do |slide|
         %div= slide
 
-  %button.carousel-btn.carousel-btn-prev.disabled{data: { action: 'carousel#prev' }}
+  %button.carousel-btn.carousel-btn-prev.disabled{type: 'button', aria: { label: 'Previous' }, data: { action: 'carousel#prev' }}
     = inline_svg_tag('icons/chevron-left.svg', width: 8, height: 12)
 
-  %button.carousel-btn.carousel-btn-next{data: { action: 'carousel#next' }}
+  %button.carousel-btn.carousel-btn-next{type: 'button', aria: { label: 'Next' }, data: { action: 'carousel#next' }}
     = inline_svg_tag('icons/chevron-left.svg', width: 8, height: 12, class: 'flip-x')

--- a/app/components/carousel_component/carousel_component.html.haml
+++ b/app/components/carousel_component/carousel_component.html.haml
@@ -1,0 +1,11 @@
+%div{class: css_class, data: { controller: 'carousel', carousel_loop_value: @loop.to_s }}
+  .carousel-viewport
+    .carousel-track{data: { carousel_target: 'container' }}
+      - slides.each do |slide|
+        %div= slide
+
+  %button.carousel-btn.carousel-btn-prev.disabled{data: { action: 'carousel#prev' }}
+    = inline_svg_tag('icons/chevron-left.svg', width: 8, height: 12)
+
+  %button.carousel-btn.carousel-btn-next{data: { action: 'carousel#next' }}
+    = inline_svg_tag('icons/chevron-left.svg', width: 8, height: 12, class: 'flip-x')

--- a/app/helpers/ontologies_helper.rb
+++ b/app/helpers/ontologies_helper.rb
@@ -651,11 +651,18 @@ module OntologiesHelper
   end
 
   def ontology_depiction_card
-    return if Array(@submission_latest&.depiction).empty?
+    depictions = Array(@submission_latest&.depiction)
+    return if depictions.empty?
 
     render Layout::CardComponent.new do
-      list_container(@submission_latest.depiction) do |depiction_url|
-        render Display::ImageComponent.new(src: depiction_url)
+      if depictions.size == 1
+        render Display::ImageComponent.new(src: depictions.first)
+      else
+        render CarouselComponent.new(images: true) do |c|
+          depictions.each do |url|
+            c.slide { render Display::ImageComponent.new(src: url) }
+          end
+        end
       end
     end
   end

--- a/app/javascript/controllers/carousel_controller.js
+++ b/app/javascript/controllers/carousel_controller.js
@@ -1,0 +1,74 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = ["container", "tab"]
+
+  static values = {
+    loop: { type: Boolean, default: false },
+    prevSelector: { type: String, default: ".carousel-btn-prev" },
+    nextSelector: { type: String, default: ".carousel-btn-next" },
+  }
+
+  connect() {
+    this.current = 0
+    this.updateUI()
+  }
+
+  get slidesCount() {
+    return this.containerTarget.children.length
+  }
+
+  prev() {
+    if (this.loopValue && this.current === 0) {
+      this.current = this.slidesCount - 1
+    } else if (this.current > 0) {
+      this.current--
+    } else {
+      return
+    }
+    this.slideTo(this.current)
+  }
+
+  next() {
+    if (this.loopValue && this.current >= this.slidesCount - 1) {
+      this.current = 0
+    } else if (this.current < this.slidesCount - 1) {
+      this.current++
+    } else {
+      return
+    }
+    this.slideTo(this.current)
+  }
+
+  goTo(event) {
+    const index = this.tabTargets.indexOf(event.currentTarget)
+    if (index >= 0) {
+      this.current = index
+      this.slideTo(this.current)
+    }
+  }
+
+  slideTo(index) {
+    if (this.hasContainerTarget) {
+      this.containerTarget.style.transform = `translateX(-${index * 100}%)`
+    }
+    this.updateUI()
+  }
+
+  updateUI() {
+    const max = this.slidesCount - 1
+    const prevBtn = this.element.querySelector(this.prevSelectorValue)
+    const nextBtn = this.element.querySelector(this.nextSelectorValue)
+
+    if (prevBtn) {
+      prevBtn.classList.toggle("disabled", !this.loopValue && this.current === 0)
+    }
+    if (nextBtn) {
+      nextBtn.classList.toggle("disabled", !this.loopValue && this.current >= max)
+    }
+
+    this.tabTargets.forEach((tab, i) => {
+      tab.classList.toggle("active", i === this.current)
+    })
+  }
+}

--- a/app/javascript/controllers/fairness_carousel_controller.js
+++ b/app/javascript/controllers/fairness_carousel_controller.js
@@ -1,46 +1,9 @@
-import { Controller } from "@hotwired/stimulus"
+import CarouselController from "./carousel_controller"
 
-export default class extends Controller {
-  static targets = ["container", "tab"]
-
-  connect() {
-    this.current = 0
-    this.updateUI()
-  }
-
-  prev() {
-    if (this.current > 0) {
-      this.current--
-      this.slideTo(this.current)
-    }
-  }
-
-  next() {
-    if (this.current < this.containerTarget.children.length - 1) {
-      this.current++
-      this.slideTo(this.current)
-    }
-  }
-
-  goTo(event) {
-    this.current = this.tabTargets.indexOf(event.currentTarget)
-    this.slideTo(this.current)
-  }
-
-  slideTo(index) {
-    this.containerTarget.style.transform = `translateX(-${index * 100}%)`
-    this.updateUI()
-  }
-
-  updateUI() {
-    const max = this.containerTarget.children.length - 1
-    const prevBtn = this.element.querySelector(".fairness-carousel-btn-prev")
-    const nextBtn = this.element.querySelector(".fairness-carousel-btn-next")
-    if (prevBtn) prevBtn.classList.toggle("disabled", this.current === 0)
-    if (nextBtn) nextBtn.classList.toggle("disabled", this.current >= max)
-
-    this.tabTargets.forEach((tab, i) => {
-      tab.classList.toggle("active", i === this.current)
-    })
+export default class extends CarouselController {
+  static values = {
+    ...CarouselController.values,
+    prevSelector: { type: String, default: ".fairness-carousel-btn-prev" },
+    nextSelector: { type: String, default: ".fairness-carousel-btn-next" },
   }
 }

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -110,6 +110,9 @@ application.register('parent-categories-selector', ParentCategoriesSelectorContr
 import SubjectsController from "./subjects_controller.js"
 application.register("subjects", SubjectsController)
 
+import ClassPickerController from "./class_picker_controller.js"
+application.register("class-picker", ClassPickerController)
+
 import CarouselController from "./carousel_controller.js"
 application.register("carousel", CarouselController)
 

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -25,9 +25,6 @@ application.register("fair-score-landscape", FairScoreLandscapeController)
 import FairScoreSummaryController from "./fair_score_summary_controller"
 application.register("fair-score-summary", FairScoreSummaryController)
 
-import FoopsScoreSummaryController from "./foops_score_summary_controller"
-application.register("foops-score-summary", FoopsScoreSummaryController)
-
 import FormAutoCompleteController from "./form_auto_complete_controller"
 application.register("form-auto-complete", FormAutoCompleteController)
 
@@ -109,16 +106,21 @@ application.register('concepts-json', ConceptsJsonButtonController)
 import ParentCategoriesSelectorController from "./parent_categories_selector_controller.js"
 application.register('parent-categories-selector', ParentCategoriesSelectorController)
 
-import ClassPickerController from "./class_picker_controller.js"
-application.register("class-picker", ClassPickerController)
 
 import SubjectsController from "./subjects_controller.js"
 application.register("subjects", SubjectsController)
 
+import CarouselController from "./carousel_controller.js"
+application.register("carousel", CarouselController)
+
 import FairnessCarouselController from "./fairness_carousel_controller.js"
 application.register("fairness-carousel", FairnessCarouselController)
 
+import FoopsScoreSummaryController from "./foops_score_summary_controller"
+application.register("foops-score-summary", FoopsScoreSummaryController)
+
 import PasswordToggleController from "./password_toggle_controller.js"
 application.register("password-toggle", PasswordToggleController)
+
 import RorSearchController from "./ror_search_controller.js"
 application.register("ror-search", RorSearchController)

--- a/test/components/previews/carousel_component_preview.rb
+++ b/test/components/previews/carousel_component_preview.rb
@@ -1,0 +1,80 @@
+# frozen_string_literal: true
+
+# Generic, reusable **carousel / slider** built with ViewComponent + Stimulus.
+#
+# It wraps any number of *slides* and shows one at a time, with **Previous /
+# Next** navigation. It is generic: a slide can hold anything (text, an image,
+# another component). For example it is used to display multiple ontology
+# depictions, or the fairness assessment charts.
+#
+# ## Usage
+#
+# ```haml
+# = render CarouselComponent.new do |c|
+#   - @items.each do |item|
+#     - c.slide { render SomeComponent.new(item) }
+# ```
+#
+# ## Options
+#
+# | Option   | Type    | Default | Description                                              |
+# |----------|---------|---------|----------------------------------------------------------|
+# | `images` | Boolean | `false` | Adds the `carousel--images` modifier (image styling).    |
+# | `loop`   | Boolean | `false` | When `true`, navigation wraps around (last → first).     |
+#
+# Slides are provided through the **`slide` slot** (`renders_many :slides`).
+# With `loop: false` the *Previous* button is disabled on the first slide and
+# *Next* on the last one.
+#
+# The behaviour lives in the `carousel` Stimulus controller; the
+# `fairness-carousel` controller extends it with custom button selectors.
+class CarouselComponentPreview < ViewComponent::Preview
+  layout 'component_preview_not_centred'
+
+  SLIDE = ->(label, bg = '#eef2f8') do
+    %(<div style="padding:3rem;text-align:center;font-weight:600;background:#{bg}">#{label}</div>).html_safe
+  end
+
+  # Basic carousel with a few text slides.
+  # *Previous* is disabled on the first slide.
+  def default
+    render CarouselComponent.new do |c|
+      4.times { |i| c.slide { SLIDE.call("Slide #{i + 1}") } }
+    end
+  end
+
+  # @label With loop
+  # With `loop: true`, *Next* on the last slide goes back to the first
+  # (and *Previous* on the first goes to the last). No button is ever disabled.
+  def with_loop
+    render CarouselComponent.new(loop: true) do |c|
+      3.times { |i| c.slide { SLIDE.call("Slide #{i + 1}", '#eef7ee') } }
+    end
+  end
+
+  # @label Images mode
+  # `images: true` applies the image-oriented styling
+  # (this is how ontology depictions are shown).
+  def images
+    render CarouselComponent.new(images: true) do |c|
+      3.times { c.slide { render Display::ImageComponent.new(src: 'empty-box.svg') } }
+    end
+  end
+
+  # A single slide: both arrows are disabled (nothing to navigate to).
+  def single_slide
+    render CarouselComponent.new do |c|
+      c.slide { SLIDE.call('Only slide') }
+    end
+  end
+
+  # @label Playground
+  # @param images toggle
+  # @param loop toggle
+  # @param slides number
+  def playground(images: false, loop: false, slides: 4)
+    render CarouselComponent.new(images: images, loop: loop) do |c|
+      slides.to_i.times { |i| c.slide { SLIDE.call("Slide #{i + 1}") } }
+    end
+  end
+end

--- a/test/system/submission_flows_test.rb
+++ b/test/system/submission_flows_test.rb
@@ -184,7 +184,7 @@ class SubmissionFlowsTest < ApplicationSystemTestCase
     # end
 
     submission_2.depiction.map do |d|
-      assert_selector "img[src=\"#{d}\"]"
+      assert_selector "img[src=\"#{d}\"]", visible: :all
     end
 
     assert_selector "img[src=\"#{submission_2.logo}\"]"


### PR DESCRIPTION
  Summary

  Introduces a generic, reusable carousel component to replace the FOOPS/fairness-specific slider logic. Any content (text, images, other components) can now be shown as slides with
  Previous/Next navigation. The fairness carousel now reuses it, and ontology depictions display through it when there are multiple images.

  What's added

  - CarouselComponent (ViewComponent) with a slide slot (renders_many :slides) and two options:
    - images: — image-oriented styling
    - loop: — wrap-around navigation (last → first)
  - carousel Stimulus controller — handles navigation, button enable/disable, optional looping, configurable prev/next selectors.
  - fairness_carousel controller now extends the generic one (removes ~40 lines of duplicated logic).
  - Lookbook preview documenting the component with interactive examples (default, loop, images, single slide, playground).

  Usage

  = render CarouselComponent.new(loop: true) do |c|
    - @items.each do |item|
      - c.slide { render SomeComponent.new(item) }





[carrousel.webm](https://github.com/user-attachments/assets/a086daa5-e9a6-437b-9db0-b728eece2e9d)
