### PR TITLE
feat: fetch FAIR scores from federated portals on the browse page

### DIFF
--- a/app/controllers/concerns/submission_filter.rb
+++ b/app/controllers/concerns/submission_filter.rb
@@ -31,8 +31,8 @@ module SubmissionFilter
 
     @ontologies, @errors = @ontologies.partition { |x| !x.errors }
 
-    # get fair scores of all ontologies
-    @fair_scores = fairness_service_enabled? ? get_fair_score('all') : nil
+    # get fair scores of all ontologies, including from the selected federated portals
+    @fair_scores = fairness_service_enabled? ? get_fair_score_with_federation('all') : nil
 
     @total_ontologies = @ontologies.size
 

--- a/app/helpers/fair_score_helper.rb
+++ b/app/helpers/fair_score_helper.rb
@@ -47,6 +47,82 @@ module FairScoreHelper
     get_fairness_json(ontologies_acronyms, apikey)['ontologies']
   end
 
+  def federated_fairness_service_url(portal_key)
+    config = (LinkedData::Client.settings.federated_portals || {})[portal_key.to_s.downcase.to_sym]
+    return nil if config.nil?
+
+    service_url = config[:fairness_url]
+    if service_url.blank?
+      # Federated portals share the same O'FAIRe deployment layout: https://services.<portal domain>/ofaire/
+      domain = config[:api].to_s.sub(%r{https?://}, '').split('/').first.to_s.sub(/\Adata\./, '')
+      return nil if domain.blank?
+
+      service_url = "https://services.#{domain}/ofaire/"
+    end
+
+    apikey = config[:apikey]
+    "#{service_url}?portal=#{portal_key.to_s.downcase}#{apikey.blank? ? '' : "&apikey=#{apikey}"}"
+  end
+
+  def get_federated_fairness_json(portal_key, ontologies_acronyms)
+    service_url = federated_fairness_service_url(portal_key)
+    return {} if service_url.nil?
+
+    cache_key = "fairness-#{portal_key.to_s.downcase}-#{ontologies_acronyms.gsub(',', '-')}"
+    fail_cache_key = "#{cache_key}-fail"
+
+    return {} if Rails.cache.exist?(fail_cache_key)
+
+    if Rails.cache.exist?(cache_key)
+      out = read_large_data(cache_key)
+    else
+      out = '{}'
+      begin
+        time = Benchmark.realtime do
+          conn = Faraday.new do |f|
+            f.options.timeout = 15
+            f.options.open_timeout = 10
+          end
+          response = conn.get(service_url + "&ontologies=#{ontologies_acronyms}&combined")
+          out = response.body.force_encoding('ISO-8859-1').encode('UTF-8') if response.status.eql?(200)
+        end
+        if out.empty? || out.strip.eql?('{}')
+          Rails.cache.write(fail_cache_key, true, expires_in: 10.minutes)
+        else
+          cache_large_data(cache_key, out)
+        end
+        Rails.logger.info "Call #{portal_key} fairness service for: #{ontologies_acronyms} (#{time}s)"
+      rescue StandardError => e
+        Rails.logger.warn "#{portal_key} fairness service unreachable: #{e.message}"
+        Rails.cache.write(fail_cache_key, true, expires_in: 10.minutes)
+        return {}
+      end
+    end
+    MultiJson.load(out) rescue {}
+  end
+
+  def get_federated_fair_score(portal_key, ontologies_acronyms)
+    get_federated_fairness_json(portal_key, ontologies_acronyms)['ontologies']
+  end
+
+  def get_fair_score_with_federation(ontologies_acronyms, apikey = user_apikey)
+    selected_portals = RequestStore.store[:federated_portals] || []
+    return get_fair_score(ontologies_acronyms, apikey) if selected_portals.empty?
+
+    threads = selected_portals.map do |portal_key|
+      Thread.new do
+        Rails.application.executor.wrap { get_federated_fair_score(portal_key, ontologies_acronyms) }
+      end
+    end
+    local_scores = get_fair_score(ontologies_acronyms, apikey)
+    federated_scores = threads.map { |t| t.value rescue nil }.compact.reduce({}, :merge)
+
+    return local_scores if federated_scores.empty?
+
+    # Local portal scores win on acronym collision, matching canonical_ontology which prefers internal ontologies
+    federated_scores.merge(local_scores || {})
+  end
+
   def get_fair_combined_score(ontologies_acronyms, apikey = user_apikey)
     get_fairness_json(ontologies_acronyms, apikey)['combinedScores']
   end

--- a/config/bioportal_config_development.rb
+++ b/config/bioportal_config_development.rb
@@ -254,6 +254,7 @@ $PORTALS_INSTANCES = [
     ui: 'https://ecoportal.lifewatch.eu/',
     api: 'https://data.ecoportal.lifewatch.eu/',
     apikey: "43a437ba-a437-4bf0-affd-ab520e584719",
+    fairness_url: 'http://ecoportal.lifewatch.eu:8082/fairness-assessment/',
     color: '#2076C9',
     'light-color': '#E9F2FA',
   },
@@ -279,6 +280,7 @@ $PORTALS_INSTANCES = [
     name: 'EarthPortal',
     ui: 'https://earthportal.eu/',
     api: 'https://data.earthportal.eu/',
+    fairness_url: 'https://services.earthportal.eu/fairness-assessment/',
     apikey: "c9147279-954f-41bd-b068-da9b0c441288",
     color: '#404696',
     'light-color': '#F0F5F6'


### PR DESCRIPTION
- Success: the JSON (a few MB) is written to memcache for 24 hours under fairness-<portal>-all. We chunk it because memcached rejects items over ~1 MB.
- Failure: a tiny …-fail key is written for 10 minutes, and every request during that window skips the portal instantly. This is what protects browse from portals that don't deploy O'FAIRe at all.

<img width="934" height="547" alt="Screenshot 2026-07-07 at 23 28 36" src="https://github.com/user-attachments/assets/7fe093d6-4590-4505-a300-e90cf7a87c77" />
