### PR TITLE
fix: FAIR score UI improvements

### DIFF
--- a/.codegraph/.gitignore
+++ b/.codegraph/.gitignore
@@ -1,0 +1,16 @@
+# CodeGraph data files
+# These are local to each machine and should not be committed
+
+# Database
+*.db
+*.db-wal
+*.db-shm
+
+# Cache
+cache/
+
+# Logs
+*.log
+
+# Hook markers
+.dirty

--- a/app/assets/stylesheets/fair_assement.scss
+++ b/app/assets/stylesheets/fair_assement.scss
@@ -1,6 +1,6 @@
-$obtained_color : rgba(102, 187, 106, 0.4);
-$not_obtained_color : rgba(251, 192, 45, 0.4);
-$non_applicable_color :  rgba(176, 190, 197, 0.4);
+$obtained_color : rgba(102, 187, 106, 0.7);
+$not_obtained_color : rgba(251, 192, 45, 0.7);
+$non_applicable_color :  rgba(176, 190, 197, 0.7);
 
 .bg-obtained_color{
   background-color: $obtained_color !important;

--- a/app/helpers/fair_score_helper.rb
+++ b/app/helpers/fair_score_helper.rb
@@ -163,10 +163,8 @@ module FairScoreHelper
           'explanation' => check['explanation'],
           'score'       => check['total_passed_tests'].to_f,
           'maxCredits'  => check['total_tests_run'].to_f,
-          'points'      => [],
-          'properties'  => {
-            'references' => check['reference_resources']&.join(', ')
-          }.compact
+          'points'      => nil,
+          'properties'  => nil
         }
       end
       out[:criteria][:questions] << questions

