### PR TITLE
feat: add XLSX (TDv5) format to the UI

### DIFF
--- a/app/controllers/concerns/submission_filter.rb
+++ b/app/controllers/concerns/submission_filter.rb
@@ -7,6 +7,8 @@ module SubmissionFilter
                        'contact', 'released', 'naturalLanguage', 'hasOntologyLanguage',
                        'hasFormalityLevel', 'isOfType', 'deprecated', 'status', 'metrics']
 
+  ONTOLOGY_FORMATS = %w[OBO OWL SKOS UMLS XLSX].freeze
+
   def init_filters(params)
     @show_views = params[:show_views]&.eql?('true')
     @show_private_only = params[:private_only]&.eql?('true')
@@ -319,7 +321,7 @@ module SubmissionFilter
       { 'id' => id, 'name' => helpers.link_last_part(id), 'acronym' => name, 'value' => helpers.link_last_part(id) }
     end
 
-    @formats = [[t("submissions.filter.all_formats"), ''], 'OBO', 'OWL', 'SKOS', 'UMLS', 'XLSX']
+    @formats = [[t("submissions.filter.all_formats"), '']] + ONTOLOGY_FORMATS
     @sorts_options = [
       [t("submissions.filter.sort"), ''],
       [t("submissions.filter.sort_by_name"), 'ontology_name'],

--- a/app/controllers/concerns/submission_filter.rb
+++ b/app/controllers/concerns/submission_filter.rb
@@ -319,7 +319,7 @@ module SubmissionFilter
       { 'id' => id, 'name' => helpers.link_last_part(id), 'acronym' => name, 'value' => helpers.link_last_part(id) }
     end
 
-    @formats = [[t("submissions.filter.all_formats"), ''], 'OBO', 'OWL', 'SKOS', 'UMLS']
+    @formats = [[t("submissions.filter.all_formats"), ''], 'OBO', 'OWL', 'SKOS', 'UMLS', 'XLSX']
     @sorts_options = [
       [t("submissions.filter.sort"), ''],
       [t("submissions.filter.sort_by_name"), 'ontology_name'],

--- a/app/controllers/my_ontologies_controller.rb
+++ b/app/controllers/my_ontologies_controller.rb
@@ -93,7 +93,7 @@ class MyOntologiesController < ApplicationController
   # --- Filters ---
   def ontology_filters_init
     ## formats and sorts_options is for the filters in the search bar
-    @formats = [[t("submissions.filter.all_formats"), ''], 'OBO', 'OWL', 'SKOS', 'UMLS', 'XLSX']
+    @formats = [[t("submissions.filter.all_formats"), '']] + ONTOLOGY_FORMATS
     @sorts_options = [
       [t("submissions.filter.sort"), ''],
       [t("submissions.filter.sort_by_name"), 'ontology_name'],

--- a/app/controllers/my_ontologies_controller.rb
+++ b/app/controllers/my_ontologies_controller.rb
@@ -93,7 +93,7 @@ class MyOntologiesController < ApplicationController
   # --- Filters ---
   def ontology_filters_init
     ## formats and sorts_options is for the filters in the search bar
-    @formats = [[t("submissions.filter.all_formats"), ''], 'OBO', 'OWL', 'SKOS', 'UMLS']
+    @formats = [[t("submissions.filter.all_formats"), ''], 'OBO', 'OWL', 'SKOS', 'UMLS', 'XLSX']
     @sorts_options = [
       [t("submissions.filter.sort"), ''],
       [t("submissions.filter.sort_by_name"), 'ontology_name'],

--- a/app/helpers/submission_inputs_helper.rb
+++ b/app/helpers/submission_inputs_helper.rb
@@ -203,8 +203,15 @@ module SubmissionInputsHelper
     end
   end
 
+  def ontology_xlsx_language_help
+    content_tag(:div, class: 'upload-ontology-desc has_ontology_language_input') do
+      text = t('submission_inputs.ontology_xlsx_language_help', portal_name: portal_name)
+      text.html_safe
+    end
+  end
+
   def has_ontology_language_input(submission = @submission)
-    render(Layout::RevealComponent.new(possible_values: %w[SKOS OBO UMLS OWL], selected: submission.hasOntologyLanguage)) do |c|
+    render(Layout::RevealComponent.new(possible_values: %w[SKOS OBO UMLS OWL XLSX], selected: submission.hasOntologyLanguage)) do |c|
       c.button do
         attribute_input("hasOntologyLanguage")
       end
@@ -216,6 +223,8 @@ module SubmissionInputsHelper
       c.container { ontology_umls_language_help }
 
       c.container { ontology_owl_language_help }
+
+      c.container { ontology_xlsx_language_help }
 
     end
   end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1573,6 +1573,7 @@ en:
 
       '
     ontology_umls_language_link: by the UMLS2RDF tool.
+    ontology_xlsx_language_help: 'Crop Ontology Template (XLSX). The file must contain a sheet named "Template for submission" with Variable, Trait, Method, and Scale columns. The uploaded XLSX will be automatically converted to OWL by %{portal_name}.'
     ontology_view_of_another_ontology: Is this ontology a view of another ontology?
     validators: Validators
     version_help: For more information on how to encode versioning information in

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -1620,6 +1620,7 @@ fr:
 
       '
     ontology_umls_language_link: par l'outil UMLS2RDF.
+    ontology_xlsx_language_help: 'Template Crop Ontology (XLSX). Le fichier doit contenir une feuille nommée "Template for submission" avec les colonnes Variable, Trait, Method et Scale. Le fichier XLSX sera automatiquement converti en OWL par %{portal_name}.'
     ontology_view_of_another_ontology: Cette ontologie est-elle une vue d'une autre
       ontologie ?
     validators: Validateurs


### PR DESCRIPTION
Adds the XLSX format (Crop Ontology TDv5 template) to the AgroPortal user interface.

  What changed

  1. Search filters (submission_filter.rb, my_ontologies_controller.rb)
  - XLSX added to the format filter list.
  - DRY refactor: extracted a shared ONTOLOGY_FORMATS constant (was duplicated across 3 places).

  2. Upload dropdown (submission_inputs_helper.rb)
  - XLSX added to the format selector (hasOntologyLanguage) via RevealComponent.
  - New ontology_xlsx_language_help text: explains that the file must contain a sheet named "Template for submission" with Variable / Trait / Method / Scale columns, which will be
  automatically converted to OWL.

  3. Translations (fr.yml)
  - Added the ontology_xlsx_language_help key in French / English .
