### PR TITLE
Fix submission location handling

### DIFF
--- a/app/controllers/concerns/ontology_updater.rb
+++ b/app/controllers/concerns/ontology_updater.rb
@@ -102,8 +102,8 @@ module OntologyUpdater
     return false if value.nil? || (value.respond_to?(:empty?) && value.empty?)
 
     attr_to_not_copy = [:versionIRI, :version, :deprecated, :valid, :curatedOn,
-                        :pullLocation, :metadataVoc, :hasPriorVersion, :creationDate,
-                        :submissionStatus]
+                        :pullLocation, :uploadFilePath, :metadataVoc, :hasPriorVersion,
+                        :creationDate, :submissionStatus]
 
     !attr_to_not_copy.include?(key.to_sym)
   end

--- a/app/controllers/concerns/submission_updater.rb
+++ b/app/controllers/concerns/submission_updater.rb
@@ -123,7 +123,12 @@ module SubmissionUpdater
       attributes << m_attr
     end
     p = params.permit(attributes.uniq)
-    p['pullLocation'] = '' if p['isRemote']&.eql?('3')
+    # the location radio buttons only hide the other inputs, their values are still submitted:
+    # keep only the value matching the selected location type ('0' local file, '1' pull URL, '3' metadata only)
+    unless p['isRemote'].nil?
+      p['pullLocation'] = '' unless p['isRemote'].eql?('1')
+      p.delete('filePath') unless p['isRemote'].eql?('0')
+    end
     p = p.to_h.transform_values do |value|
       if value.is_a?(Hash)
         value.values.map { |v| normalize(v) }.reject { |v| v.respond_to?(:empty?) && v.empty? }


### PR DESCRIPTION
## Bugs fixed

- Related issues : 
  - https://github.com/agroportal/project-management/issues/882 
  - https://github.com/agroportal/project-management/issues/801

**1. Adding a submission with an empty local file silently reused the previous submission's file**

Fix: exclude `uploadFilePath` from the copied attributes in `copyable_submission_params?`.
<img width="410" height="62" alt="Image" src="https://github.com/user-attachments/assets/2a6405ca-4b57-4174-80ad-7c8400047fd5" />

**2. Switching the location radio button still submitted the other location's value**

Fix: 

- isRemote=0 (local file selected): the stale pullLocation is now cleared to "" while the uploaded file is kept.
- isRemote=1 (pullLocation selected): the symmetric case now also works, a stale chosen file is dropped and pullLocation is kept.
- isRemote=3 (metadata only): unchanged behavior, both are cleared.