--- a/app/javascript/mixins/useFairScore.js
+++ b/app/javascript/mixins/useFairScore.js
@@ -238,7 +238,7 @@ class FairScorePrincipleBar extends  FairScoreChart{
                 label: 'Obtained score',
                 data: scores,
                 fill: true,
-                backgroundColor: 'rgba(102, 187, 106, 0.2)',
+                backgroundColor: 'rgba(102, 187, 106, 0.5)',
                 borderColor: 'rgba(102, 187, 106, 1)',
                 pointBorderColor: 'rgba(102, 187, 106, 1)',
                 pointBackgroundColor: 'rgba(102, 187, 106, 1)'
@@ -247,7 +247,7 @@ class FairScorePrincipleBar extends  FairScoreChart{
                 label: 'Not obtained score',
                 data: notObtained,
                 fill: true,
-                backgroundColor: 'rgba(251, 192, 45, 0.2)',
+                backgroundColor: 'rgba(251, 192, 45, 0.5)',
                 borderColor: 'rgba(251, 192, 45, 1)',
                 pointBorderColor: 'rgba(251, 192, 45, 1)',
                 pointBackgroundColor: 'rgba(251, 192, 45, 1)'
@@ -256,7 +256,7 @@ class FairScorePrincipleBar extends  FairScoreChart{
                 label: 'Not yet supported',
                 data: na,
                 fill: true,
-                backgroundColor: 'rgba(176, 190, 197, 0.2)',
+                backgroundColor: 'rgba(176, 190, 197, 0.5)',
                 borderColor: 'rgba(176, 190, 197, 1)',
                 pointBorderColor: 'rgba(176, 190, 197, 1)',
                 pointBackgroundColor: 'rgba(176, 190, 197, 1)'
@@ -396,7 +396,7 @@ class FairScoreCriteriaRadar extends FairScoreChart{
                 label: 'Fair score',
                 data: scores,
                 fill: true,
-                backgroundColor: 'rgba(151, 187, 205, 0.2)',
+                backgroundColor: 'rgba(151, 187, 205, 0.5)',
                 borderColor: 'rgba(151, 187, 205, 1)',
                 pointBorderColor: 'rgba(151, 187, 205, 1)',
                 pointBackgroundColor: 'rgba(151, 187, 205, 1)'
@@ -582,7 +582,7 @@ class FairScoreCriteriaBar extends  FairScoreChart{
                 label: 'Obtained score',
                 data: scores ,
                 fill: true,
-                backgroundColor: 'rgba(102, 187, 106, 0.2)',
+                backgroundColor: 'rgba(102, 187, 106, 0.5)',
                 borderColor: 'rgba(102, 187, 106, 1)',
                 pointBorderColor: 'rgba(102, 187, 106, 1)',
                 pointBackgroundColor: 'rgba(102, 187, 106, 1)'
@@ -591,7 +591,7 @@ class FairScoreCriteriaBar extends  FairScoreChart{
                 label: 'Not obtained score',
                 data:  notObtained,
                 fill: true,
-                backgroundColor: 'rgba(251, 192, 45, 0.2)',
+                backgroundColor: 'rgba(251, 192, 45, 0.5)',
                 borderColor: 'rgba(251, 192, 45, 1)',
                 pointBorderColor: 'rgba(251, 192, 45, 1)',
                 pointBackgroundColor: 'rgba(251, 192, 45, 1)',
@@ -600,7 +600,7 @@ class FairScoreCriteriaBar extends  FairScoreChart{
                 label: 'Not yet supported',
                 data: na,
                 fill: true,
-                backgroundColor: 'rgba(176, 190, 197, 0.2)',
+                backgroundColor: 'rgba(176, 190, 197, 0.5)',
                 borderColor: 'rgba(176, 190, 197, 1)',
                 pointBorderColor: 'rgba(176, 190, 197, 1)',
                 pointBackgroundColor: 'rgba(176, 190, 197, 1)'

--- a/app/views/fair_score/_details.html.haml
+++ b/app/views/fair_score/_details.html.haml
@@ -68,7 +68,7 @@
                             %div.btn.text-white{class:"#{(
                                                if question[1]["score"] > 0
                                                    'bg-obtained_color'
-                                               elsif not_implemented?(question[1])
+                                               elsif !@is_foops && not_implemented?(question[1])
                                                   'bg-non-applicable_color'
                                                else
                                                   'bg-not-obtained_color'
@@ -77,10 +77,10 @@
                               %span.badge.badge-pill.badge-light
                                 #{ print_score(question[1]["score"])} / #{print_score(question[1]["maxCredits"])}
                         %div.mb-3
-                          -if not_implemented?(question[1])
+                          -if !@is_foops && not_implemented?(question[1])
                             %span.badge.badge-pill.badge-danger{style:"white-space:normal;font-size:14px"}
                               #{question[1]["explanation"]}
-                          -elsif default_score?(question[1])
+                          -elsif !@is_foops && default_score?(question[1])
                             %span.badge.badge-pill.badge-success{style:"white-space:normal;font-size:14px"}
                               #{question[1]["explanation"]}
                         %div
@@ -92,15 +92,16 @@
                               %button.btn.btn-outline-primary{'data-toggle':"collapse" ,'data-target':"#collapse-properties-"+get_name_with_out_dot(question[0])}
                                 = t("fair_score.see_metadata_used_properties")
                         %div.mt-2
-                          %div.collapse{id:"collapse-credits-"+get_name_with_out_dot(question[0])}
-                            %div.card.p-3
-                              - question[1]["points"].each do |point|
-                                %ul.list-group.list-group-flush
-                                  %li.list-group-item.d-flex.justify-content-between.align-items-center
-                                    %div.mr-2
-                                      = point["explanation"]
-                                    %span.badge.badge-pill.badge-primary
-                                      = point["score"]
+                          -if question[1]["points"]
+                            %div.collapse{id:"collapse-credits-"+get_name_with_out_dot(question[0])}
+                              %div.card.p-3
+                                - question[1]["points"].each do |point|
+                                  %ul.list-group.list-group-flush
+                                    %li.list-group-item.d-flex.justify-content-between.align-items-center
+                                      %div.mr-2
+                                        = point["explanation"]
+                                      %span.badge.badge-pill.badge-primary
+                                        = point["score"]
                           -if question[1]["properties"]
                             %div.collapse{id:"collapse-properties-"+get_name_with_out_dot(question[0])}
                               %div.card.p-3{style:"font-size:18px"}

--- a/app/views/ontologies/_fairs_score.html.haml
+++ b/app/views/ontologies/_fairs_score.html.haml
@@ -11,11 +11,12 @@
 %div.text-center
   - text = " <span>#{t("ontologies.see_details")}</span>"
   - combined_param = id_prefix == "ont-foops" ? "&foops=true" : ""
+  - modal_title_key = id_prefix == "ont-foops" ? "ontologies.fairness_assessment_questions_foops" : "ontologies.fairness_assessment_questions_ofaire"
   = link_to_modal(text.html_safe,
                 "/ajax/fair_score/html/?ontologies=#{@ontology.acronym}#{combined_param}",
                 class: "btn",
                 id:"#{id_prefix}-details-link",
-                data: { show_modal_title_value: t("ontologies.fairness_assessment_questions"), show_modal_size_value: 'modal-xl' },
+                data: { show_modal_title_value: t(modal_title_key), show_modal_size_value: 'modal-xl' },
                 )
 
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1046,7 +1046,8 @@ en:
       ontology.
 
       '
-    fairness_assessment_questions: O'FAIRe FAIRness assessment questions
+    fairness_assessment_questions_ofaire: O'FAIRe FAIRness assessment questions
+    fairness_assessment_questions_foops: FOOPS! FAIRness assessment questions
     filters: Filters
     formality_levels: Formality levels
     general_information: General information

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -1077,7 +1077,8 @@ fr:
     exploring_and_searching: |-
       dans notre liste d'ontologies mais ils ne peuvent pas l'explorer ou la rechercher. Pour permettre l'exploration et la recherche,
       veuillez télécharger une version complète de votre ontologie.
-    fairness_assessment_questions: Questions d'évaluation du nveau de FAIRness O'FAIRe
+    fairness_assessment_questions_ofaire: Questions d'évaluation du niveau de FAIRness O'FAIRe
+    fairness_assessment_questions_foops: Questions d'évaluation du niveau de FAIRness FOOPS!
     filters: Filtres
     formality_levels: Niveaux de formalité
     general_information: Informations générales

--- a/reasonix.toml
+++ b/reasonix.toml
@@ -1,0 +1,88 @@
+# Reasonix configuration.
+# Resolution order: flag > ./reasonix.toml > ~/.config/reasonix/config.toml > built-in defaults.
+# Secrets come from the environment via api_key_env; never put keys here.
+
+default_model = "deepseek-flash"
+language      = "en"   # ui language; empty = auto-detect from $LANG / $REASONIX_LANG
+
+[agent]
+system_prompt = """
+You are Reasonix, a coding agent focused on executing code tasks.
+Use the provided tools to read and write files and run shell commands.
+Principles: understand the request before acting; verify with tools instead of
+guessing; keep changes minimal and correct; briefly summarize what you did.
+When the request leaves a real choice to the user — which approach or library,
+the scope, or a consequential or ambiguous decision — call the ask tool to offer
+2-4 concrete options rather than guessing or burying the question in prose. Skip
+it when there's an obvious default; don't ask just to confirm.
+For multi-step work, track progress with the todo_write tool: lay out the steps,
+keep exactly one in_progress, and flip each to completed as you finish it — update
+the list as you go, not just at the end.
+In plan mode the harness blocks writer tools: do read-only research, then write a
+concise plan as your reply and stop. The user is asked to approve before anything
+is changed; once approved, work through the steps, updating the task list as you go."""
+# system_prompt_file = "prompts/system.md"   # overrides system_prompt when set
+max_steps   = 0
+temperature = 0.0
+# planner_model = "mimo"   # optional: enable two-model collaboration
+# subagent_model = "deepseek-pro"   # optional default for runAs=subagent skills
+# subagent_models = { review = "deepseek-pro", security_review = "deepseek-pro" }   # per-skill overrides
+# output_style = "explanatory"   # explanatory | learning | concise | custom; empty = default
+
+[[providers]]
+name        = "deepseek-flash"
+kind        = "openai"
+base_url    = "https://api.deepseek.com"
+model       = "deepseek-v4-flash"
+api_key_env = "DEEPSEEK_API_KEY"
+balance_url = "https://api.deepseek.com/user/balance"   # optional; wallet-balance endpoint shown in the status bar
+context_window = 1000000   # tokens; compaction triggers near this limit
+price       = { cache_hit = 0.02, input = 1, output = 2, currency = "¥" }   # per 1M tokens
+
+[[providers]]
+name        = "deepseek-pro"
+kind        = "openai"
+base_url    = "https://api.deepseek.com"
+model       = "deepseek-v4-pro"
+api_key_env = "DEEPSEEK_API_KEY"
+balance_url = "https://api.deepseek.com/user/balance"   # optional; wallet-balance endpoint shown in the status bar
+context_window = 1000000   # tokens; compaction triggers near this limit
+price       = { cache_hit = 0.025, input = 3, output = 6, currency = "¥" }   # per 1M tokens
+
+[tools]
+enabled = []   # empty = all built-in tools
+
+[permissions]
+# Per-call gating. mode = writer fallback when no rule matches: ask|allow|deny.
+# Readers always default to allow. Precedence: deny > ask > allow > fallback.
+# Rules are "ToolName" or "ToolName(glob)"; '*' matches any run, '?' one char.
+mode  = "ask"
+# deny = ["bash(rm -rf*)", "bash(git push*)"]   # hard-blocked in every mode
+# allow = ["bash(go test*)", "bash(git status*)"]   # never prompted
+# ask = ["write_file"]   # force a prompt even if otherwise allowed
+
+[sandbox]
+# Confine tool blast radius. File-writers (write_file/edit_file/multi_edit)
+# may only write under workspace_root (empty = current dir) + allow_write.
+# bash = "enforce" (default) jails each command in an OS sandbox (macOS now;
+# graceful fallback elsewhere); "off" disables it. network allows egress.
+# workspace_root = ""            # default: current working directory
+# allow_write = ["/tmp"]          # extra dirs writers may also modify
+bash    = "enforce"
+network = true
+
+[statusline]
+# A custom status line: a command whose first stdout line replaces the built-in
+# data row. It receives {"model","contextUsed","contextWindow"} as JSON on stdin.
+# command = "my-statusline.sh"
+
+# External MCP servers. type: "stdio" (default, a subprocess) | "http" | "sse".
+# ${VAR} / ${VAR:-default} are expanded from the environment in command/args/env/url/headers.
+# [[plugins]]
+# name    = "example"
+# command = "reasonix-plugin-example"
+# [[plugins]]                                  # a remote server over Streamable HTTP
+# name    = "stripe"
+# type    = "http"
+# url     = "https://mcp.stripe.com"
+# headers = { Authorization = "Bearer ${STRIPE_KEY}" }


### PR DESCRIPTION
This PR fixes several UI issues with the FAIR score display:
  * Fixes
  1. Typo in French modal title — nveau → niveau
  2. O'FAIRe title shown for FOOPS — The detail modal title always displayed "O'FAIRe" even when viewing FOOPS! scores. Now the title is dynamic based on which score is being viewed.
  3. Pale colors in summary tables — Increased opacity of obtained/not-obtained/not-applicable colors:
    - SCSS variables: 0.4 → 0.7
    - Chart.js backgrounds: 0.2 → 0.5
  4. "Voir les crédits" / "Voir les propriétés" incorrectly shown for FOOPS — These buttons are O'FAIRe-specific and should not appear in FOOPS! check-level details. Also added
  nil-guards so the not_implemented?/default_score? badges don't trigger for FOOPS.
<img width="1158" height="796" alt="image" src="https://github.com/user-attachments/assets/56bb2423-7d72-4403-b5ac-90c71ef2fe93" />
<img width="1158" height="796" alt="image" src="https://github.com/user-attachments/assets/2d496384-87af-4fdf-aa95-4343140ef82f" />
<img width="720" height="428" alt="image" src="https://github.com/user-attachments/assets/04529adb-8d10-4be1-9049-e5f0bc15d777" />
