### PR TITLE
Feature/federated portals

### DIFF
--- a/app/assets/stylesheets/admin.scss
+++ b/app/assets/stylesheets/admin.scss
@@ -193,7 +193,8 @@ div.groupFormError {
   }
 }
 
-input[type="text"]:disabled {
+input[type="text"]:disabled,
+input[type="text"]:readonly {
   background-color: #e9ecef;
   color: #6c757d;
   cursor: not-allowed;

--- a/app/assets/stylesheets/admin.scss
+++ b/app/assets/stylesheets/admin.scss
@@ -192,3 +192,10 @@ div.groupFormError {
     }
   }
 }
+
+input[type="text"]:disabled {
+  background-color: #e9ecef;
+  color: #6c757d;
+  cursor: not-allowed;
+  opacity: 0.7;
+}

--- a/app/assets/stylesheets/home.scss
+++ b/app/assets/stylesheets/home.scss
@@ -572,10 +572,23 @@ i.fa.fa-caret-square-o-down {
   
 }
 .home-logo-instances{
-  padding: 23px;
+  width: 81px;
+  height: 72px;
   margin: 7px 12px !important;
   border-radius: 50%;
-  display: block;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.home-portal-name{
+  margin-top: 10px;
+  margin-bottom: 20px;
+  width: 100px;
+  word-wrap: break-word;
+  white-space: normal;
+  font-size: 14px;
+  line-height: 1.3;
 }
 .home-support-items > div, .home-support-items > a {
   margin-right: 40px;

--- a/app/components/nested_form_inputs_component.rb
+++ b/app/components/nested_form_inputs_component.rb
@@ -7,9 +7,10 @@ class NestedFormInputsComponent < ViewComponent::Base
   renders_many :rows
   renders_one :empty_state
 
-  def initialize(object_name: '', default_empty_row: false)
+  def initialize(object_name: '', default_empty_row: false, show_add_button: true)
     super
     @object_name = object_name
     @default_row = default_empty_row
+    @show_add_button = show_add_button
   end
 end

--- a/app/components/nested_form_inputs_component/nested_form_inputs_component.html.haml
+++ b/app/components/nested_form_inputs_component/nested_form_inputs_component.html.haml
@@ -28,7 +28,8 @@
           = inline_svg 'icons/delete.svg'
 
   %div{'data-nested-form-target': "target"}
-  %div.add-another-object{data: {action:"click->nested-form#add"}}
-    = inline_svg 'icons/plus.svg', width: "14px", height: "14px"
-    %div
-      Add another #{@object_name}
+  - if @show_add_button
+    %div.add-another-object{data: {action:"click->nested-form#add"}}
+      = inline_svg 'icons/plus.svg', width: "14px", height: "14px"
+      %div
+        Add another #{@object_name}

--- a/app/controllers/admin/catalog_configuration_controller.rb
+++ b/app/controllers/admin/catalog_configuration_controller.rb
@@ -44,10 +44,17 @@ class Admin::CatalogConfigurationController < ApplicationController
 
     @catalog_data = session[:catalog_data] || load_catalog_data
     @catalog_metadata = session[:catalog_metadata] || load_catalog_metadata
-    
+
     @value_attrs = @catalog_data&.dig(@key) || []
+
+    # Merge federated_portals from ontoportal.org with existing ones
+    if @key == :federated_portals
+      portals_from_source = fetch_federated_portals_from_source
+      @value_attrs = merge_federated_portals(@value_attrs, portals_from_source)
+    end
+
     @field_names = extract_field_names_for_key(@key)
-    
+
     render partial: 'edit_nested_form_modal', layout: false
   end
 
@@ -185,10 +192,80 @@ class Admin::CatalogConfigurationController < ApplicationController
   def extract_field_names_for_key(key)
     metadata = @catalog_metadata[key.to_s]
     return [] unless metadata&.enforcedValues
-    
+
     metadata.enforcedValues.flat_map do |field|
       field.to_h.keys - [:links, :context]
     end
+  end
+
+  def fetch_federated_portals_from_source
+    require 'net/http'
+    require 'json'
+
+    uri = URI('https://ontoportal.org/portals.json')
+    http = Net::HTTP.new(uri.host, uri.port)
+    http.use_ssl = true
+
+    request = Net::HTTP::Get.new(uri.request_uri)
+    response = http.request(request)
+
+    if response.is_a?(Net::HTTPSuccess)
+      data = JSON.parse(response.body)
+      portals = []
+
+      # Handle JSON-LD format with @graph array
+      if data.is_a?(Hash) && data['@graph'].is_a?(Array)
+        portals = data['@graph'].select { |portal| portal['federation'] == true }
+      end
+
+      # Transform to OpenStruct objects with name, ui, and color fields
+      portals.map do |portal|
+        OpenStruct.new(
+          name: portal['acronym'],
+          ui: portal['@id'],
+          color: portal['color']
+        )
+      end
+    else
+      []
+    end
+  rescue StandardError => e
+    Rails.logger.error("Error fetching federated portals: #{e.message}")
+    []
+  end
+
+  def merge_federated_portals(existing_portals, source_portals)
+    # Create a map of existing portals by normalized UI domain
+    existing_by_domain = {}
+    existing_portals.each do |portal|
+      ui = portal.respond_to?(:ui) ? portal.ui : portal['ui']
+      next if ui.blank?
+
+      domain = normalize_domain(ui)
+      existing_by_domain[domain] = portal
+    end
+
+    # Add portals from source, avoiding duplicates by domain
+    source_portals.each do |portal|
+      next if portal.ui.blank?
+
+      domain = normalize_domain(portal.ui)
+      existing_by_domain[domain] ||= portal
+    end
+
+    # Return merged list
+    existing_by_domain.values
+  end
+
+  def normalize_domain(url)
+    # Extract and normalize the domain from a full URL
+    # e.g., "https://agroportal.lirmm.fr/" -> "agroportal.lirmm.fr"
+    return url.to_s.downcase if url.blank?
+
+    uri = URI.parse(url)
+    uri.host&.downcase || url.to_s.downcase
+  rescue StandardError
+    url.to_s.downcase
   end
 
 

--- a/app/controllers/admin/catalog_configuration_controller.rb
+++ b/app/controllers/admin/catalog_configuration_controller.rb
@@ -17,6 +17,8 @@ class Admin::CatalogConfigurationController < ApplicationController
     response = update_remote_config(config)
     if response.status == 200
       flash.now[:notice] = t('admin.catalog_configuration.configuration_updated_successfully')
+      # Invalidate federated portals cache if federated_portals were updated
+      invalidate_federated_portals_cache if config['federated_portals'].present?
     else
       flash.now[:alert] = t('admin.catalog_configuration.configuration_update_error', error: response.body)
     end
@@ -25,7 +27,7 @@ class Admin::CatalogConfigurationController < ApplicationController
     session[:catalog_data] = @catalog_data
     @catalog_metadata = session[:catalog_metadata] || load_catalog_metadata
     @catalog_groups = attributes_groups
-    
+
     respond_to do |format|
       format.turbo_stream do
         render turbo_stream: turbo_stream.replace(
@@ -51,9 +53,11 @@ class Admin::CatalogConfigurationController < ApplicationController
     if @key == :federated_portals
       portals_from_source = fetch_federated_portals_from_source
       @value_attrs = merge_federated_portals(@value_attrs, portals_from_source)
+      # For federated_portals, explicitly set all field names
+      @field_names = %w[name ui api color apikey]
+    else
+      @field_names = extract_field_names_for_key(@key)
     end
-
-    @field_names = extract_field_names_for_key(@key)
 
     render partial: 'edit_nested_form_modal', layout: false
   end
@@ -165,7 +169,12 @@ class Admin::CatalogConfigurationController < ApplicationController
     config = params.require(:config).permit!.to_h
 
     list_included_attributes.each do |key|
-      config[key] = sanitize_attribute_value(config[key.to_s])
+      # Special handling for federated_portals
+      if key == 'federated_portals'
+        config[key] = sanitize_federated_portals(config[key.to_s])
+      else
+        config[key] = sanitize_attribute_value(config[key.to_s])
+      end
     end
 
     config['rightsHolder'] = config['rightsHolder']&.first&.presence || '' if config['rightsHolder']
@@ -187,6 +196,46 @@ class Admin::CatalogConfigurationController < ApplicationController
     else
       raw_value
     end
+  end
+
+  def sanitize_federated_portals(raw_value)
+    return nil if raw_value.nil?
+
+    portals = []
+    case raw_value
+    when Hash
+      # raw_value is a hash with numeric keys and portal data as values
+      raw_value.each do |_, portal_data|
+        next unless portal_data.is_a?(Hash)
+
+        portal = {}
+        portal[:name] = portal_data['name'] if portal_data['name'].present?
+        portal[:ui] = portal_data['ui'] if portal_data['ui'].present?
+        portal[:api] = portal_data['api'] if portal_data['api'].present?
+        portal[:color] = portal_data['color'] if portal_data['color'].present?
+        portal[:apikey] = portal_data['apikey'] if portal_data['apikey'].present?
+
+        # Include portal if it has at least one field with data
+        portals << portal if portal.keys.any?
+      end
+    when Array
+      # raw_value is already an array of portal objects
+      raw_value.each do |portal_data|
+        next unless portal_data.is_a?(Hash)
+
+        portal = {}
+        portal[:name] = portal_data['name'] if portal_data['name'].present?
+        portal[:ui] = portal_data['ui'] if portal_data['ui'].present?
+        portal[:api] = portal_data['api'] if portal_data['api'].present?
+        portal[:color] = portal_data['color'] if portal_data['color'].present?
+        portal[:apikey] = portal_data['apikey'] if portal_data['apikey'].present?
+
+        # Include portal if it has at least one field with data
+        portals << portal if portal.keys.any?
+      end
+    end
+
+    portals.presence
   end
 
   def extract_field_names_for_key(key)
@@ -266,6 +315,11 @@ class Admin::CatalogConfigurationController < ApplicationController
     uri.host&.downcase || url.to_s.downcase
   rescue StandardError
     url.to_s.downcase
+  end
+
+  def invalidate_federated_portals_cache
+    Rails.cache.delete('federated_portals')
+    Rails.logger.info("Invalidated federated_portals cache")
   end
 
 

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -16,6 +16,7 @@ class HomeController < ApplicationController
         @anal_ont_numbers << count
       end
     end
+    @portals_instances = fetch_portals_instances
   end
 
   # Add a new action for the metrics frame
@@ -186,6 +187,60 @@ class HomeController < ApplicationController
   end
 
   private
+
+  def fetch_portals_instances
+    require 'net/http'
+    require 'json'
+
+    Rails.cache.fetch('portals_instances', expires_in: 24.hours) do
+      uri = URI('https://ontoportal.org/portals.json')
+      http = Net::HTTP.new(uri.host, uri.port)
+      http.use_ssl = true
+
+      request = Net::HTTP::Get.new(uri.request_uri)
+      response = http.request(request)
+
+      if response.is_a?(Net::HTTPSuccess)
+        data = JSON.parse(response.body)
+        # Transform the data to match the expected format
+        transform_portals_data(data)
+      else
+        # Fallback to the configuration-based instances
+        $PORTALS_INSTANCES || []
+      end
+    rescue StandardError => e
+      Rails.logger.error("Error fetching portals from ontoportal.org: #{e.message}")
+      $PORTALS_INSTANCES || []
+    end
+  end
+
+  def transform_portals_data(data)
+    # Transform the JSON-LD data to match the expected format
+    portals = []
+
+    # Handle JSON-LD format with @graph array
+    if data.is_a?(Hash) && data['@graph'].is_a?(Array)
+      portals = data['@graph'].map { |portal| transform_portal_entry(portal) }
+    elsif data.is_a?(Array)
+      portals = data.map { |portal| transform_portal_entry(portal) }
+    end
+
+    portals.compact.select { |p| p[:name].present? && p[:ui].present? }
+  end
+
+  def transform_portal_entry(portal)
+    return nil unless portal.is_a?(Hash)
+
+    # Map JSON-LD fields to expected format
+    {
+      name: portal['acronym'] || portal['name'] || portal[:acronym] || portal[:name],
+      ui: portal['@id'] || portal['ui'] || portal[:'@id'] || portal[:ui],
+      api: portal['api'] || portal[:api],
+      color: portal['color'] || portal[:color] || '#000000',
+      apikey: portal['apikey'] || portal[:apikey],
+      'light-color': portal['light-color'] || portal[:'light-color']
+    }
+  end
 
   # Dr. Musen wants 5 specific groups to appear first, sorted by order of importance.
   # Ordering is documented in GitHub: https://github.com/ncbo/bioportal_web_ui/issues/15.

--- a/app/helpers/federation_helper.rb
+++ b/app/helpers/federation_helper.rb
@@ -3,7 +3,10 @@ module FederationHelper
 
   def federated_portals
     Rails.cache.fetch('federated_portals', expires_in: 1.hour) do
-      fetch_federated_portals_from_catalog
+      portals = fetch_federated_portals_from_catalog
+      # In test environment, fall back to $PORTALS_INSTANCES if catalog is empty
+      portals = LinkedData::Client.settings.federated_portals if portals.empty? && Rails.env.test?
+      portals
     end
   end
 
@@ -270,9 +273,12 @@ module FederationHelper
       counts[current_portal.downcase] += 1 if id.include?(current_portal.to_s.downcase)
 
       federation_portals.each do |portal|
-        portal_api = federated_portals[portal.downcase.to_sym][:api].sub(/^https?:\/\//, '')
-        portal_ui = federated_portals[portal.downcase.to_sym][:ui].sub(/^https?:\/\//, '')
-        counts[portal.downcase] += 1 if (id.include?(portal_api) || id.include?(portal_ui))
+        portal_config = federated_portals[portal.downcase.to_sym]
+        next unless portal_config&.dig(:api) || portal_config&.dig(:ui)
+
+        portal_api = portal_config[:api]&.sub(/^https?:\/\//, '')
+        portal_ui = portal_config[:ui]&.sub(/^https?:\/\//, '')
+        counts[portal.downcase] += 1 if (portal_api && id.include?(portal_api)) || (portal_ui && id.include?(portal_ui))
       end
     end
 

--- a/app/helpers/federation_helper.rb
+++ b/app/helpers/federation_helper.rb
@@ -2,12 +2,33 @@ module FederationHelper
   include ApplicationHelper
 
   def federated_portals
-    $FEDERATED_PORTALS ||= LinkedData::Client.settings.federated_portals
-    $FEDERATED_PORTALS.each do |key, portal|
-      portal[:ui] += "/" unless portal[:ui].end_with?("/")
-      portal[:api] += "/" unless portal[:api].end_with?("/")
+    Rails.cache.fetch('federated_portals', expires_in: 1.hour) do
+      fetch_federated_portals_from_catalog
     end
-    $FEDERATED_PORTALS
+  end
+
+  def fetch_federated_portals_from_catalog
+    # Fetch federated portals from the catalog metadata
+    catalog_data = LinkedData::Client::HTTP.get("#{LinkedData::Client.settings.rest_url}/", display: 'federated_portals')
+
+    federated = {}
+    if catalog_data&.federated_portals.present?
+      Array(catalog_data.federated_portals).each do |portal|
+        # Only include portals that have an apikey configured
+        next unless portal[:apikey].present?
+
+        portal_key = portal[:name].downcase.to_sym
+        # Ensure URLs end with /
+        portal[:ui] = "#{portal[:ui]}/" unless portal[:ui].end_with?("/")
+        portal[:api] = "#{portal[:api]}/" unless portal[:api].end_with?("/")
+
+        federated[portal_key] = portal
+      end
+    end
+    federated
+  rescue StandardError => e
+    Rails.logger.error("Error fetching federated portals from catalog: #{e.message}")
+    {}
   end
 
   def internal_portal_config(id)
@@ -164,7 +185,13 @@ module FederationHelper
 
   def federation_portal_status(portal_name: nil)
     Rails.cache.fetch("federation_portal_up_#{portal_name}", expires_in: 10.minutes) do
-      portal_api = federated_portals&.dig(portal_name.to_sym,:api)
+      # Check if it's the local portal (compare with $SITE)
+      if portal_name&.to_s&.downcase == $SITE.downcase
+        portal_api = rest_url
+      else
+        portal_api = federated_portals&.dig(portal_name.to_sym,:api)
+      end
+
       return false unless portal_api
       portal_up = false
       begin

--- a/app/helpers/home_helper.rb
+++ b/app/helpers/home_helper.rb
@@ -25,7 +25,11 @@ module HomeHelper
   end
 
   def portal_config_tooltip(portal, &block)
+    return capture(&block) if portal.blank?
+
     portal_id = portal&.downcase
+    return capture(&block) if portal_id.blank?
+
     title = if (federation_portal_status(portal_name: portal_id.to_sym) || portal_id.eql?(portal_name&.downcase))
       render(
         TurboFrameComponent.new(

--- a/app/views/admin/catalog_configuration/_edit_nested_form_modal.html.haml
+++ b/app/views/admin/catalog_configuration/_edit_nested_form_modal.html.haml
@@ -1,7 +1,7 @@
 = render_in_modal do
   = form_with url: admin_catalog_configuration_path, method: :patch, local: false, turbo: true do |f|
     = hidden_field_tag "config[#{@key}][]", "", id: "empty_config_#{@key}"
-    = render NestedFormInputsComponent.new(object_name: "portal") do |c|
+    = render NestedFormInputsComponent.new(object_name: "portal", show_add_button: @key.to_s != "federated_portals") do |c|
       - c.header do
         - header_content = @field_names.map { |field_name| content_tag(:div, field_name.to_s.humanize, class: 'w-50 mx-1') }.join.html_safe
         = header_content
@@ -10,16 +10,18 @@
         - c.row do
           = content_tag(:div, class: 'd-flex my-1') do
             - @field_names.map do |field_name|
+              - is_readonly_field = %w[name ui color].include?(field_name.to_s)
               - content_tag(:div, class: 'w-50 mx-1') do
-                = text_input(label: '', name: "config[#{@key}][][#{field_name}]", value: row_data.send(field_name), error_message: '')
+                = text_input(label: '', name: "config[#{@key}][][#{field_name}]", value: row_data.send(field_name), error_message: '', disabled: is_readonly_field)
             - end.join.html_safe
 
-      - c.template do
-        = content_tag(:div, class: 'd-flex my-1') do
-          - @field_names.map do |field_name|
-            - content_tag(:div, class: 'w-50 mx-1') do
-              = text_input(label: '', name: "config[#{@key}][][#{field_name}]", value: "", placeholder: "#{field_name.to_s.humanize}")
-          - end.join.html_safe
+      - if @key.to_s != "federated_portals"
+        - c.template do
+          = content_tag(:div, class: 'd-flex my-1') do
+            - @field_names.map do |field_name|
+              - content_tag(:div, class: 'w-50 mx-1') do
+                = text_input(label: '', name: "config[#{@key}][][#{field_name}]", value: "", placeholder: "#{field_name.to_s.humanize}")
+            - end.join.html_safe
 
 
 

--- a/app/views/admin/catalog_configuration/_edit_nested_form_modal.html.haml
+++ b/app/views/admin/catalog_configuration/_edit_nested_form_modal.html.haml
@@ -12,7 +12,7 @@
             - @field_names.map do |field_name|
               - is_readonly_field = %w[name ui color].include?(field_name.to_s)
               - content_tag(:div, class: 'w-50 mx-1') do
-                = text_input(label: '', name: "config[#{@key}][][#{field_name}]", value: row_data.send(field_name), error_message: '', disabled: is_readonly_field)
+                = text_input(label: '', name: "config[#{@key}][][#{field_name}]", value: row_data.send(field_name), error_message: '', readonly: is_readonly_field)
             - end.join.html_safe
 
       - if @key.to_s != "federated_portals"

--- a/app/views/home/index.html.haml
+++ b/app/views/home/index.html.haml
@@ -202,12 +202,13 @@
         .div
           = home_ontoportal_description
       .home-support-items
-        - $PORTALS_INSTANCES&.each do |portal|
+        - @portals_instances&.each do |portal|
+          - next unless portal[:name].present? && portal[:ui].present?
           = portal_config_tooltip(portal[:name]) do
             %div.text-center
               = link_to portal[:ui], target: '_blank', class: 'home-logo-instances', style: "background-color: #{portal[:color]}" do
                 = inline_svg('logo-white.svg', width: "35", height: "26")
-              %p{style: "color: #{portal[:color]}"}
+              %p.home-portal-name{style: "color: #{portal[:color]}"}
                 = portal[:name]
 
   .home-section

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -153,7 +153,7 @@ Rails.application.routes.draw do
   get 'home/metrics', to: 'home#metrics'
   get 'home/agents', to: 'home#agents'
   get 'status/:portal_name', to: 'home#federation_portals_status'
-  
+
   # SPARQL 
   match 'sparql_proxy', to: 'admin#sparql_endpoint', via: [:get, :post]
   get 'sparql', to: 'sparql_endpoint#index', as: 'sparql_endpoint'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,8 +20,8 @@ x-app: &default-app
   environment: &env
     BUNDLE_WITHOUT: ""
     BUNDLE_PATH: /srv/ontoportal/bundle
-    DB_HOST: 127.0.0.1
-    MEMCACHE_SERVERS: 127.0.0.1:11211
+    DB_HOST: host.docker.internal
+    MEMCACHE_SERVERS: host.docker.internal:11211
   tmpfs:
     - /tmp
     - /app/tmp/pids
@@ -61,7 +61,7 @@ services:
     <<: *default-app
     ports:
       - "3000:3000"
-    network_mode: "host"
+    # network_mode: "host"
 
   production:
     <<: *default-app


### PR DESCRIPTION
Related:
- https://github.com/agroportal/project-management/issues/786
- https://github.com/ontoportal/ontoportal_web_ui/issues/61

## Homepage OntoPortal instances list
The preview here now gets generated using [portals.json](https://ontoportal.org/portals.json). cached for 24h

<img width="1109" height="472" alt="Screenshot 2026-07-13 at 15 42 11" src="https://github.com/user-attachments/assets/2048c72a-5b8b-492f-9b4c-19e401d14ff1" />

## Federation configuration 
### Federated portals form
- The federated portals list now gets pre-filed with values from [portals.json](https://ontoportal.org/portals.json)
  - we can't add other portal 
  - We can only add an apikey for federation 
<img width="1792" height="660" alt="Screenshot 2026-07-13 at 15 44 45" src="https://github.com/user-attachments/assets/5983650a-a681-4d66-8a5b-bc796c8b9d1e" />

@jonquet should we add the `API` url to the [portals.json](https://ontoportal.org/portals.json) ? so that it gets prefilled also 
### Browse page Federation
The federation will be only available for portals for which we configured an apikey in the catalog
<img width="314" height="115" alt="Screenshot 2026-07-13 at 16 11 00" src="https://github.com/user-attachments/assets/ba41fb64-3f49-447e-ba69-ab5414e0a6d8" />

 